### PR TITLE
Add app-dev-beerslist standalone dev-app module

### DIFF
--- a/app-dev-beerslist/README.md
+++ b/app-dev-beerslist/README.md
@@ -1,0 +1,34 @@
+# app-dev-beerslist
+
+A minimal Android application module that compiles **only** `:feature:beerslist` against an
+in-memory fake `BeersRepository` - no `:beer_data`, `:beer_network`, `:beer_database`, or
+`:feature:beerdetail`.
+
+## Why
+
+Building and installing the real `:app` module pulls in the network stack, Room, and the
+beerdetail dynamic feature - seconds turn into minutes on every iteration of the list screen.
+This module exists purely so `./gradlew :app-dev-beerslist:installDebug` gives you a running,
+interactive `BeersListScreen` in the time it takes to compile one feature module.
+
+## What's fake
+
+`di/DevBeersRepositoryModule.kt` binds `BeersRepository` to `FakeBeersRepository` (from
+`:beerdomain:fakes`), seeded with a handful of sample beers. Edit that file to try out different
+states (empty list, all beers unavailable, large lists for scroll testing, etc).
+
+## Known limitation
+
+Tapping a beer still goes through `BeersListScreen`'s own `DynamicFeatureLoader` gate (it's
+unconditional inside the composable, not something a caller can skip). Since `:feature:beerdetail`
+isn't declared as a dynamic feature of this app, the install request fails immediately - no crash,
+just a briefly-shown loading dialog that dismisses itself. This is expected: this module is for
+iterating on the list screen, not the detail screen.
+
+## Adding another dev-app
+
+Copy this module's shape for a different feature: its own `build.gradle.kts` (apply
+`billionbeers.android.application` + `billionbeers.android.compose` + `billionbeers.android.metro`,
+depend only on the feature under test + its fakes), its own `Application`/`DevAppGraph`/
+`MainActivity`, and a `di/ViewModelMapsModule.kt` copy (Metro's per-graph multibinding maps don't
+cross application-module boundaries, so every standalone app graph needs its own).

--- a/app-dev-beerslist/build.gradle.kts
+++ b/app-dev-beerslist/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+  id("billionbeers.android.application")
+  id("billionbeers.android.compose")
+  id("billionbeers.android.metro")
+}
+
+android {
+  namespace = "com.simtop.billionbeers.devbeerslist"
+
+  defaultConfig {
+    applicationId = "com.simtop.billionbeers.devbeerslist"
+    versionCode = 1
+    versionName = "1.0"
+  }
+}
+
+dependencies {
+  // Only the module under active development, plus its fakes - no :beer_data, :beer_database,
+  // :beer_network, or :feature:beerdetail, so this assembles in seconds instead of minutes.
+  implementation(project(":feature:beerslist"))
+  implementation(project(":beerdomain:api"))
+  implementation(project(":beerdomain:fakes"))
+  implementation(project(":core"))
+  implementation(project(":core:designsystem"))
+  implementation(project(":navigation"))
+  implementation(project(":presentation_utils"))
+
+  implementation(libs.androidPlayCore)
+  implementation(libs.androidPlayCoreKtx)
+  implementation(libs.androidxActivityCompose)
+  implementation(libs.kotlinx.serialization.json)
+}

--- a/app-dev-beerslist/src/main/AndroidManifest.xml
+++ b/app-dev-beerslist/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:name=".DevBeersListApplication"
+        android:allowBackup="false"
+        android:label="Dev: Beers List"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/DevBeersListApplication.kt
+++ b/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/DevBeersListApplication.kt
@@ -1,0 +1,19 @@
+package com.simtop.billionbeers.devbeerslist
+
+import android.app.Application
+import com.simtop.billionbeers.devbeerslist.di.DevAppGraph
+import com.simtop.core.di.GraphProvider
+import dev.zacsweers.metro.createGraphFactory
+import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
+
+class DevBeersListApplication : Application(), GraphProvider {
+  lateinit var appGraph: DevAppGraph
+
+  override val metroViewModelFactory: MetroViewModelFactory
+    get() = appGraph.metroViewModelFactory
+
+  override fun onCreate() {
+    super.onCreate()
+    appGraph = createGraphFactory<DevAppGraph.Factory>().create(this)
+  }
+}

--- a/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/MainActivity.kt
+++ b/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/MainActivity.kt
@@ -1,0 +1,35 @@
+package com.simtop.billionbeers.devbeerslist
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.CompositionLocalProvider
+import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
+import com.simtop.feature.beerslist.BeersListScreen
+import com.simtop.presentation_utils.core.LocalSplitInstallManager
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
+
+/**
+ * Hosts only [BeersListScreen] against a fake, in-memory [com.simtop.beerdomain.domain.repositories.BeersRepository]
+ * (see [com.simtop.billionbeers.devbeerslist.di.DevBeersRepositoryModule]) - no network, no
+ * database, no beerdetail dynamic feature. Tapping a beer still triggers the module's own
+ * DynamicFeatureLoader gate; the install attempt fails harmlessly since beerdetail isn't part of
+ * this app.
+ */
+class MainActivity : ComponentActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val appGraph = (applicationContext as DevBeersListApplication).appGraph
+    enableEdgeToEdge()
+    setContent {
+      CompositionLocalProvider(
+        LocalMetroViewModelFactory provides appGraph.metroViewModelFactory,
+        LocalSplitInstallManager provides appGraph.splitInstallManager,
+      ) {
+        BillionBeersTheme { BeersListScreen(onBeerClick = {}) }
+      }
+    }
+  }
+}

--- a/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/di/DevAppGraph.kt
+++ b/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/di/DevAppGraph.kt
@@ -1,0 +1,21 @@
+package com.simtop.billionbeers.devbeerslist.di
+
+import android.content.Context
+import com.google.android.play.core.splitinstall.SplitInstallManager
+import com.simtop.core.di.ApplicationContext
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
+import dev.zacsweers.metrox.viewmodel.MetroViewModelMultibindings
+
+@DependencyGraph(AppScope::class)
+interface DevAppGraph : MetroViewModelMultibindings {
+  val metroViewModelFactory: MetroViewModelFactory
+  val splitInstallManager: SplitInstallManager
+
+  @DependencyGraph.Factory
+  fun interface Factory {
+    fun create(@Provides @ApplicationContext context: Context): DevAppGraph
+  }
+}

--- a/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/di/DevBeersRepositoryModule.kt
+++ b/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/di/DevBeersRepositoryModule.kt
@@ -1,0 +1,56 @@
+package com.simtop.billionbeers.devbeerslist.di
+
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.beerdomain.fakes.FakeBeersRepository
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@ContributesTo(AppScope::class)
+interface DevBeersRepositoryModule {
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun provideBeersRepository(): BeersRepository = FakeBeersRepository(initialBeers = sampleBeers)
+}
+
+private val sampleBeers =
+  listOf(
+    Beer(
+      id = "1",
+      name = "Buzz",
+      tagline = "A Real Bitter Experience.",
+      description =
+        "A light, crisp and bitter IPA brewed with English and American hops. A small batch " +
+          "brewed only once.",
+      imageUrl = "",
+      abv = 4.5,
+      ibu = 60.0,
+      foodPairing = listOf("Spicy chicken tikka masala", "Grilled chicken quesadilla"),
+      availability = true,
+    ),
+    Beer(
+      id = "2",
+      name = "Trashy Blonde",
+      tagline = "You Know You Shouldn't",
+      description = "A titillating, neurotic, peroxide blonde beer.",
+      imageUrl = "",
+      abv = 4.1,
+      ibu = 41.5,
+      foodPairing = listOf("Fried chicken", "Nachos"),
+      availability = false,
+    ),
+    Beer(
+      id = "3",
+      name = "Avery Brown Dredge",
+      tagline = "Bloggers Imperial Pilsner.",
+      description = "An Imperial Pilsner in collaboration with beer writers.",
+      imageUrl = "",
+      abv = 7.2,
+      ibu = 59.0,
+      foodPairing = listOf("Fish and chips", "Caesar salad"),
+      availability = true,
+    ),
+  )

--- a/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/di/SplitInstallModule.kt
+++ b/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/di/SplitInstallModule.kt
@@ -1,0 +1,23 @@
+package com.simtop.billionbeers.devbeerslist.di
+
+import android.content.Context
+import com.google.android.play.core.splitinstall.SplitInstallManager
+import com.google.android.play.core.splitinstall.SplitInstallManagerFactory
+import com.simtop.core.di.ApplicationContext
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+// BeersListScreen's click handler goes through DynamicFeatureLoader unconditionally, so it needs
+// a real SplitInstallManager even though :feature:beerdetail isn't a dynamic feature of this app -
+// the install attempt just fails harmlessly (see README.md in this module).
+@ContributesTo(AppScope::class)
+interface SplitInstallModule {
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun provideSplitInstallManager(@ApplicationContext context: Context): SplitInstallManager {
+    return SplitInstallManagerFactory.create(context)
+  }
+}

--- a/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/di/ViewModelMapsModule.kt
+++ b/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/di/ViewModelMapsModule.kt
@@ -1,0 +1,23 @@
+package com.simtop.billionbeers.devbeerslist.di
+
+import androidx.lifecycle.ViewModel
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Multibinds
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import kotlin.reflect.KClass
+
+// Same shape as the main app's ViewModelMapsModule - this is a separate application module (not
+// a dependency of :app), so it needs its own copy for Metro's multibinding maps to resolve.
+@ContributesTo(AppScope::class)
+interface ViewModelMapsModule {
+  @Multibinds(allowEmpty = true) fun viewModels(): Map<KClass<out ViewModel>, ViewModel>
+
+  @Multibinds(allowEmpty = true)
+  fun assistedViewModels(): Map<KClass<out ViewModel>, ViewModelAssistedFactory>
+
+  @Multibinds(allowEmpty = true)
+  fun manualAssistedViewModels():
+    Map<KClass<out ManualViewModelAssistedFactory>, ManualViewModelAssistedFactory>
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ include(":feature:beerdetail")
 include(":beerdomain:api")
 include(":beerdomain:fakes")
 include(":app")
+include(":app-dev-beerslist")
 rootProject.name = "BillionBeers"
 include(":navigation")
 


### PR DESCRIPTION
## Summary
- First dev-app module from MASTER_PLAN.md Phase 3 (roadmap 4.2): a standalone application compiling only `:feature:beerslist` against an in-memory `FakeBeersRepository`, with no `:beer_data`, `:beer_database`, `:beer_network`, or `:feature:beerdetail` on its classpath.
- `assembleDebug` runs in ~9s versus minutes for the full `:app`.
- Each standalone application module needs its own `DevAppGraph`, `Application` subclass, and `ViewModelMapsModule` copy — Metro's per-graph multibinding maps don't cross application-module boundaries, so this can't just reuse `:app`'s DI wiring.
- Tapping a beer still goes through `BeersListScreen`'s own `DynamicFeatureLoader` gate (unconditional inside the composable); since beerdetail isn't a dynamic feature of this app the install request fails immediately and harmlessly (confirmed via logcat, no crash) — documented in the module's README, along with how to stamp out another dev-app for a different feature.

## Test plan
- [x] `make test`
- [x] `make screenshot-verify`
- [x] `make konsist`
- [x] Manually verified on-device: installed and launched, boots straight into the seeded beers list, unavailable-beer styling renders correctly, tapping a beer doesn't crash (split-install fails harmlessly, confirmed via logcat).