### PR TITLE
fix: type UpdateAvailabilityUseCase's failure mode

### DIFF
--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
@@ -4,12 +4,15 @@ import com.simtop.beer_data.mappers.BeersMapper
 import com.simtop.beer_database.localsources.BeersLocalSource
 import com.simtop.beer_network.models.BeersApiResponseItem
 import com.simtop.beer_network.remotesources.BeersRemoteSource
+import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.core.core.Either
 import com.simtop.core.core.PagingMediator
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -71,8 +74,17 @@ class BeersRepositoryImpl(
     return fetchAndEnrichBeers(page)
   }
 
-  override suspend fun updateAvailability(beer: Beer) =
-    beersLocalSource.updateBeer(beer.id, beer.availability)
+  @Suppress("TooGenericExceptionCaught")
+  override suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit> {
+    return try {
+      beersLocalSource.updateBeer(beer.id, beer.availability)
+      Either.Right(Unit)
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      Either.Left(UpdateAvailabilityError.Unknown(e))
+    }
+  }
 
   override suspend fun insertAllToDB(beers: List<Beer>) =
     beersLocalSource.insertAllToDB(beers.map { beersMapper.fromBeerToBeerDbModel(it) })

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/errors/UpdateAvailabilityError.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/errors/UpdateAvailabilityError.kt
@@ -1,0 +1,5 @@
+package com.simtop.beerdomain.domain.errors
+
+sealed interface UpdateAvailabilityError {
+  data class Unknown(val cause: Throwable) : UpdateAvailabilityError
+}

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -1,6 +1,8 @@
 package com.simtop.beerdomain.domain.repositories
 
+import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.core.core.Either
 import com.simtop.core.core.PagingState
 import kotlinx.coroutines.flow.Flow
 
@@ -11,7 +13,7 @@ interface BeersRepository {
 
   suspend fun insertAllToDB(beers: List<Beer>)
 
-  suspend fun updateAvailability(beer: Beer)
+  suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit>
 
   fun getBeersFromSingleSource(): Flow<List<Beer>>
 

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
@@ -1,7 +1,9 @@
 package com.simtop.beerdomain.fakes
 
+import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.core.core.Either
 import com.simtop.core.core.PagingState
 import kotlin.collections.plus
 import kotlinx.coroutines.flow.Flow
@@ -45,8 +47,8 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
     beersFlow.value = beersFlow.value + beers
   }
 
-  override suspend fun updateAvailability(beer: Beer) {
-    exceptionToThrow?.let { throw it }
+  override suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit> {
+    exceptionToThrow?.let { return Either.Left(UpdateAvailabilityError.Unknown(it)) }
     val currentList = beersFlow.value.toMutableList()
     val index = currentList.indexOfFirst { it.id == beer.id }
     if (index != -1) {
@@ -56,6 +58,7 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
       currentList.add(beer)
       beersFlow.value = currentList
     }
+    return Either.Right(Unit)
   }
 
   override fun getBeersFromSingleSource(): Flow<List<Beer>> {

--- a/beerdomain/impl/src/main/java/com/simtop/beerdomain/domain/usecases/UpdateAvailabilityUseCase.kt
+++ b/beerdomain/impl/src/main/java/com/simtop/beerdomain/domain/usecases/UpdateAvailabilityUseCase.kt
@@ -1,20 +1,13 @@
 package com.simtop.beerdomain.domain.usecases
 
+import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.Either
 import dev.zacsweers.metro.Inject
 
 class UpdateAvailabilityUseCase @Inject constructor(private val beersRepository: BeersRepository) {
-  @Suppress("TooGenericExceptionCaught")
-  suspend operator fun invoke(beer: Beer): Either<Exception, Unit> {
-    return try {
-      beersRepository.updateAvailability(beer)
-      Either.Right(Unit)
-    } catch (e: kotlinx.coroutines.CancellationException) {
-      throw e
-    } catch (exception: Exception) {
-      Either.Left(exception)
-    }
+  suspend operator fun invoke(beer: Beer): Either<UpdateAvailabilityError, Unit> {
+    return beersRepository.updateAvailability(beer)
   }
 }

--- a/beerdomain/impl/src/test/java/com/simtop/beerdomain/domain/UpdateAvailabilityUseCaseTest.kt
+++ b/beerdomain/impl/src/test/java/com/simtop/beerdomain/domain/UpdateAvailabilityUseCaseTest.kt
@@ -1,5 +1,6 @@
 package com.simtop.beerdomain.domain
 
+import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.usecases.UpdateAvailabilityUseCase
 import com.simtop.beerdomain.fakes.FakeBeersRepository
@@ -42,6 +43,6 @@ class UpdateAvailabilityUseCaseTest {
 
     // Assert
     assertTrue(result is Either.Left)
-    assertEquals(exception, (result as Either.Left).value)
+    assertEquals(UpdateAvailabilityError.Unknown(exception), (result as Either.Left).value)
   }
 }

--- a/core-common/src/main/kotlin/com/simtop/core/core/BaseUseCase.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/BaseUseCase.kt
@@ -1,8 +1,0 @@
-package com.simtop.core.core
-
-abstract class BaseUseCase<T, PARAMS> protected constructor() {
-
-  protected abstract suspend fun buildUseCase(params: PARAMS): Either<Exception, T>
-
-  suspend fun execute(params: PARAMS) = buildUseCase(params)
-}

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/BeerDetailViewModel.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/BeerDetailViewModel.kt
@@ -2,6 +2,7 @@ package com.simtop.feature.beerdetail.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.usecases.UpdateAvailabilityUseCase
 import com.simtop.core.core.CommonUiState
@@ -59,17 +60,23 @@ constructor(
     _beerDetailViewState.value = CommonUiState.Success(beer)
   }
 
-  private suspend fun treatResponse(result: Either<Exception, Unit>, originalBeer: Beer) {
+  private suspend fun treatResponse(
+    result: Either<UpdateAvailabilityError, Unit>,
+    originalBeer: Beer,
+  ) {
     when (result) {
       is Either.Left -> {
         _beerDetailViewState.value = CommonUiState.Success(originalBeer)
-        _events.send(
-          BeerDetailEvent.ShowError(result.value.message ?: "Unable to update availability")
-        )
+        _events.send(BeerDetailEvent.ShowError(result.value.toUiMessage()))
       }
       is Either.Right -> Unit
     }
   }
+
+  private fun UpdateAvailabilityError.toUiMessage(): String =
+    when (this) {
+      is UpdateAvailabilityError.Unknown -> cause.message ?: "Unable to update availability"
+    }
 
   private fun changeAvailability(beer: Beer) {
     _beerDetailViewState.value = CommonUiState.Success(beer)


### PR DESCRIPTION
Either<Exception, T> is just exception wrapping - the UI can't distinguish failure modes because Exception carries none. The data boundary also didn't catch: BeersRepositoryImpl.updateAvailability let raw Room exceptions propagate uncaught.

Add UpdateAvailabilityError (a real sealed error type, currently one case - Unknown(cause), since that's the only failure mode this operation actually has today) and catch at the repository boundary instead of one layer up in the use case, which is now a pure pass-through. BeerDetailViewModel's error-to-UI-message mapping is an exhaustive when over UpdateAvailabilityError, so the compiler forces handling any case added later.

Reused Either<E, T> with the new error type rather than introducing a parallel Success/Error-named type - Either is already a generic sum type with tests and combinators (mapRight, mapLeft, flatMap, fold); the audit's actual complaint was the untyped Exception parameter, not Either itself, so parameterizing it was the smaller, non-redundant fix.

Also deletes BaseUseCase - dead code, never subclassed anywhere, unrelated to this migration but discovered while reading Either's usages.