### PR TITLE
feat: add observability seam (Logger, AnalyticsTracker, CrashReporter)

### DIFF
--- a/app/src/androidTest/java/com/simtop/billionbeers/di/LocalDataSourceTest2.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/di/LocalDataSourceTest2.kt
@@ -10,6 +10,7 @@ import com.simtop.beer_database.localsources.BeersLocalSourceImpl
 import com.simtop.beer_network.models.BeersApiResponseItem
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.core.core.LanguageProvider
+import com.simtop.core.core.NoOpLogger
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -94,4 +95,5 @@ val fakeBeerModel2 = Beer("1", "Buzz", "A Real Bitter Experience.", "", "", 4.5,
 
 val fakeBeerListModel2 = listOf(fakeBeerModel2.copy())
 
-val fakeDbBeerList = listOf(BeersMapper(LanguageProvider { "en" }).fromBeerToBeerDbModel(fakeBeerModel2))
+val fakeDbBeerList =
+  listOf(BeersMapper(LanguageProvider { "en" }, NoOpLogger()).fromBeerToBeerDbModel(fakeBeerModel2))

--- a/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
@@ -6,9 +6,12 @@ import com.simtop.beer_network.models.BeersApiResponseItem
 import com.simtop.beer_network.network.BeersService
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.core.core.LanguageProvider
+import com.simtop.core.core.Logger
 import dev.zacsweers.metro.Inject
 
-class BeersMapper @Inject constructor(private val languageProvider: LanguageProvider) {
+class BeersMapper
+@Inject
+constructor(private val languageProvider: LanguageProvider, private val logger: Logger) {
 
   fun fromBeersApiResponseItemToBeer(response: BeersApiResponseItem?): Beer {
     val languageCode = languageProvider.currentLanguageCode()
@@ -33,12 +36,8 @@ class BeersMapper @Inject constructor(private val languageProvider: LanguageProv
     )
   }
 
-  // TODO: route through the observability seam (Logger facade) once it lands - the codebase has
-  // no logging today (docs/MASTER_PLAN.md Phase 3). System.err is a dependency-free stopgap so
-  // malformed backend data isn't silently swallowed in the meantime, without dragging
-  // android.util.Log's static-mock requirement into every indirect caller's unit tests.
   private fun logMissingField(field: String, response: BeersApiResponseItem?) {
-    System.err.println("$TAG: missing $field for beer id=${response?.id}, defaulting")
+    logger.warn(TAG, "missing $field for beer id=${response?.id}, defaulting")
   }
 
   fun fromBeerToBeerDbModel(beer: Beer) =

--- a/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
@@ -6,6 +6,7 @@ import com.simtop.beer_network.models.Language
 import com.simtop.beer_network.models.Translation
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.core.core.LanguageProvider
+import com.simtop.core.core.NoOpLogger
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
@@ -13,7 +14,7 @@ import strikt.assertions.isEqualTo
 class BeersMapperTest {
 
   private var languageCode = "en"
-  private val mapper = BeersMapper(LanguageProvider { languageCode })
+  private val mapper = BeersMapper(LanguageProvider { languageCode }, NoOpLogger())
 
   private fun fullResponse() =
     BeersApiResponseItem(

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
@@ -8,6 +8,7 @@ import com.simtop.beer_database.models.BeerDbModel
 import com.simtop.beer_network.models.BeersApiResponseItem
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.core.core.LanguageProvider
+import com.simtop.core.core.NoOpLogger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -28,7 +29,7 @@ class BeersRepositoryTest {
   fun setUp() {
     beersRemoteSource = FakeBeersRemoteSource()
     beersLocalSource = FakeBeersLocalSource()
-    val beersMapper = BeersMapper(LanguageProvider { "en" })
+    val beersMapper = BeersMapper(LanguageProvider { "en" }, NoOpLogger())
     beersRepository = BeersRepositoryImpl(beersRemoteSource, beersLocalSource, beersMapper)
   }
 

--- a/core-common/src/main/kotlin/com/simtop/core/core/AnalyticsTracker.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/AnalyticsTracker.kt
@@ -1,0 +1,11 @@
+package com.simtop.core.core
+
+fun interface AnalyticsTracker {
+  fun logEvent(name: String, params: Map<String, String>)
+}
+
+fun AnalyticsTracker.logEvent(name: String) = logEvent(name, emptyMap())
+
+class NoOpAnalyticsTracker : AnalyticsTracker {
+  override fun logEvent(name: String, params: Map<String, String>) {}
+}

--- a/core-common/src/main/kotlin/com/simtop/core/core/CrashReporter.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/CrashReporter.kt
@@ -1,0 +1,17 @@
+package com.simtop.core.core
+
+interface CrashReporter {
+  fun recordException(throwable: Throwable)
+
+  fun log(message: String)
+
+  fun setCustomKey(key: String, value: String)
+}
+
+class NoOpCrashReporter : CrashReporter {
+  override fun recordException(throwable: Throwable) = Unit
+
+  override fun log(message: String) = Unit
+
+  override fun setCustomKey(key: String, value: String) = Unit
+}

--- a/core-common/src/main/kotlin/com/simtop/core/core/Logger.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/Logger.kt
@@ -1,0 +1,26 @@
+package com.simtop.core.core
+
+enum class LogPriority {
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+}
+
+fun interface Logger {
+  fun log(priority: LogPriority, tag: String, message: String, throwable: Throwable?)
+
+  fun debug(tag: String, message: String) = log(LogPriority.DEBUG, tag, message, null)
+
+  fun info(tag: String, message: String) = log(LogPriority.INFO, tag, message, null)
+
+  fun warn(tag: String, message: String, throwable: Throwable? = null) =
+    log(LogPriority.WARN, tag, message, throwable)
+
+  fun error(tag: String, message: String, throwable: Throwable? = null) =
+    log(LogPriority.ERROR, tag, message, throwable)
+}
+
+class NoOpLogger : Logger {
+  override fun log(priority: LogPriority, tag: String, message: String, throwable: Throwable?) {}
+}

--- a/core/src/main/java/com/simtop/core/di/ObservabilityModule.kt
+++ b/core/src/main/java/com/simtop/core/di/ObservabilityModule.kt
@@ -1,0 +1,31 @@
+package com.simtop.core.di
+
+import com.simtop.core.core.AnalyticsTracker
+import com.simtop.core.core.CrashReporter
+import com.simtop.core.core.Logger
+import com.simtop.core.core.NoOpAnalyticsTracker
+import com.simtop.core.core.NoOpCrashReporter
+import com.simtop.core.observability.AndroidLogcatLogger
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+/**
+ * The observability seam: swap [NoOpAnalyticsTracker] / [NoOpCrashReporter] for real backends
+ * (Firebase Analytics, Crashlytics, Sentry, ...) here, one binding at a time, without touching any
+ * call site.
+ */
+@ContributesTo(AppScope::class)
+interface ObservabilityModule {
+
+  @Provides @SingleIn(AppScope::class) fun providesLogger(): Logger = AndroidLogcatLogger()
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun providesAnalyticsTracker(): AnalyticsTracker = NoOpAnalyticsTracker()
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun providesCrashReporter(): CrashReporter = NoOpCrashReporter()
+}

--- a/core/src/main/java/com/simtop/core/observability/AndroidLogcatLogger.kt
+++ b/core/src/main/java/com/simtop/core/observability/AndroidLogcatLogger.kt
@@ -1,0 +1,20 @@
+package com.simtop.core.observability
+
+import android.util.Log
+import com.simtop.core.core.LogPriority
+import com.simtop.core.core.Logger
+
+/**
+ * Only reached through DI in the running app - unit tests inject [com.simtop.core.core.NoOpLogger]
+ * or a fake instead, so android.util.Log's unmocked-by-default JVM stub is never on the call path.
+ */
+class AndroidLogcatLogger : Logger {
+  override fun log(priority: LogPriority, tag: String, message: String, throwable: Throwable?) {
+    when (priority) {
+      LogPriority.DEBUG -> Log.d(tag, message, throwable)
+      LogPriority.INFO -> Log.i(tag, message, throwable)
+      LogPriority.WARN -> Log.w(tag, message, throwable)
+      LogPriority.ERROR -> Log.e(tag, message, throwable)
+    }
+  }
+}


### PR DESCRIPTION
Introduces the facade from MASTER_PLAN.md Phase 3 (§13.8): Logger, AnalyticsTracker and CrashReporter interfaces live in :core-common with no-op default implementations, so wiring in a real backend (Crashlytics, Sentry, Firebase Analytics) later is a single Metro binding swap in ObservabilityModule, not a call-site rewrite.

Logger's production binding is AndroidLogcatLogger (android.util.Log), confined to :core and only reachable through DI - unit tests inject NoOpLogger instead, so the Log-unmocked-by-default JVM problem hit earlier with BeersMapper can't resurface.

BeersMapper now takes an injected Logger instead of the System.err stopgap that was standing in for this seam.