### PR TITLE
fix: keep screenshot service file out of APKs to unblock installDebug

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,6 @@ android {
       excludes += "a/b.class"
       excludes += "META-INF/LICENSE.md"
       excludes += "META-INF/LICENSE-notice.md"
-      pickFirsts += "META-INF/services/com.simtop.billionbeers.snapshot_testing.PreviewProvider"
     }
   }
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
@@ -130,6 +130,20 @@ pluginManager.withPlugin("com.android.dynamic-feature") {
     }
 }
 
+// The KSP-generated PreviewProvider service file is only consumed by the generated Paparazzi
+// unit test (via ServiceLoader on the test resources wired up above) - it must never ship in
+// APKs/bundles: bundletool rejects the app bundle because the base module and the beerdetail
+// dynamic feature both contain the same entry path with different content.
+// packaging.resources.excludes cannot strip it because AGP merges META-INF/services/** by
+// default and merge rules take precedence over excludes, so it is filtered out of the java
+// resources before packaging instead. Unit-test variants keep it.
+tasks.matching {
+    it.name.startsWith("process") && it.name.endsWith("JavaRes") && !it.name.contains("UnitTest")
+}.configureEach {
+    (this as? org.gradle.api.tasks.Sync)
+        ?.exclude("META-INF/services/com.simtop.billionbeers.snapshot_testing.PreviewProvider")
+}
+
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     if (name.contains("Test", ignoreCase = true)) {
         source(generatePaparazziTest)


### PR DESCRIPTION
`make install` (`:app:installDebug`) failed at `:app:packageDebugBundle` with bundletool's `InvalidBundleException`: modules `base` and `beerdetail` both contained `META-INF/services/com.simtop.billionbeers.snapshot_testing.PreviewProvider` with different content. The screenshot KSP processor generates that service file into every module's **main** java resources, so it ships in production packaging even though its only consumer is the generated Paparazzi unit test, which reads it from the test source set resources the convention plugin wires up.

**Why not `packaging.resources.excludes`?** Tried first — it has no effect. AGP merges `META-INF/services/**` by default, and in AGP's packaging action resolution pickFirsts > merges > excludes, so the default merge rule always wins over an exclude for service files. (That default merge is also why the base APK's copy was a concatenation of the designsystem / presentation_utils / beerslist lists.)

**Fix:** the screenshot convention plugin now filters the service file out of the `process*JavaRes` tasks for all non-UnitTest variants, so it never enters production java resources in any module applying the plugin. The app's `pickFirsts` workaround is removed — it only papered over the intra-base collision (several libraries shipping the same path) and could not fix the base-vs-dynamic-feature conflict, which bundletool checks by content.

Verified:
- `:app:installDebug` succeeds and the app installs/runs on an emulator
- the service entry is gone from both `base` and `feature-beerdetail` merged java resources
- `:feature:beerslist:verifyPaparazziDebug --rerun-tasks` still discovers all five previews via ServiceLoader and verifies them against the golden images (no `DUMMY_NO_PREVIEWS_FOUND` skip)
- catalog is unaffected: it ServiceLoads `CatalogProvider`, a different service file

🤖 Generated with [Claude Code](https://claude.com/claude-code)