### PR TITLE
Add debug drawer: network faults, theme, feature flags, deep links

### DIFF
--- a/app/src/debug/java/com/simtop/billionbeers/debug/DebugDrawerContent.kt
+++ b/app/src/debug/java/com/simtop/billionbeers/debug/DebugDrawerContent.kt
@@ -1,0 +1,136 @@
+package com.simtop.billionbeers.debug
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.simtop.billionbeers.di.BaseAppGraph
+import com.simtop.core.core.FeatureFlag
+import com.simtop.core.core.NetworkFaultMode
+import com.simtop.core.core.ThemeMode
+import com.simtop.navigation.DeepLinkParser
+
+private data class DeepLinkEntry(val label: String, val uri: String)
+
+@Composable
+fun DebugDrawerContent(appGraph: BaseAppGraph, modifier: Modifier = Modifier) {
+  val context = LocalContext.current
+
+  Column(modifier = modifier.verticalScroll(rememberScrollState()).padding(16.dp)) {
+    Text(text = "Debug Drawer", style = MaterialTheme.typography.titleLarge)
+
+    Spacer(modifier = Modifier.padding(top = 12.dp))
+    SectionTitle("Network fault injection")
+    val faultMode by appGraph.networkFaultController.mode.collectAsState()
+    NetworkFaultMode.entries.forEach { mode ->
+      RadioRow(
+        label = mode.name,
+        selected = faultMode == mode,
+        onClick = { appGraph.networkFaultController.setMode(mode) },
+      )
+    }
+
+    Spacer(modifier = Modifier.padding(top = 12.dp))
+    SectionTitle("Theme")
+    val themeMode by appGraph.themeController.mode.collectAsState()
+    ThemeMode.entries.forEach { mode ->
+      RadioRow(
+        label = mode.name,
+        selected = themeMode == mode,
+        onClick = { appGraph.themeController.setMode(mode) },
+      )
+    }
+
+    Spacer(modifier = Modifier.padding(top = 12.dp))
+    SectionTitle("Feature flags")
+    val overrides by appGraph.featureFlagProvider.overrides.collectAsState()
+    FeatureFlag.entries.forEach { flag ->
+      Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(text = flag.displayName, modifier = Modifier.weight(1f))
+        Switch(
+          checked = overrides[flag] ?: flag.defaultValue,
+          onCheckedChange = { enabled -> appGraph.featureFlagProvider.setOverride(flag, enabled) },
+        )
+      }
+    }
+
+    Spacer(modifier = Modifier.padding(top = 12.dp))
+    SectionTitle("Deep link directory")
+    var sampleBeerId by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(Unit) {
+      sampleBeerId = appGraph.beersRepository.getAllBeersFromDB().firstOrNull()?.id
+    }
+    val entries =
+      buildList {
+        add(DeepLinkEntry("Beers list", "${DeepLinkParser.SCHEME}://${DeepLinkParser.HOST_BEERS}"))
+        sampleBeerId?.let { id ->
+          add(
+            DeepLinkEntry(
+              "Beer detail (id=$id)",
+              "${DeepLinkParser.SCHEME}://${DeepLinkParser.HOST_BEERS}/$id",
+            )
+          )
+        }
+      }
+    entries.forEach { entry ->
+      Column(
+        modifier =
+          Modifier.fillMaxWidth()
+            .clickable {
+              context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(entry.uri)))
+            }
+            .padding(vertical = 8.dp)
+      ) {
+        Text(text = entry.label, style = MaterialTheme.typography.bodyLarge)
+        Text(
+          text = entry.uri,
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+      HorizontalDivider()
+    }
+  }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+  Text(text = text, style = MaterialTheme.typography.titleMedium)
+}
+
+@Composable
+private fun RadioRow(label: String, selected: Boolean, onClick: () -> Unit) {
+  Row(
+    modifier = Modifier.fillMaxWidth().selectable(selected = selected, onClick = onClick),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    RadioButton(selected = selected, onClick = onClick)
+    Text(text = label)
+  }
+}

--- a/app/src/debug/java/com/simtop/billionbeers/debug/DebugDrawerHost.kt
+++ b/app/src/debug/java/com/simtop/billionbeers/debug/DebugDrawerHost.kt
@@ -1,0 +1,60 @@
+package com.simtop.billionbeers.debug
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material3.DrawerValue
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalDrawerSheet
+import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.rememberDrawerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.simtop.billionbeers.di.BaseAppGraph
+import com.simtop.presentation_utils.core.LocalDebugDrawerToggle
+import kotlinx.coroutines.launch
+
+/**
+ * Debug-build-only wrapper: a floating trigger opens a drawer with network fault injection,
+ * theme override, feature flag overrides, and a deep link directory (docs/MASTER_PLAN.md Phase 3,
+ * roadmap 4.1). Release builds get the no-op twin in app/src/release - same signature.
+ *
+ * The trigger is hidden by default and shown by long-pressing a screen's title (wired via
+ * [LocalDebugDrawerToggle]), so it doesn't float over every screen all the time.
+ */
+@Composable
+fun DebugDrawerHost(appGraph: BaseAppGraph, content: @Composable () -> Unit) {
+  val drawerState = rememberDrawerState(DrawerValue.Closed)
+  val scope = rememberCoroutineScope()
+  var isFabVisible by remember { mutableStateOf(false) }
+
+  CompositionLocalProvider(LocalDebugDrawerToggle provides { isFabVisible = !isFabVisible }) {
+    ModalNavigationDrawer(
+      drawerState = drawerState,
+      drawerContent = { ModalDrawerSheet { DebugDrawerContent(appGraph = appGraph) } },
+    ) {
+      Box(modifier = Modifier.fillMaxSize()) {
+        content()
+        if (isFabVisible) {
+          FloatingActionButton(
+            onClick = { scope.launch { drawerState.open() } },
+            modifier = Modifier.align(Alignment.BottomStart).padding(16.dp),
+          ) {
+            Icon(imageVector = Icons.Default.Build, contentDescription = "Open debug drawer")
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,11 +17,22 @@
         <activity
             android:name=".presentation.MainActivity"
             android:theme="@style/AppTheme.NoActionBar"
+            android:launchMode="singleTask"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!-- billionbeers://beers and billionbeers://beers/{beerId} -->
+            <intent-filter android:autoVerify="false">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="billionbeers" android:host="beers" />
             </intent-filter>
 
         </activity>

--- a/app/src/main/java/com/simtop/billionbeers/di/BaseAppGraph.kt
+++ b/app/src/main/java/com/simtop/billionbeers/di/BaseAppGraph.kt
@@ -3,6 +3,9 @@ package com.simtop.billionbeers.di
 import com.google.android.play.core.splitinstall.SplitInstallManager
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.CoroutineDispatcherProvider
+import com.simtop.core.core.FeatureFlagProvider
+import com.simtop.core.core.NetworkFaultController
+import com.simtop.core.core.ThemeController
 import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
 import dev.zacsweers.metrox.viewmodel.MetroViewModelMultibindings
 
@@ -11,4 +14,7 @@ interface BaseAppGraph : DynamicDependencies, MetroViewModelMultibindings {
     override val coroutineDispatcher: CoroutineDispatcherProvider
     val splitInstallManager: SplitInstallManager
     val metroViewModelFactory: MetroViewModelFactory
+    val themeController: ThemeController
+    val networkFaultController: NetworkFaultController
+    val featureFlagProvider: FeatureFlagProvider
 }

--- a/app/src/main/java/com/simtop/billionbeers/presentation/AppNavigation.kt
+++ b/app/src/main/java/com/simtop/billionbeers/presentation/AppNavigation.kt
@@ -1,18 +1,47 @@
 package com.simtop.billionbeers.presentation
 
+import android.net.Uri
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
+import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.feature.beerslist.BeersListScreen
 import com.simtop.navigation.BeerDetail
 import com.simtop.navigation.BeersList
+import com.simtop.navigation.DeepLinkDestination
 import com.simtop.navigation.DynamicFeatureContent
 import com.simtop.navigation.FeatureConstants
+import com.simtop.navigation.toDeepLinkDestination
+import com.simtop.presentation_utils.core.DynamicFeatureLoader
+import dev.zacsweers.metrox.viewmodel.metroViewModel
 
 @Composable
-fun AppNavigation() {
+fun AppNavigation(deepLinkUri: Uri? = null, viewModel: AppNavigationViewModel = metroViewModel()) {
   val backStack = rememberNavBackStack(BeersList)
+
+  // Beer resolved from an incoming deep link, pending the beerdetail dynamic feature install -
+  // mirrors BeersListScreen's own installingBeer/DynamicFeatureLoader gate, since BeerDetail can
+  // only be pushed onto the back stack once that module is installed.
+  var pendingDeepLinkBeer by remember { mutableStateOf<Beer?>(null) }
+
+  LaunchedEffect(deepLinkUri) {
+    when (val destination = deepLinkUri?.toDeepLinkDestination()) {
+      null -> Unit
+      DeepLinkDestination.BeersList -> {
+        backStack.clear()
+        backStack.add(BeersList)
+      }
+      is DeepLinkDestination.BeerDetail -> {
+        pendingDeepLinkBeer = viewModel.resolveBeer(destination.beerId)
+      }
+    }
+  }
 
   NavDisplay(
     backStack = backStack,
@@ -33,4 +62,13 @@ fun AppNavigation() {
       }
     }
   )
+
+  pendingDeepLinkBeer?.let { beer ->
+    DynamicFeatureLoader(featureName = FeatureConstants.BEER_DETAIL_MODULE) {
+      LaunchedEffect(beer) {
+        backStack.add(BeerDetail(beer))
+        pendingDeepLinkBeer = null
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/simtop/billionbeers/presentation/AppNavigationViewModel.kt
+++ b/app/src/main/java/com/simtop/billionbeers/presentation/AppNavigationViewModel.kt
@@ -1,0 +1,19 @@
+package com.simtop.billionbeers.presentation
+
+import androidx.lifecycle.ViewModel
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.repositories.BeersRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metrox.viewmodel.ViewModelKey
+
+@ContributesIntoMap(AppScope::class)
+@ViewModelKey(AppNavigationViewModel::class)
+@Inject
+class AppNavigationViewModel(private val beersRepository: BeersRepository) : ViewModel() {
+
+  // Resolves a deep-linked beer id against the local cache - deep links only carry an id,
+  // never the full Beer payload the BeerDetail nav key needs.
+  suspend fun resolveBeer(beerId: String): Beer? = beersRepository.getBeerById(beerId)
+}

--- a/app/src/main/java/com/simtop/billionbeers/presentation/MainActivity.kt
+++ b/app/src/main/java/com/simtop/billionbeers/presentation/MainActivity.kt
@@ -1,13 +1,23 @@
 package com.simtop.billionbeers.presentation
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import com.google.android.play.core.splitinstall.SplitInstallManager
 import com.simtop.billionbeers.BillionBeersApplication
 import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
+import com.simtop.billionbeers.debug.DebugDrawerHost
+import com.simtop.core.core.ThemeController
+import com.simtop.core.core.ThemeMode
 import com.simtop.presentation_utils.core.LocalSplitInstallManager
 import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
 
@@ -15,18 +25,43 @@ class MainActivity : ComponentActivity() {
 
   lateinit var splitInstallManager: SplitInstallManager
 
+  // Holds the current deep link Uri as Compose state so both a cold start (onCreate) and a
+  // deep link arriving while already running (onNewIntent) feed AppNavigation the same way.
+  private var deepLinkUri by mutableStateOf<android.net.Uri?>(null)
+
   override fun onCreate(savedInstanceState: Bundle?) {
     val appGraph = (applicationContext as BillionBeersApplication).appGraph
     splitInstallManager = appGraph.splitInstallManager
     super.onCreate(savedInstanceState)
     enableEdgeToEdge()
+    deepLinkUri = intent?.data
     setContent {
       CompositionLocalProvider(
         LocalMetroViewModelFactory provides appGraph.metroViewModelFactory,
         LocalSplitInstallManager provides splitInstallManager,
       ) {
-        BillionBeersTheme { AppNavigation() }
+        BillionBeersTheme(darkTheme = isDarkTheme(appGraph.themeController)) {
+          DebugDrawerHost(appGraph = appGraph) { AppNavigation(deepLinkUri = deepLinkUri) }
+        }
       }
     }
+  }
+
+  override fun onNewIntent(intent: Intent) {
+    super.onNewIntent(intent)
+    setIntent(intent)
+    deepLinkUri = intent.data
+  }
+}
+
+// SYSTEM (the only mode reachable outside a debug build with the drawer wired in) falls straight
+// back to isSystemInDarkTheme(), so this changes nothing for release builds.
+@Composable
+private fun isDarkTheme(themeController: ThemeController): Boolean {
+  val mode by themeController.mode.collectAsState()
+  return when (mode) {
+    ThemeMode.LIGHT -> false
+    ThemeMode.DARK -> true
+    ThemeMode.SYSTEM -> isSystemInDarkTheme()
   }
 }

--- a/app/src/release/java/com/simtop/billionbeers/debug/DebugDrawerHost.kt
+++ b/app/src/release/java/com/simtop/billionbeers/debug/DebugDrawerHost.kt
@@ -1,0 +1,13 @@
+package com.simtop.billionbeers.debug
+
+import androidx.compose.runtime.Composable
+import com.simtop.billionbeers.di.BaseAppGraph
+
+/**
+ * Release twin of the debug-build DebugDrawerHost (app/src/debug) - same signature, no drawer.
+ * MainActivity calls this uniformly across build types.
+ */
+@Composable
+fun DebugDrawerHost(appGraph: BaseAppGraph, content: @Composable () -> Unit) {
+  content()
+}

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
@@ -109,6 +109,9 @@ class BeersRepositoryImpl(
   override suspend fun getAllBeersFromDB() =
     beersLocalSource.getAllBeersFromDB().first().map { beersMapper.fromBeerDbModelToBeer(it) }
 
+  override suspend fun getBeerById(id: String): Beer? =
+    getAllBeersFromDB().find { it.id == id }
+
   override suspend fun countDBEntries() = beersLocalSource.getCountFromDB()
 
   override fun getBeersFromSingleSource(): Flow<List<Beer>> {

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -12,6 +12,8 @@ interface BeersRepository {
 
   suspend fun getAllBeersFromDB(): List<Beer>
 
+  suspend fun getBeerById(id: String): Beer?
+
   suspend fun insertAllToDB(beers: List<Beer>)
 
   suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit>

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
@@ -44,6 +44,10 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
     return beersFlow.value
   }
 
+  override suspend fun getBeerById(id: String): Beer? {
+    return beersFlow.value.find { it.id == id }
+  }
+
   override suspend fun insertAllToDB(beers: List<Beer>) {
     beersFlow.value = beersFlow.value + beers
   }

--- a/core-common/src/main/kotlin/com/simtop/core/core/FeatureFlagProvider.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/FeatureFlagProvider.kt
@@ -1,0 +1,35 @@
+package com.simtop.core.core
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Placeholder flag set - a real project grows this enum as flags are added. The remote
+ * (Firebase Remote Config) implementation of [FeatureFlagProvider] is a later addition; this one
+ * is local-override-only, driven by the debug drawer.
+ */
+enum class FeatureFlag(val key: String, val displayName: String, val defaultValue: Boolean) {
+  SHOW_DEBUG_BANNER("show_debug_banner", "Show Debug Banner", false)
+}
+
+interface FeatureFlagProvider {
+  val overrides: StateFlow<Map<FeatureFlag, Boolean>>
+
+  fun isEnabled(flag: FeatureFlag): Boolean
+
+  /** Pass `null` to clear the override and fall back to [FeatureFlag.defaultValue]. */
+  fun setOverride(flag: FeatureFlag, enabled: Boolean?)
+}
+
+class LocalFeatureFlagProvider : FeatureFlagProvider {
+  private val _overrides = MutableStateFlow<Map<FeatureFlag, Boolean>>(emptyMap())
+  override val overrides: StateFlow<Map<FeatureFlag, Boolean>> = _overrides.asStateFlow()
+
+  override fun isEnabled(flag: FeatureFlag): Boolean = _overrides.value[flag] ?: flag.defaultValue
+
+  override fun setOverride(flag: FeatureFlag, enabled: Boolean?) {
+    _overrides.update { current -> if (enabled == null) current - flag else current + (flag to enabled) }
+  }
+}

--- a/core-common/src/main/kotlin/com/simtop/core/core/NetworkFaultController.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/NetworkFaultController.kt
@@ -1,0 +1,27 @@
+package com.simtop.core.core
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+enum class NetworkFaultMode {
+  NONE,
+  FORCE_404,
+  FORCE_500,
+  EXTRA_LATENCY,
+}
+
+interface NetworkFaultController {
+  val mode: StateFlow<NetworkFaultMode>
+
+  fun setMode(mode: NetworkFaultMode)
+}
+
+class DefaultNetworkFaultController : NetworkFaultController {
+  private val _mode = MutableStateFlow(NetworkFaultMode.NONE)
+  override val mode: StateFlow<NetworkFaultMode> = _mode.asStateFlow()
+
+  override fun setMode(mode: NetworkFaultMode) {
+    _mode.value = mode
+  }
+}

--- a/core-common/src/main/kotlin/com/simtop/core/core/ThemeController.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/ThemeController.kt
@@ -1,0 +1,26 @@
+package com.simtop.core.core
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+enum class ThemeMode {
+  LIGHT,
+  DARK,
+  SYSTEM,
+}
+
+interface ThemeController {
+  val mode: StateFlow<ThemeMode>
+
+  fun setMode(mode: ThemeMode)
+}
+
+class DefaultThemeController : ThemeController {
+  private val _mode = MutableStateFlow(ThemeMode.SYSTEM)
+  override val mode: StateFlow<ThemeMode> = _mode.asStateFlow()
+
+  override fun setMode(mode: ThemeMode) {
+    _mode.value = mode
+  }
+}

--- a/core/src/main/java/com/simtop/core/di/DebugModule.kt
+++ b/core/src/main/java/com/simtop/core/di/DebugModule.kt
@@ -1,0 +1,34 @@
+package com.simtop.core.di
+
+import com.simtop.core.core.DefaultNetworkFaultController
+import com.simtop.core.core.DefaultThemeController
+import com.simtop.core.core.FeatureFlagProvider
+import com.simtop.core.core.LocalFeatureFlagProvider
+import com.simtop.core.core.NetworkFaultController
+import com.simtop.core.core.ThemeController
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+/**
+ * Bindings backing the debug drawer. Registered in every build type - the drawer UI itself
+ * (app/src/debug) is what's actually gated to debug builds; [NetworkFaultController] and
+ * [FeatureFlagProvider] always exist so production code can read them cheaply (fault mode stays
+ * NONE and flags stay at their defaults outside debug, since nothing ever calls setMode/setOverride).
+ */
+@ContributesTo(AppScope::class)
+interface DebugModule {
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun providesNetworkFaultController(): NetworkFaultController = DefaultNetworkFaultController()
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun providesFeatureFlagProvider(): FeatureFlagProvider = LocalFeatureFlagProvider()
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun providesThemeController(): ThemeController = DefaultThemeController()
+}

--- a/core/src/main/java/com/simtop/core/di/NetworkingModule.kt
+++ b/core/src/main/java/com/simtop/core/di/NetworkingModule.kt
@@ -2,6 +2,8 @@ package com.simtop.core.di
 
 import android.content.Context
 import com.simtop.core.BuildConfig
+import com.simtop.core.core.NetworkFaultController
+import com.simtop.core.network.NetworkFaultInterceptor
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Named
@@ -46,13 +48,19 @@ interface NetworkingModule {
   @SingleIn(AppScope::class)
   fun provideOkHttpClient(
     loggingInterceptor: HttpLoggingInterceptor,
+    networkFaultController: NetworkFaultController,
     @ApplicationContext context: Context,
   ): OkHttpClient {
     return OkHttpClient.Builder()
       .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
       .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
       .cache(Cache(File(context.cacheDir, "http"), HTTP_CACHE_SIZE_BYTES))
-      .apply { if (BuildConfig.DEBUG) addInterceptor(loggingInterceptor) }
+      .apply {
+        if (BuildConfig.DEBUG) {
+          addInterceptor(loggingInterceptor)
+          addInterceptor(NetworkFaultInterceptor(networkFaultController))
+        }
+      }
       .build()
   }
 

--- a/core/src/main/java/com/simtop/core/network/NetworkFaultInterceptor.kt
+++ b/core/src/main/java/com/simtop/core/network/NetworkFaultInterceptor.kt
@@ -1,0 +1,42 @@
+package com.simtop.core.network
+
+import com.simtop.core.core.NetworkFaultController
+import com.simtop.core.core.NetworkFaultMode
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+/**
+ * Debug-only fault injection: lets the debug drawer force 404/500 responses or extra latency
+ * without touching any call site, so error-state UI is testable on demand.
+ */
+class NetworkFaultInterceptor(private val controller: NetworkFaultController) : Interceptor {
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val request = chain.request()
+    return when (controller.mode.value) {
+      NetworkFaultMode.NONE -> chain.proceed(request)
+      NetworkFaultMode.EXTRA_LATENCY -> {
+        Thread.sleep(EXTRA_LATENCY_MS)
+        chain.proceed(request)
+      }
+      NetworkFaultMode.FORCE_404 -> fakeErrorResponse(request, code = 404, message = "Not Found")
+      NetworkFaultMode.FORCE_500 ->
+        fakeErrorResponse(request, code = 500, message = "Internal Server Error")
+    }
+  }
+
+  private fun fakeErrorResponse(request: Request, code: Int, message: String): Response =
+    Response.Builder()
+      .request(request)
+      .protocol(Protocol.HTTP_1_1)
+      .code(code)
+      .message(message)
+      .body("".toResponseBody(null))
+      .build()
+
+  private companion object {
+    const val EXTRA_LATENCY_MS = 3000L
+  }
+}

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -62,6 +64,7 @@ import com.simtop.core.core.CommonUiState
 import com.simtop.navigation.FeatureConstants
 import com.simtop.presentation_utils.core.DynamicFeatureLoader
 import com.simtop.presentation_utils.core.InfiniteListHandler
+import com.simtop.presentation_utils.core.LocalDebugDrawerToggle
 import com.simtop.presentation_utils.custom_views.ComposeBeersListItem
 import com.simtop.presentation_utils.custom_views.ComposeErrorView
 import dev.zacsweers.metrox.viewmodel.metroViewModel
@@ -103,7 +106,7 @@ fun BeersListScreen(viewModel: BeersListViewModel = metroViewModel(), onBeerClic
   }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun BeersListContent(
   viewState: CommonUiState<BeersListUiModel>,
@@ -113,8 +116,19 @@ fun BeersListContent(
   onRetry: () -> Unit,
 ) {
   val context = LocalContext.current
+  val toggleDebugDrawer = LocalDebugDrawerToggle.current
   Scaffold(
-    topBar = { TopAppBar(title = { Text(text = stringResource(R.string.billion_beers_list)) }) },
+    topBar = {
+      TopAppBar(
+        title = {
+          Text(
+            text = stringResource(R.string.billion_beers_list),
+            // Long-press reveals the debug drawer's floating trigger - see LocalDebugDrawerToggle.
+            modifier = Modifier.combinedClickable(onClick = {}, onLongClick = toggleDebugDrawer),
+          )
+        }
+      )
+    },
     contentWindowInsets = WindowInsets.statusBars,
   ) { paddingValues ->
     val dataVisibility = rememberSaveable { mutableStateOf(false) }

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -10,4 +10,6 @@ dependencies {
   implementation(project(":beerdomain:api"))
   implementation(libs.androidx.navigation3.runtime)
   implementation(libs.kotlinx.serialization.json)
+
+  testImplementation(libs.striktCore)
 }

--- a/navigation/src/main/java/com/simtop/navigation/DeepLinkDestination.kt
+++ b/navigation/src/main/java/com/simtop/navigation/DeepLinkDestination.kt
@@ -1,0 +1,29 @@
+package com.simtop.navigation
+
+import android.net.Uri
+
+sealed interface DeepLinkDestination {
+  data object BeersList : DeepLinkDestination
+
+  data class BeerDetail(val beerId: String) : DeepLinkDestination
+}
+
+// Takes decomposed Uri parts (not android.net.Uri itself) so this stays a pure function testable
+// on the plain JVM - android.net.Uri's methods throw when unmocked outside instrumented tests.
+object DeepLinkParser {
+  const val SCHEME = "billionbeers"
+  const val HOST_BEERS = "beers"
+
+  fun parse(scheme: String?, host: String?, pathSegments: List<String>): DeepLinkDestination? {
+    if (scheme != SCHEME || host != HOST_BEERS) return null
+    val beerId = pathSegments.firstOrNull()
+    return if (beerId.isNullOrBlank()) {
+      DeepLinkDestination.BeersList
+    } else {
+      DeepLinkDestination.BeerDetail(beerId)
+    }
+  }
+}
+
+fun Uri.toDeepLinkDestination(): DeepLinkDestination? =
+  DeepLinkParser.parse(scheme, host, pathSegments)

--- a/navigation/src/test/java/com/simtop/navigation/DeepLinkParserTest.kt
+++ b/navigation/src/test/java/com/simtop/navigation/DeepLinkParserTest.kt
@@ -1,0 +1,44 @@
+package com.simtop.navigation
+
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNull
+
+class DeepLinkParserTest {
+
+  @Test
+  fun `parses beers list when there is no path segment`() {
+    val destination = DeepLinkParser.parse("billionbeers", "beers", emptyList())
+
+    expectThat(destination).isEqualTo(DeepLinkDestination.BeersList)
+  }
+
+  @Test
+  fun `parses beer detail when the first path segment is a beer id`() {
+    val destination = DeepLinkParser.parse("billionbeers", "beers", listOf("42"))
+
+    expectThat(destination).isEqualTo(DeepLinkDestination.BeerDetail("42"))
+  }
+
+  @Test
+  fun `returns null for a mismatched scheme`() {
+    val destination = DeepLinkParser.parse("https", "beers", listOf("42"))
+
+    expectThat(destination).isNull()
+  }
+
+  @Test
+  fun `returns null for a mismatched host`() {
+    val destination = DeepLinkParser.parse("billionbeers", "brewery", listOf("42"))
+
+    expectThat(destination).isNull()
+  }
+
+  @Test
+  fun `treats a blank path segment as the beers list`() {
+    val destination = DeepLinkParser.parse("billionbeers", "beers", listOf(""))
+
+    expectThat(destination).isEqualTo(DeepLinkDestination.BeersList)
+  }
+}

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/core/LocalDebugDrawerToggle.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/core/LocalDebugDrawerToggle.kt
@@ -1,0 +1,11 @@
+package com.simtop.presentation_utils.core
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * Long-pressing the top bar title calls this to show/hide the debug drawer's floating trigger
+ * (app/src/debug's DebugDrawerHost provides the real toggle) - keeps it out of the way until
+ * needed, rather than always floating over the content. Defaults to a no-op so screens compile
+ * and preview without a debug host in the tree (release builds, Paparazzi, etc).
+ */
+val LocalDebugDrawerToggle = staticCompositionLocalOf<() -> Unit> { {} }


### PR DESCRIPTION
## Summary
- Debug-build-only sandbox (docs/MASTER_PLAN.md Phase 3, roadmap 4.1), gated via `app/src/debug` with a no-op `app/src/release` twin so none of it ships.
- Network fault injection: an OkHttp interceptor forces 404/500 or extra latency on demand, controlled from the drawer.
- Theme override (Light/Dark/System), applied live via `ThemeController`.
- Feature flag overrides: a minimal `FeatureFlag` enum + local-override `FeatureFlagProvider`, a seam for a future remote (Firebase Remote Config) implementation.
- Deep link directory: a real `android:scheme` intent-filter (`billionbeers://beers`, `billionbeers://beers/{beerId}`) wired through `MainActivity`/`AppNavigation`, so directory entries fire actual Android Intents through the full real pipeline. Required adding `BeersRepository.getBeerById`.
- The drawer's floating trigger is hidden by default and toggled by long-pressing a screen's title (`LocalDebugDrawerToggle` in `presentation_utils`).

## Test plan
- [x] `make test`
- [x] `make screenshot-verify`
- [x] `make konsist`
- [x] Manually verified on-device (debug build, split-APK install): network fault injection (confirmed real 500 response via logcat), live theme switching, feature flag toggling, deep-link navigation both cold-start and while already running (`onNewIntent`), and the long-press FAB show/hide toggle.