### PR TITLE
fix: survive process death for mid-flight beer state

### DIFF
--- a/feature/beerdetail/build.gradle.kts
+++ b/feature/beerdetail/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
   implementation(project(":core:designsystem"))
   implementation(project(":navigation"))
   implementation(libs.androidx.navigation3.runtime)
+  implementation(libs.kotlinx.serialization.json)
+  implementation(libs.lifecycle.viewmodel.savedstate)
 
   implementation(libs.coil3)
   implementation(libs.coil3.network)

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/BeerDetailScreen.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/BeerDetailScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.repeatOnLifecycle
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.billionbeers.BillionBeersApplication
@@ -38,7 +39,12 @@ fun BeerDetailScreenImpl(beer: Beer, onBackClick: () -> Unit) {
 
   CompositionLocalProvider(LocalMetroViewModelFactory provides factory) {
     val viewModel: BeerDetailViewModel =
-      assistedMetroViewModel<BeerDetailViewModel, BeerDetailViewModel.Factory>(key = beer.id) { create(beer) }
+      assistedMetroViewModel<BeerDetailViewModel, BeerDetailViewModel.Factory>(key = beer.id) {
+        extras ->
+        // The SavedStateHandle lets the ViewModel restore a toggled beer across process death
+        // instead of reverting to the (stale) nav-arg beer this composable was launched with.
+        create(beer, extras.createSavedStateHandle())
+      }
     val viewState by viewModel.beerDetailViewState.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
 

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/BeerDetailViewModel.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/BeerDetailViewModel.kt
@@ -1,6 +1,8 @@
 package com.simtop.feature.beerdetail.presentation
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.serialization.saved
 import androidx.lifecycle.viewModelScope
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
@@ -28,15 +30,24 @@ class BeerDetailViewModel
 constructor(
   private val coroutineDispatcher: CoroutineDispatcherProvider,
   private val beersRepository: BeersRepository,
-  @Assisted private val beer: Beer,
+  @Assisted beer: Beer,
+  @Assisted savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
   @AssistedFactory
   @ManualViewModelAssistedFactoryKey(Factory::class)
   @ContributesIntoMap(FeatureDetailScope::class)
   interface Factory : ManualViewModelAssistedFactory {
-    fun create(@Assisted beer: Beer): BeerDetailViewModel
+    fun create(
+      @Assisted beer: Beer,
+      @Assisted savedStateHandle: SavedStateHandle,
+    ): BeerDetailViewModel
   }
+
+  // Last state shown on screen, saved across process death. The assisted beer param comes from
+  // the nav arg, which goes stale the moment availability is toggled - restoring from it would
+  // silently revert the toggle.
+  private var lastKnownBeer: Beer by savedStateHandle.saved(serializer = Beer.serializer()) { beer }
 
   private val _beerDetailViewState = MutableStateFlow<CommonUiState<Beer>>(CommonUiState.Loading)
   val beerDetailViewState: StateFlow<CommonUiState<Beer>> = _beerDetailViewState.asStateFlow()
@@ -45,18 +56,19 @@ constructor(
   val events: Flow<BeerDetailEvent> = _events.receiveAsFlow()
 
   init {
-    setBeer(beer)
+    setBeer(lastKnownBeer)
   }
 
   fun updateAvailability(beer: Beer) {
     viewModelScope.launch(coroutineDispatcher.io) {
       val newBeer = beer.copy(availability = !beer.availability)
-      changeAvailability(newBeer)
+      setBeer(newBeer)
       treatResponse(result = beersRepository.updateAvailability(newBeer), originalBeer = beer)
     }
   }
 
   private fun setBeer(beer: Beer) {
+    lastKnownBeer = beer
     _beerDetailViewState.value = CommonUiState.Success(beer)
   }
 
@@ -66,7 +78,7 @@ constructor(
   ) {
     when (result) {
       is Either.Left -> {
-        _beerDetailViewState.value = CommonUiState.Success(originalBeer)
+        setBeer(originalBeer)
         _events.send(BeerDetailEvent.ShowError(result.value.toUiMessage()))
       }
       is Either.Right -> Unit
@@ -77,10 +89,6 @@ constructor(
     when (this) {
       is UpdateAvailabilityError.Unknown -> cause.message ?: "Unable to update availability"
     }
-
-  private fun changeAvailability(beer: Beer) {
-    _beerDetailViewState.value = CommonUiState.Success(beer)
-  }
 }
 
 sealed interface BeerDetailEvent {

--- a/feature/beerdetail/src/test/java/com/simtop/feature/beerdetail/BeerDetailViewModelTest.kt
+++ b/feature/beerdetail/src/test/java/com/simtop/feature/beerdetail/BeerDetailViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.simtop.feature.beerdetail
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.fakes.FakeBeersRepository
@@ -47,7 +48,12 @@ internal class BeerDetailViewModelTest {
     runTest(testDispatcher) {
       // Arrange & Act
       val beerDetailViewModel =
-        BeerDetailViewModel(coroutineDispatcherProvider, fakeBeersRepository, fakeBeerModel)
+        BeerDetailViewModel(
+          coroutineDispatcherProvider,
+          fakeBeersRepository,
+          fakeBeerModel,
+          SavedStateHandle(),
+        )
 
       // Assert
       beerDetailViewModel.beerDetailViewState.test {
@@ -65,7 +71,12 @@ internal class BeerDetailViewModelTest {
       fakeBeersRepository.setExceptionToThrow(fakeException)
 
       val beerDetailViewModel =
-        BeerDetailViewModel(coroutineDispatcherProvider, fakeBeersRepository, fakeBeerModel)
+        BeerDetailViewModel(
+          coroutineDispatcherProvider,
+          fakeBeersRepository,
+          fakeBeerModel,
+          SavedStateHandle(),
+        )
 
       // Act
       beerDetailViewModel.events.test {
@@ -106,7 +117,12 @@ internal class BeerDetailViewModelTest {
       val testExpectedResponse = fakeBeerModel.copy(availability = !fakeBeerModel.availability)
 
       val beerDetailViewModel =
-        BeerDetailViewModel(coroutineDispatcherProvider, fakeBeersRepository, fakeBeerModel)
+        BeerDetailViewModel(
+          coroutineDispatcherProvider,
+          fakeBeersRepository,
+          fakeBeerModel,
+          SavedStateHandle(),
+        )
 
       // Act
       beerDetailViewModel.beerDetailViewState.test {

--- a/feature/beerslist/build.gradle.kts
+++ b/feature/beerslist/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   implementation(project(":presentation_utils"))
   implementation(project(":core"))
   implementation(project(":core:designsystem"))
+  implementation(libs.kotlinx.serialization.json)
   testImplementation(project(":beerdomain:fakes"))
   testImplementation(libs.striktCore)
 

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -65,14 +65,24 @@ import com.simtop.presentation_utils.core.InfiniteListHandler
 import com.simtop.presentation_utils.custom_views.ComposeBeersListItem
 import com.simtop.presentation_utils.custom_views.ComposeErrorView
 import dev.zacsweers.metrox.viewmodel.metroViewModel
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private val BeerSaver: Saver<Beer?, String> =
+  Saver(
+    save = { beer -> beer?.let { Json.encodeToString(it) }.orEmpty() },
+    restore = { json -> json.takeIf { it.isNotEmpty() }?.let { Json.decodeFromString<Beer>(it) } },
+  )
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BeersListScreen(viewModel: BeersListViewModel = metroViewModel(), onBeerClick: (Beer) -> Unit) {
   val rawState by viewModel.beerListViewState.collectAsState()
 
-  // State to track if we are installing the feature for a specific beer
-  var installingBeer by remember { mutableStateOf<Beer?>(null) }
+  // State to track if we are installing the feature for a specific beer - saved across process
+  // death so the install flow resumes instead of silently dropping the in-flight navigation.
+  var installingBeer by rememberSaveable(stateSaver = BeerSaver) { mutableStateOf<Beer?>(null) }
 
   BeersListContent(
     viewState = rawState,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -58,6 +58,7 @@ androidx-annotation = { module = "androidx.annotation:annotation", version.ref =
 constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 lifecycleRuntimeKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
 lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
+lifecycle-viewmodel-savedstate = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "androidx-lifecycle" }
 
 # Navigation
 navigationFragmentKtx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }


### PR DESCRIPTION
Per improvements.md §13.4: neither BeersListViewModel nor BeerDetailViewModel used a SavedStateHandle, so an availability toggle would silently revert to the pre-toggle nav-arg beer if the process died, and installingBeer (a plain mutableStateOf tracking an in-progress dynamic feature install) would drop the install target entirely.

**BeerDetailViewModel** now takes a `SavedStateHandle` as a second assisted param. Metro can't graph-inject one here (the manual assisted factory has no such binding), but the metrox `assistedMetroViewModel` creator lambda receives the `CreationExtras`, so the call site derives a handle via `extras.createSavedStateHandle()` and passes it in. The last shown beer is persisted through lifecycle 2.10's `SavedStateHandle.saved(serializer)` delegate: every state write goes through `setBeer`, which keeps the saved copy in sync, and `init` seeds the UI from it instead of the (possibly stale) nav-arg beer. This keeps saved-state ownership in the ViewModel — the composable stays a dumb renderer with no duplicated state or sync effects.

Verified end-to-end on an emulator: open detail → toggle availability ("Mark as Empty" → "Refill Barrels") → home → `am kill` (process confirmed dead) → relaunch: the detail screen restores showing the toggled state instead of the stale nav arg.

**installingBeer** in BeersListScreen stays at the Compose layer with `rememberSaveable` + a small JSON Saver — it's UI flow state with no ViewModel owner (BeersListViewModel is created via the non-assisted path, which has no handle binding), and `DynamicFeatureLoader` re-issues the install when recomposed after restore, so the in-flight navigation resumes rather than being dropped.

Scroll position already survives via rememberLazyListState (confirmed in the audit, no change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)