### PR TITLE
feat: add remaining Konsist architecture rules

### DIFF
--- a/konsist/src/test/kotlin/com/simtop/konsist/DomainLayerPurityTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/DomainLayerPurityTest.kt
@@ -1,0 +1,21 @@
+package com.simtop.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.jupiter.api.Test
+
+/**
+ * :beerdomain:api is the pure-Kotlin domain layer - models, repository interfaces, error types.
+ * An android.* import here means an Android framework type leaked into a layer that every other
+ * module (including a future KMP non-Android target) depends on.
+ */
+class DomainLayerPurityTest {
+
+  @Test
+  fun `beerdomain domain layer has no android imports`() {
+    Konsist.scopeFromProject()
+      .files
+      .filter { it.packagee?.name?.startsWith("com.simtop.beerdomain.domain") == true }
+      .assertFalse { file -> file.hasImport { import -> import.name.startsWith("android") } }
+  }
+}

--- a/konsist/src/test/kotlin/com/simtop/konsist/FeatureModuleBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/FeatureModuleBoundaryTest.kt
@@ -1,0 +1,34 @@
+package com.simtop.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.jupiter.api.Test
+
+/**
+ * Feature modules are siblings, never dependents of each other - each communicates with the rest
+ * of the app only through the domain layer (repositories, use cases, models) and navigation. A
+ * feature importing another feature directly is exactly the kind of coupling that makes dynamic
+ * delivery (feature/beerdetail) and independent feature ownership impossible to scale.
+ */
+class FeatureModuleBoundaryTest {
+
+  @Test
+  fun `feature-beerslist does not depend on feature-beerdetail`() {
+    Konsist.scopeFromProject()
+      .files
+      .filter { it.packagee?.name?.startsWith("com.simtop.feature.beerslist") == true }
+      .assertFalse { file ->
+        file.hasImport { import -> import.name.startsWith("com.simtop.feature.beerdetail") }
+      }
+  }
+
+  @Test
+  fun `feature-beerdetail does not depend on feature-beerslist`() {
+    Konsist.scopeFromProject()
+      .files
+      .filter { it.packagee?.name?.startsWith("com.simtop.feature.beerdetail") == true }
+      .assertFalse { file ->
+        file.hasImport { import -> import.name.startsWith("com.simtop.feature.beerslist") }
+      }
+  }
+}

--- a/konsist/src/test/kotlin/com/simtop/konsist/RepositoryBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/RepositoryBoundaryTest.kt
@@ -1,0 +1,29 @@
+package com.simtop.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.ext.list.withNameEndingWith
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.jupiter.api.Test
+
+/**
+ * Repository interfaces are the boundary between the domain layer and the data layer - their
+ * public signatures must only expose domain types (Beer, PagingState<E>, Either<E, T>), never DB
+ * entities or network DTOs. If a repository interface needs to import beer_database or
+ * beer_network, a data-layer type is leaking through its signature.
+ */
+class RepositoryBoundaryTest {
+
+  private val forbiddenPackagePrefixes = listOf("com.simtop.beer_database", "com.simtop.beer_network")
+
+  @Test
+  fun `repository interfaces do not import data-layer types`() {
+    Konsist.scopeFromProject()
+      .interfaces()
+      .withNameEndingWith("Repository")
+      .assertFalse { repository ->
+        forbiddenPackagePrefixes.any { prefix ->
+          repository.containingFile.hasImport { import -> import.name.startsWith(prefix) }
+        }
+      }
+  }
+}


### PR DESCRIPTION
Rounds out the konsist/ module (MASTER_PLAN Phase 2 §4) beyond the ViewModel boundary rule already in place:

- Feature modules don't depend on each other (feature/beerslist and feature/beerdetail communicate only through the domain layer and navigation, never directly).
- :beerdomain:api has no android.* imports - it's the pure-Kotlin domain layer every module depends on, including a future KMP non-Android target.
- Repository interfaces don't import data-layer types (beer_database, beer_network) - their public signatures must stay domain-only.

All three currently pass with zero violations - they're preventive, not fixing an existing problem, same as the ViewModel rule was.

Implementation note: KoFileDeclaration doesn't implement KoResideInPackageProvider (that interface's resideInPackage/ resideOutsidePackage methods are for declarations like classes/ interfaces, not files), so package scoping here goes through file.packagee?.name directly rather than a resideInPackage-style helper.