### PR TITLE
fix: type the beers-list fetch error the same way

### DIFF
--- a/beer_data/build.gradle.kts
+++ b/beer_data/build.gradle.kts
@@ -12,5 +12,6 @@ dependencies {
   implementation(project(":beer_network"))
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
+  implementation(libs.retrofit2)
   testImplementation(libs.striktCore)
 }

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.simtop.beer_data.mappers.BeersMapper
 import com.simtop.beer_database.localsources.BeersLocalSource
 import com.simtop.beer_network.models.BeersApiResponseItem
 import com.simtop.beer_network.remotesources.BeersRemoteSource
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.repositories.BeersRepository
@@ -12,6 +13,8 @@ import com.simtop.core.core.PagingMediator
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
+import java.io.IOException
+import java.net.HttpURLConnection
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -20,6 +23,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
+import retrofit2.HttpException
 
 @SingleIn(AppScope::class)
 @Inject
@@ -35,10 +39,11 @@ class BeersRepositoryImpl(
   // hypothetical second consumer (docs/MASTER_PLAN.md Phase 1, improvements.md §12.3).
   // Revisit if a second paged screen (favorites, search) is ever added.
   private val pagingMediator =
-    PagingMediator<Int, Beer>(
+    PagingMediator<Int, Beer, FetchBeersError>(
       initialKey = 1,
       nextKey = { currentKey, _ -> currentKey + 1 },
       fetchRemote = { page -> fetchAndEnrichBeers(page) },
+      classifyError = { it.toFetchBeersError() },
       saveLocal = { beers ->
         beersLocalSource.insertAllToDB(beers.map { beersMapper.fromBeerToBeerDbModel(it) })
       },
@@ -48,6 +53,18 @@ class BeersRepositoryImpl(
         }
       }
     )
+
+  private fun Throwable.toFetchBeersError(): FetchBeersError =
+    when (this) {
+      is HttpException ->
+        when (code()) {
+          HttpURLConnection.HTTP_NOT_FOUND -> FetchBeersError.NotFound
+          HttpURLConnection.HTTP_FORBIDDEN -> FetchBeersError.Forbidden
+          else -> FetchBeersError.Unknown(this)
+        }
+      is IOException -> FetchBeersError.Network
+      else -> FetchBeersError.Unknown(this)
+    }
 
   // Fetches one image per beer (N+1). Deliberate: the API has no batch-image endpoint, so this
   // is a forced trade-off, not a bug - see docs/MASTER_PLAN.md Phase 1.

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/errors/FetchBeersError.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/errors/FetchBeersError.kt
@@ -1,0 +1,11 @@
+package com.simtop.beerdomain.domain.errors
+
+sealed interface FetchBeersError {
+  data object Network : FetchBeersError
+
+  data object NotFound : FetchBeersError
+
+  data object Forbidden : FetchBeersError
+
+  data class Unknown(val cause: Throwable) : FetchBeersError
+}

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -1,5 +1,6 @@
 package com.simtop.beerdomain.domain.repositories
 
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.core.core.Either
@@ -17,7 +18,7 @@ interface BeersRepository {
 
   fun getBeersFromSingleSource(): Flow<List<Beer>>
 
-  fun observePagingState(): Flow<PagingState>
+  fun observePagingState(): Flow<PagingState<FetchBeersError>>
 
   suspend fun loadNextPage()
 

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
@@ -1,5 +1,6 @@
 package com.simtop.beerdomain.fakes
 
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.repositories.BeersRepository
@@ -14,18 +15,18 @@ import kotlinx.coroutines.flow.map
 class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersRepository {
 
   private val beersFlow = MutableStateFlow<List<Beer>>(initialBeers)
-  private val pagingStateFlow = MutableStateFlow<PagingState>(PagingState.Idle)
+  private val pagingStateFlow = MutableStateFlow<PagingState<FetchBeersError>>(PagingState.Idle)
 
   // Helper to inspect state
   fun getBeers(): List<Beer> = beersFlow.value
 
-  fun getPagingState(): PagingState = pagingStateFlow.value
+  fun getPagingState(): PagingState<FetchBeersError> = pagingStateFlow.value
 
   fun setBeers(beers: List<Beer>) {
     beersFlow.value = beers
   }
 
-  fun setPagingState(state: PagingState) {
+  fun setPagingState(state: PagingState<FetchBeersError>) {
     pagingStateFlow.value = state
   }
 
@@ -65,7 +66,7 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
     return beersFlow
   }
 
-  override fun observePagingState(): Flow<PagingState> {
+  override fun observePagingState(): Flow<PagingState<FetchBeersError>> {
     return pagingStateFlow
   }
 

--- a/beerdomain/impl/src/main/java/com/simtop/beerdomain/domain/usecases/ObservePagingStateUseCase.kt
+++ b/beerdomain/impl/src/main/java/com/simtop/beerdomain/domain/usecases/ObservePagingStateUseCase.kt
@@ -1,10 +1,11 @@
 package com.simtop.beerdomain.domain.usecases
 
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.PagingState
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
 
 class ObservePagingStateUseCase @Inject constructor(private val beersRepository: BeersRepository) {
-  fun execute(): Flow<PagingState> = beersRepository.observePagingState()
+  fun execute(): Flow<PagingState<FetchBeersError>> = beersRepository.observePagingState()
 }

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagingHandler.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagingHandler.kt
@@ -6,11 +6,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
  * A helper class to handle PagingState updates in ViewModels. It helps reduce boilerplate when
  * mapping PagingState to UI State.
  */
-class PagingHandler<T>(
+class PagingHandler<T, Error : Any>(
   private val uiState: MutableStateFlow<T>,
-  private val reduce: (T, PagingState) -> T,
+  private val reduce: (T, PagingState<Error>) -> T,
 ) {
-  fun handlePagingState(pagingState: PagingState) {
+  fun handlePagingState(pagingState: PagingState<Error>) {
     val currentState = uiState.value
     val newState = reduce(currentState, pagingState)
     uiState.value = newState

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
@@ -9,18 +9,18 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
-sealed class PagingState {
-  object Idle : PagingState()
+sealed class PagingState<out Error : Any> {
+  object Idle : PagingState<Nothing>()
 
-  object Loading : PagingState()
+  object Loading : PagingState<Nothing>()
 
-  object LoadingNextPage : PagingState()
+  object LoadingNextPage : PagingState<Nothing>()
 
-  object Success : PagingState()
+  object Success : PagingState<Nothing>()
 
-  data class Error(val message: String) : PagingState()
+  data class Error<out E : Any>(val error: E) : PagingState<E>()
 
-  object EndOfPagination : PagingState()
+  object EndOfPagination : PagingState<Nothing>()
 }
 
 /**
@@ -29,17 +29,20 @@ sealed class PagingState {
  *
  * @param Key The type of the key used for paging (e.g., Int for page number).
  * @param Value The type of the data being paged.
+ * @param Error The caller's typed error for a failed fetch, produced from the caught [Throwable]
+ *   by [classifyError] - callers get to `when` over real failure modes instead of a raw message.
  */
-class PagingMediator<Key : Any, Value : Any>(
+class PagingMediator<Key : Any, Value : Any, Error : Any>(
   private val initialKey: Key,
   private val nextKey: (currentKey: Key, lastPage: List<Value>) -> Key?,
   private val fetchRemote: suspend (key: Key) -> List<Value>,
+  private val classifyError: (Throwable) -> Error,
   private val saveLocal: (suspend (List<Value>) -> Unit)? = null,
   private val fetchLocal: (() -> Flow<List<Value>>)? = null,
 ) {
 
-  private val _pagingState = MutableStateFlow<PagingState>(PagingState.Idle)
-  val pagingState: StateFlow<PagingState> = _pagingState.asStateFlow()
+  private val _pagingState = MutableStateFlow<PagingState<Error>>(PagingState.Idle)
+  val pagingState: StateFlow<PagingState<Error>> = _pagingState.asStateFlow()
 
   private val mutex = Mutex()
   private var currentKey: Key? = initialKey
@@ -107,7 +110,7 @@ class PagingMediator<Key : Any, Value : Any>(
     } catch (e: CancellationException) {
       throw e
     } catch (e: Exception) {
-      _pagingState.value = PagingState.Error(e.message ?: "Unknown error")
+      _pagingState.value = PagingState.Error(classifyError(e))
     }
   }
 

--- a/core/src/test/java/com/simtop/core/core/PagingMediatorTest.kt
+++ b/core/src/test/java/com/simtop/core/core/PagingMediatorTest.kt
@@ -23,10 +23,11 @@ class PagingMediatorTest {
       }
 
       val mediator =
-        PagingMediator<Int, String>(
+        PagingMediator<Int, String, String>(
           initialKey = 1,
           nextKey = { current, _ -> current + 1 },
           fetchRemote = fetchRemote,
+          classifyError = { it.message ?: "Unknown error" },
           saveLocal = {},
           fetchLocal = { flowOf(emptyList()) },
         )
@@ -47,10 +48,11 @@ class PagingMediatorTest {
       val fetchRemote: suspend (Int) -> List<String> = { throw RuntimeException("Network error") }
 
       val mediator =
-        PagingMediator<Int, String>(
+        PagingMediator<Int, String, String>(
           initialKey = 1,
           nextKey = { current, _ -> current + 1 },
           fetchRemote = fetchRemote,
+          classifyError = { it.message ?: "Unknown error" },
           saveLocal = {},
           fetchLocal = { flowOf(emptyList()) },
         )
@@ -61,8 +63,8 @@ class PagingMediatorTest {
         mediator.loadNextPage()
 
         assertEquals(PagingState.LoadingNextPage, awaitItem())
-        val error = awaitItem() as PagingState.Error
-        assertEquals("Network error", error.message)
+        val error = awaitItem() as PagingState.Error<*>
+        assertEquals("Network error", error.error)
       }
     }
 }

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
@@ -3,6 +3,7 @@ package com.simtop.feature.beerslist
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.simtop.beerdomain.domain.GetAllBeersUseCase
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.usecases.LoadNextPageUseCase
 import com.simtop.beerdomain.domain.usecases.ObservePagingStateUseCase
@@ -40,7 +41,9 @@ class BeersListViewModel(
     _beerListViewState.asStateFlow()
 
   private val pagingHandler =
-    PagingHandler(_beerListViewState) { currentState, pagingState ->
+    PagingHandler<CommonUiState<BeersListUiModel>, FetchBeersError>(_beerListViewState) {
+      currentState,
+      pagingState ->
       if (currentState is CommonUiState.Success) {
         val currentUiModel = currentState.data
         when (pagingState) {
@@ -73,10 +76,18 @@ class BeersListViewModel(
             } else {
               CommonUiState.Loading
             }
-          is PagingState.Error -> CommonUiState.Error(pagingState.message)
+          is PagingState.Error -> CommonUiState.Error(pagingState.error.toUiMessage())
           else -> currentState
         }
       }
+    }
+
+  private fun FetchBeersError.toUiMessage(): String =
+    when (this) {
+      FetchBeersError.Network -> "No internet connection"
+      FetchBeersError.NotFound -> "Beers not found"
+      FetchBeersError.Forbidden -> "Access denied"
+      is FetchBeersError.Unknown -> cause.message ?: "Failed to load beers"
     }
 
   init {


### PR DESCRIPTION
PagingMediator caught every fetch exception and kept only e.message as a String - not meaningfully more typed than Either<Exception, T>, since it threw away the exception object and left only prose. The UI still couldn't distinguish offline vs. server error vs. not-found.

Make PagingMediator<Key, Value, Error> generic over the error type, with a required classifyError: (Throwable) -> Error replacing the previous e.message fallback. PagingState.Error and PagingHandler follow the same generic parameter.

Add FetchBeersError (Network / NotFound / Forbidden / Unknown) and classify Retrofit's HttpException by status code and IOException as Network in BeersRepositoryImpl - the only place that actually knows what kind of request failed. BeersListViewModel maps it to a UI message via an exhaustive when, same pattern as UpdateAvailabilityError.

PagingMediatorTest uses String as its Error type with a trivial classifyError, since the mediator's own tests are domain-agnostic and don't need a real sealed error type.