### PR TITLE
Add Android skills setup for AI agents

### DIFF
--- a/.claude/skills/.android-skills-ignore
+++ b/.claude/skills/.android-skills-ignore
@@ -1,0 +1,18 @@
+# Android skills to NOT install from github.com/android/skills.
+# One skill `name` (from its SKILL.md frontmatter) per line; # for comments.
+# scripts/update-android-skills.sh skips these and removes them if present,
+# so `make update-android-skills` won't resurrect skills you deliberately dropped.
+# Add a name here to opt out; delete a line to start pulling that skill again.
+
+agp-9-upgrade
+camera1-to-camerax
+display-glasses-with-jetpack-compose-glimmer
+migrate-xml-views-to-jetpack-compose
+wear-compose-m3
+# Not relevant to BillionBeers (pruned 2026-07-04 to keep skill-description
+# context overhead down):
+appfunctions
+engage-sdk-integration
+play-billing-library-version-upgrade
+styles
+verified-email

--- a/.claude/skills/billionbeers-android/SKILL.md
+++ b/.claude/skills/billionbeers-android/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: billionbeers-android
+description: >-
+  Drive the Android SDK command-line tools (adb, emulator, sdkmanager, avdmanager)
+  for the BillionBeers app. Use this WHENEVER a task touches a real device or
+  emulator — starting/stopping an emulator, checking connected devices or SDK
+  status, installing/uninstalling the app, launching the app, taking a
+  screenshot, reading logcat, clearing app data, or running instrumented
+  (androidTest) tests on a device. Prefer this over ad-hoc adb invocations so
+  paths and the known installDebug workaround are handled correctly. Triggers on:
+  "adb", "emulator", "install the app", "launch the app", "screenshot the app",
+  "logcat", "run on device", "connected devices", "AVD", "sdkmanager".
+---
+
+# Android CLI (BillionBeers)
+
+Wraps the local Android SDK CLI so agents interact with devices/emulators
+consistently. **Always prefer these recipes over improvising `adb` paths.**
+
+## Environment (already installed)
+
+- SDK root: `$ANDROID_HOME` = `~/Library/Android/sdk` (also `$ANDROID_SDK_ROOT`).
+- `adb` is **not on PATH by default** — always invoke it as
+  `"$ANDROID_HOME/platform-tools/adb"` (or plain `adb` if PATH is configured).
+- `emulator` binary: `/usr/local/bin/emulator` (or `$ANDROID_HOME/emulator/emulator`).
+- `sdkmanager` / `avdmanager` are on PATH (Homebrew `android-commandlinetools`).
+- App id: `com.simtop.billionbeers` — launcher:
+  `com.simtop.billionbeers/.presentation.MainActivity`.
+
+Define a shorthand at the top of a shell session:
+
+```bash
+ADB="$ANDROID_HOME/platform-tools/adb"
+EMU="${ANDROID_HOME}/emulator/emulator"   # or /usr/local/bin/emulator
+APP=com.simtop.billionbeers
+```
+
+## 0. Preflight — check status first
+
+```bash
+"$ADB" version                 # confirm adb works
+"$ADB" devices -l              # list connected devices/emulators
+"$EMU" -list-avds              # list installable AVDs
+sdkmanager --list_installed    # SDK packages (optional)
+```
+
+If `adb devices` shows no `device` (only `offline`/empty), start an emulator (§1).
+
+## 1. Emulator lifecycle
+
+```bash
+"$EMU" -list-avds                                   # pick one, e.g. Resizable_Android_17
+"$EMU" -avd Resizable_Android_17 -netdelay none -netspeed full &   # boot (backgrounded)
+"$ADB" wait-for-device
+# block until fully booted:
+until [ "$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" = "1" ]; do sleep 2; done
+"$ADB" shell input keyevent 82                      # dismiss keyguard
+```
+
+Stop an emulator: `"$ADB" -s emulator-5554 emu kill`.
+
+## 2. Install the app  ⚠️ read this
+
+`make install` / `:app:installDebug` is **broken on this branch** — the dynamic
+feature install goes through the app bundle and bundletool rejects a duplicate
+`META-INF/services/...PreviewProvider` entry (see the
+`installdebug-bundle-broken` memory; real fix is PR #30). Until that fix is on
+your branch, install the split APKs directly:
+
+```bash
+make build            # or: ./gradlew assembleDebug  (bb/rtk wrappers via Makefile)
+"$ADB" install-multiple -r \
+  app/build/outputs/apk/debug/app-debug.apk \
+  feature/beerdetail/build/outputs/apk/debug/beerdetail-debug.apk
+```
+
+Once PR #30 is merged into the working branch, `make install` works again — try
+it first and fall back to `install-multiple` only if bundletool complains.
+
+Uninstall: `"$ADB" uninstall "$APP"`.
+
+## 3. Launch / drive / observe the app
+
+```bash
+"$ADB" shell am start -n "$APP/.presentation.MainActivity"   # launch
+"$ADB" shell pm clear "$APP"                                  # reset app data
+"$ADB" logcat --pid=$("$ADB" shell pidof "$APP")             # app logs only
+# screenshot to the host:
+"$ADB" exec-out screencap -p > /tmp/billionbeers-$(date +%s).png
+```
+
+## 4. Instrumented tests on a device
+
+Prefer the Gradle/Makefile path (routes through `bb`/`rtk`):
+
+```bash
+./gradlew :app:connectedDebugAndroidTest        # needs a booted device (§1)
+```
+
+## Notes
+
+- For **unit tests, builds, lint, format, screenshots (Paparazzi)** use the
+  `Makefile` targets (`make test`, `make build`, `make screenshot-verify`, …),
+  not adb — those don't need a device. This skill is only for on-device work.
+- Never hardcode `emulator-5554`; read the serial from `adb devices` and pass it
+  with `-s <serial>` when more than one device is attached.
+- This is the **project-specific** device skill (app id, install workaround). For
+  general Android tasks there are also vendored **official Android skills** from
+  [github.com/android/skills](https://github.com/android/skills) in
+  `.claude/skills/` — e.g. `android-cli` (Google's `android` tool), `navigation-3`,
+  `r8-analyzer`, `testing-setup`, `edge-to-edge`, `perfetto-trace-analysis`. Refresh
+  them with `make update-android-skills`.

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ gradle-user-home/
 /tmp/
 .temp_research/
 profile-out/
+
+# Claude Code local state. Vendored Android skills (github.com/android/skills)
+# are synced locally via `make update-android-skills`, not committed — only the
+# sync opt-out list and the project-authored billionbeers-android skill live in git.
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/.android-skills-ignore
+!.claude/skills/billionbeers-android/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,31 @@ Always use the `Makefile` wrappers which automatically detect if `bb` or `rtk` i
 
 ---
 
-## 📱 Android CLI & Custom Skills
+## 📱 Android Skills
 
-This workspace includes the `android-cli` plugin skill. Coding agents can call:
-- `android-cli` to start/stop emulators, install APKs, run tests, and check system/SDK status.
-- Refer to the skill specifications in `android-cli/skills/SKILL.md` to trigger actions dynamically.
+Skills live in `.claude/skills/` and Claude Code agents should reach for them
+whenever a task matches their domain.
+
+**Project skill — `billionbeers-android`** (`.claude/skills/billionbeers-android/SKILL.md`):
+**Always use it whenever a task touches a real device or emulator** — starting/stopping
+emulators, checking devices/SDK status, installing/launching the app, screenshots, logcat,
+or running instrumented (`androidTest`) tests. It handles the correct `adb` path
+(`$ANDROID_HOME/platform-tools/adb`) and the known `installDebug` bundle workaround. For
+device-free work (unit tests, builds, lint, screenshots) keep using the `Makefile` targets above.
+
+**Official Android skills** — a curated subset from
+[github.com/android/skills](https://github.com/android/skills) is vendored into
+`.claude/skills/` (each carries a `.android-skill-source` marker). Agents should use the
+relevant one for its domain, e.g. `android-cli` (Google's `android` tool), `navigation-3`,
+`r8-analyzer`, `perfetto-trace-analysis`, `testing-setup`, `edge-to-edge`, `adaptive`,
+`android-intent-security`, and more.
+
+- **Update / pull new skills**: `make update-android-skills` (wraps
+  `scripts/update-android-skills.sh`). Re-run any time — it installs newly added upstream
+  skills, prunes ones removed upstream, and never touches locally-authored skills like
+  `billionbeers-android`.
+- **Opt out of a skill**: add its name to `.claude/skills/.android-skills-ignore`. Ignored
+  skills are skipped and removed on sync, so `make update-android-skills` won't resurrect
+  skills you deliberately dropped. Currently ignored: `agp-9-upgrade`, `camera1-to-camerax`,
+  `display-glasses-with-jetpack-compose-glimmer`, `migrate-xml-views-to-jetpack-compose`,
+  `wear-compose-m3`.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ UI_TEST_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,:app:)
 # Wrapper for Gradle to support build-brief (bb) or rtk if available
 GRADLE_RUNNER := $(shell if command -v bb >/dev/null 2>&1; then echo "bb ./gradlew"; elif command -v build-brief >/dev/null 2>&1; then echo "build-brief --gradle ./gradlew"; elif command -v rtk >/dev/null 2>&1; then echo "rtk ./gradlew"; else echo "./gradlew"; fi)
 
-.PHONY: help setup setup-ai-tools build install clean test konsist ui-test screenshot-record screenshot-verify screenshot-clean lint format check check-duplicates check-unused-deps benchmark-micro benchmark-macro generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse
+.PHONY: help setup setup-ai-tools update-android-skills build install clean test konsist ui-test screenshot-record screenshot-verify screenshot-clean lint format check check-duplicates check-unused-deps benchmark-micro benchmark-macro generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse
 
 help: ## Show this help message.
 	@echo "\n📊 BillionBeers Makefile Help"
@@ -44,6 +44,9 @@ setup-ai-tools: ## Install token-saving tools (rtk, build-brief, snip) via Homeb
 	brew install rtk || true
 	brew install edouard-claude/tap/snip || true
 	@echo "🎉 AI tools setup complete!"
+
+update-android-skills: ## Sync official Android skills (github.com/android/skills) into .claude/skills.
+	@bash scripts/update-android-skills.sh
 
 # Basic Commands
 build: ## Assemble the debug APK.

--- a/scripts/update-android-skills.sh
+++ b/scripts/update-android-skills.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Sync the official Android skills (https://github.com/android/skills) into
+# .claude/skills/ so Claude Code agents can use them. Re-run any time to pull the
+# latest set — newly added upstream skills are installed automatically and removed
+# upstream skills are pruned. Locally-authored skills (anything NOT present in the
+# upstream repo, e.g. `billionbeers-android`) are always left untouched.
+#
+# Usage: scripts/update-android-skills.sh   (or: make update-android-skills)
+
+set -euo pipefail
+
+REPO="https://github.com/android/skills.git"
+# Resolve repo root from this script's location so it works from any cwd.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SKILLS_DIR="$ROOT/.claude/skills"
+# Marker file dropped into each vendored skill so we know which dirs we own.
+MARKER=".android-skill-source"
+# Opt-out list: skill names (one per line, # comments) we never install.
+IGNORE_FILE="$SKILLS_DIR/.android-skills-ignore"
+
+mkdir -p "$SKILLS_DIR"
+
+# True if $1 is listed in the ignore file.
+is_ignored() {
+  [ -f "$IGNORE_FILE" ] || return 1
+  grep -vE '^[[:space:]]*(#|$)' "$IGNORE_FILE" | sed 's/[[:space:]]*$//' | grep -qxF "$1"
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "→ Cloning $REPO ..."
+git clone --depth 1 -q "$REPO" "$TMP/skills"
+
+# 1. Prune vendored skills that no longer exist upstream (only ones we own).
+#    (bash 3.2 compatible — no associative arrays: use a newline-delimited list.)
+UPSTREAM_NAMES="$(find "$TMP/skills" -name SKILL.md -exec sed -n 's/^name:[[:space:]]*//p' {} \; | head -n1000)"
+
+for dir in "$SKILLS_DIR"/*/; do
+  [ -e "$dir" ] || continue
+  name="$(basename "$dir")"
+  if [ -f "$dir$MARKER" ] && ! printf '%s\n' "$UPSTREAM_NAMES" | grep -qxF "$name"; then
+    echo "  ✗ pruning removed-upstream skill: $name"
+    rm -rf "$dir"
+  fi
+done
+
+# 2. Install / refresh every upstream skill, keyed by its frontmatter `name`.
+count=0
+while IFS= read -r skillmd; do
+  src="$(dirname "$skillmd")"
+  name="$(sed -n 's/^name:[[:space:]]*//p' "$skillmd" | head -n1)"
+  if [ -z "$name" ]; then
+    echo "  ! skipping (no name): ${skillmd#$TMP/skills/}" >&2
+    continue
+  fi
+  dest="$SKILLS_DIR/$name"
+  # Honour the opt-out list: skip install and remove any stale copy.
+  if is_ignored "$name"; then
+    [ -e "$dest" ] && rm -rf "$dest"
+    echo "  ⊘ ignored (in .android-skills-ignore): $name"
+    continue
+  fi
+  # Guard: never clobber a local (non-vendored) skill that shares the name.
+  if [ -d "$dest" ] && [ ! -f "$dest/$MARKER" ]; then
+    echo "  ! name clash with LOCAL skill '$name' — skipping upstream copy" >&2
+    continue
+  fi
+  rm -rf "$dest"
+  cp -R "$src" "$dest"
+  printf 'Vendored from %s\nUpstream path: %s\nUpdated: %s\nDo not edit by hand; run scripts/update-android-skills.sh\n' \
+    "android/skills" "${src#$TMP/skills/}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$dest/$MARKER"
+  count=$((count + 1))
+  echo "  ✓ $name"
+done < <(find "$TMP/skills" -name SKILL.md | sort)
+
+echo "→ Done. $count Android skill(s) installed in .claude/skills/"


### PR DESCRIPTION
- billionbeers-android skill: project-specific device/emulator recipes (adb path, app id, installDebug split-APK workaround)
- scripts/update-android-skills.sh + make update-android-skills: sync a curated subset of github.com/android/skills into .claude/skills/
- .android-skills-ignore: opt-out list so pruned skills stay pruned
- Vendored skills and local AI planning docs are gitignored: they are regenerated/kept locally, not committed
- Document the setup in AGENTS.md