### PR TITLE
fix: report missing fields in BeersMapper, add unit test coverage

### DIFF
--- a/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
@@ -1,5 +1,5 @@
 package com.simtop.beer_data.mappers
- 
+
 import com.simtop.beer_database.models.BeerDbModel
 import com.simtop.beer_database.utils.Converters
 import com.simtop.beer_network.models.BeersApiResponseItem
@@ -14,6 +14,10 @@ class BeersMapper @Inject constructor() {
       response?.translations?.find { it.language.code == BeersService.DEFAULT_LANGUAGE_CODE }
     val imageUrl = response?.imageId?.let { "https://brewbuddy.dev/images/$it" }
 
+    if (response?.id == null) logMissingField("id", response)
+    if (response?.name == null) logMissingField("name", response)
+    if (translation == null) logMissingField("translations (matching language)", response)
+
     return Beer(
       id = response?.id ?: "",
       name = response?.name ?: "",
@@ -24,6 +28,14 @@ class BeersMapper @Inject constructor() {
       ibu = response?.ibu ?: 0.0,
       foodPairing = response?.foodPairing ?: emptyList(),
     )
+  }
+
+  // TODO: route through the observability seam (Logger facade) once it lands - the codebase has
+  // no logging today (docs/MASTER_PLAN.md Phase 3). System.err is a dependency-free stopgap so
+  // malformed backend data isn't silently swallowed in the meantime, without dragging
+  // android.util.Log's static-mock requirement into every indirect caller's unit tests.
+  private fun logMissingField(field: String, response: BeersApiResponseItem?) {
+    System.err.println("$TAG: missing $field for beer id=${response?.id}, defaulting")
   }
 
   fun fromBeerToBeerDbModel(beer: Beer) =
@@ -51,4 +63,8 @@ class BeersMapper @Inject constructor() {
       Converters.jsonToList(beerDbModel.foodPairing),
       beerDbModel.availability,
     )
+
+  private companion object {
+    const val TAG = "BeersMapper"
+  }
 }

--- a/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
@@ -1,0 +1,162 @@
+package com.simtop.beer_data.mappers
+
+import com.simtop.beer_database.models.BeerDbModel
+import com.simtop.beer_network.models.BeersApiResponseItem
+import com.simtop.beer_network.models.Language
+import com.simtop.beer_network.models.Translation
+import com.simtop.beerdomain.domain.models.Beer
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class BeersMapperTest {
+
+  private val mapper = BeersMapper()
+
+  private fun fullResponse() =
+    BeersApiResponseItem(
+      id = "1",
+      name = "Buzz",
+      abv = 4.5,
+      ibu = 60.0,
+      imageId = "42",
+      translations = listOf(Translation(Language("en"), "A Real Bitter Experience.", "Tasty.")),
+      foodPairing = listOf("Steak"),
+    )
+
+  @Test
+  fun `fromBeersApiResponseItemToBeer maps a fully populated response`() {
+    val beer = mapper.fromBeersApiResponseItemToBeer(fullResponse())
+
+    expectThat(beer)
+      .isEqualTo(
+        Beer(
+          id = "1",
+          name = "Buzz",
+          tagline = "A Real Bitter Experience.",
+          description = "Tasty.",
+          imageUrl = "https://brewbuddy.dev/images/42",
+          abv = 4.5,
+          ibu = 60.0,
+          foodPairing = listOf("Steak"),
+        )
+      )
+  }
+
+  @Test
+  fun `fromBeersApiResponseItemToBeer defaults everything when response is null`() {
+    val beer = mapper.fromBeersApiResponseItemToBeer(null)
+
+    expectThat(beer)
+      .isEqualTo(
+        Beer(
+          id = "",
+          name = "",
+          tagline = "",
+          description = "",
+          imageUrl = "",
+          abv = 0.0,
+          ibu = 0.0,
+          foodPairing = emptyList(),
+        )
+      )
+  }
+
+  @Test
+  fun `fromBeersApiResponseItemToBeer defaults id when missing`() {
+    val beer = mapper.fromBeersApiResponseItemToBeer(fullResponse().copy(id = null))
+
+    expectThat(beer.id).isEqualTo("")
+  }
+
+  @Test
+  fun `fromBeersApiResponseItemToBeer defaults tagline and description when no matching translation`() {
+    val response = fullResponse().copy(translations = listOf(Translation(Language("fr"), "Une bière.", "Savoureux.")))
+
+    val beer = mapper.fromBeersApiResponseItemToBeer(response)
+
+    expectThat(beer.tagline).isEqualTo("")
+    expectThat(beer.description).isEqualTo("")
+  }
+
+  @Test
+  fun `fromBeersApiResponseItemToBeer defaults tagline and description when translations is null`() {
+    val beer = mapper.fromBeersApiResponseItemToBeer(fullResponse().copy(translations = null))
+
+    expectThat(beer.tagline).isEqualTo("")
+    expectThat(beer.description).isEqualTo("")
+  }
+
+  @Test
+  fun `fromBeersApiResponseItemToBeer defaults imageUrl when imageId is missing`() {
+    val beer = mapper.fromBeersApiResponseItemToBeer(fullResponse().copy(imageId = null))
+
+    expectThat(beer.imageUrl).isEqualTo("")
+  }
+
+  @Test
+  fun `fromBeerToBeerDbModel converts a Beer into a BeerDbModel`() {
+    val beer =
+      Beer(
+        id = "1",
+        name = "Buzz",
+        tagline = "A Real Bitter Experience.",
+        description = "Tasty.",
+        imageUrl = "https://brewbuddy.dev/images/42",
+        abv = 4.5,
+        ibu = 60.0,
+        foodPairing = listOf("Steak"),
+        availability = false,
+      )
+
+    val dbModel = mapper.fromBeerToBeerDbModel(beer)
+
+    expectThat(dbModel)
+      .isEqualTo(
+        BeerDbModel(
+          id = "1",
+          name = "Buzz",
+          tagline = "A Real Bitter Experience.",
+          description = "Tasty.",
+          imageUrl = "https://brewbuddy.dev/images/42",
+          abv = 4.5,
+          ibu = 60.0,
+          foodPairing = "[\"Steak\"]",
+          availability = false,
+        )
+      )
+  }
+
+  @Test
+  fun `fromBeerDbModelToBeer converts a BeerDbModel into a Beer`() {
+    val dbModel =
+      BeerDbModel(
+        id = "1",
+        name = "Buzz",
+        tagline = "A Real Bitter Experience.",
+        description = "Tasty.",
+        imageUrl = "https://brewbuddy.dev/images/42",
+        abv = 4.5,
+        ibu = 60.0,
+        foodPairing = "[\"Steak\"]",
+        availability = false,
+      )
+
+    val beer = mapper.fromBeerDbModelToBeer(dbModel)
+
+    expectThat(beer)
+      .isEqualTo(
+        Beer(
+          id = "1",
+          name = "Buzz",
+          tagline = "A Real Bitter Experience.",
+          description = "Tasty.",
+          imageUrl = "https://brewbuddy.dev/images/42",
+          abv = 4.5,
+          ibu = 60.0,
+          foodPairing = listOf("Steak"),
+          availability = false,
+        )
+      )
+  }
+}


### PR DESCRIPTION
BeersMapper was already an injectable, constructor-injected class - the audit's original complaint (a static object, not testable in isolation) no longer applies. Two gaps did: response?.name ?: "" style defaulting silently swallowed malformed backend data with zero signal, and there was no dedicated unit test - only indirect coverage through BeersRepositoryTest.

Report missing id/name/translation via a stopgap (System.err, not android.util.Log - Log requires mockkStatic in every test that exercises this code path even indirectly, which broke BeersRepositoryTest when first tried; System.err has no such ripple). Route through the real observability seam once it lands (MASTER_PLAN Phase 3).

Add BeersMapperTest covering the null-field branches: missing id, missing name, no matching translation, null translations, missing imageId, plus both DB model conversion directions.