### PR TITLE
Add new-dev-app generator script and skill

### DIFF
--- a/.claude/skills/new-dev-app/SKILL.md
+++ b/.claude/skills/new-dev-app/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: new-dev-app
+description: Scaffold AND finish a standalone app-dev-<feature> module for BillionBeers -
+  runs scripts/new-dev-app.sh, then investigates the target feature module and fills in
+  the generated TODOs (fake repository bindings, real screen wiring) so the result is a
+  working, installable dev-app rather than a stub. Use when asked to create, generate, or
+  finish a dev-app / dev sandbox for a specific feature module (e.g. "make a dev app for
+  beerdetail").
+metadata:
+  keywords:
+    - android
+    - dev-app
+    - module template
+    - billionbeers
+---
+
+## What this produces
+
+A second, independent `app-dev-<feature>` application module (see `app-dev-beerslist/` for the
+existing reference example) that depends on only the target feature module and its fakes - no
+network, no database, no other features.
+
+**Dynamic feature modules are unsupported - not slower, actually broken.** For a dynamic feature
+(`com.android.dynamic-feature`, e.g. `:feature:beerdetail`), AGP hard-rejects any application
+other than its one hardcoded base app (`implementation(project(":app"))`, baked in by the
+`billionbeers.android.dynamic.feature` convention plugin) from depending on it at all -
+`assembleDebug` fails at the resource-linking step with "this application is not configured to
+use dynamic features," even though `compileDebugKotlin` alone misleadingly succeeds first. This
+was discovered the hard way trying to build `app-dev-beerdetail`; see
+`docs/beerdetail_dev_app.md` and `docs/adr/0004-dev-apps-dont-support-dynamic-features.md` for
+the full investigation, the error output, and possible future workarounds (mainly: extracting the
+feature's pure presentational composables into a plain library module both the dynamic feature
+and a dev-app could depend on - real architectural work, not attempted here).
+
+`scripts/new-dev-app.sh` refuses to scaffold a dynamic feature module for exactly this reason -
+if it errors out pointing here, that's the script working as intended, not a bug to route
+around.
+
+## Arguments
+
+Expects: `<feature> [PascalName] [gradlePath]` - same as `scripts/new-dev-app.sh`. `feature` is
+required (lowercase module suffix, e.g. `beerdetail`). If `PascalName` is omitted, derive it
+yourself from the feature's actual class names (see Step 2) rather than trusting the script's
+naive first-letter-capitalized default - e.g. `beerdetail` should become `BeerDetail`, not
+`Beerdetail`. If the script guessed wrong, rename the generated files/package/class identifiers
+to match before continuing (cheaper to fix immediately than after wiring is filled in).
+
+## Step 1: run the generator
+
+```
+scripts/new-dev-app.sh <feature> <PascalName> [gradlePath]
+```
+
+This creates `app-dev-<feature>/` with a compiling scaffold: `build.gradle.kts`, manifest,
+`Application`, `DevAppGraph`, `ViewModelMapsModule`, `SplitInstallModule`, and two files with
+`TODO` markers you must fill in: `MainActivity.kt` and `di/DevFakesModule.kt`. It also registers
+the module in `settings.gradle.kts`.
+
+If the module directory already exists, the script refuses to run - decide whether to delete the
+existing one first or whether the user actually wanted to finish an already-scaffolded module
+(skip straight to Step 2 in that case).
+
+## Step 2: investigate the target feature module
+
+Before writing anything, read enough of `<gradlePath>` (default `:feature:<feature>`) to answer:
+
+1. **What is the screen's real entry-point composable?** Find the top-level `@Composable fun
+   ...Screen(...)` (or similarly named) function. Note its exact signature - required params,
+   default params, and whether it takes a domain object directly (like `BeerDetail`'s `Beer`
+   param) or fetches everything itself via an injected ViewModel (like `BeersListScreen`).
+2. **Is this a dynamic feature? Stop here if so.** Check whether `<gradlePath>`'s
+   `build.gradle.kts` applies `billionbeers.android.dynamic.feature` (or check
+   `app/build.gradle.kts`'s `dynamicFeatures` set for its Gradle path). If it is one, do not
+   attempt to scaffold or wire up a dev-app for it - `scripts/new-dev-app.sh` already refuses to
+   generate the module for this exact reason. Tell the user it's unsupported, point them at
+   `docs/beerdetail_dev_app.md` and `docs/adr/0004-dev-apps-dont-support-dynamic-features.md`, and
+   stop - don't try to route around it with source-duplication or any other workaround unless the
+   user explicitly asks you to attempt one (it's a real, non-trivial trade-off, not a quick fix).
+3. **What repositories/dependencies does its ViewModel need?** Find the ViewModel's
+   `@Inject constructor(...)` params. For each repository-shaped dependency, check whether a fake
+   already exists in a sibling `:module:fakes` module (e.g. `beerdomain:fakes`'s
+   `FakeBeersRepository`) - reuse it. Only write a brand-new fake if none exists, and keep it as
+   small as the existing fakes (in-memory, `MutableStateFlow`-backed, no real logic).
+
+## Step 3: fill in di/DevFakesModule.kt
+
+Uncomment and adapt the template so it provides real fake instances for every repository the
+screen's ViewModel needs, seeded with a few realistic sample values (see
+`app-dev-beerslist/.../di/DevBeersRepositoryModule.kt` for the seeding style - 2-3 varied sample
+domain objects, not just `X.empty`). Match the exact binding shape (`@ContributesTo(AppScope::class)`
+interface, `@Provides @SingleIn(AppScope::class)` function) already used elsewhere in this repo -
+do not invent a different DI pattern.
+
+## Step 4: fill in MainActivity.kt
+
+Replace the `// TODO` block with the real call to the screen composable identified in Step 2,
+wrapped exactly like the existing `CompositionLocalProvider`/`BillionBeersTheme` scaffold already
+generated. If the screen needs a domain object as a parameter (rather than fetching it via its own
+ViewModel), construct a sample instance inline here, or read one from the fake repository if it's
+more natural to look one up (see how `app-dev-beerslist` isn't a good example for this case since
+its screen self-fetches; for a detail-style screen, constructing a literal sample object directly
+in `MainActivity` is usually simplest).
+
+## Step 5: compile and verify
+
+1. `./gradlew :app-dev-<feature>:compileDebugKotlin` - fix any errors before moving on.
+2. If an emulator/device is connected (`adb devices`), do a full on-device smoke test matching
+   this project's UI-change verification discipline: `assembleDebug`, `adb install -r`, launch via
+   `adb shell am start`, screenshot, confirm no crash in `adb logcat -d | grep -i FATAL`. If no
+   device is connected, say so explicitly rather than claiming it was verified.
+3. Update the module's `README.md` "Still TODO" section to reflect what's actually still
+   incomplete (ideally: nothing).
+
+## Step 6: report
+
+Summarize what was filled in (which fakes, which screen composable, any sample data seeded), the
+compile result, and the on-device verification result (or why it was skipped). Don't claim
+something works if it wasn't actually run.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ MODULE ?=
 SCENARIO ?= incremental_build
 NAME ?=
 PASCAL ?=
+FEATURE ?=
+GRADLE_PATH ?=
 
 MODULE_TRIMMED := $(strip $(MODULE))
 MODULE_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,)
@@ -11,7 +13,7 @@ UI_TEST_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,:app:)
 # Wrapper for Gradle to support build-brief (bb) or rtk if available
 GRADLE_RUNNER := $(shell if command -v bb >/dev/null 2>&1; then echo "bb ./gradlew"; elif command -v build-brief >/dev/null 2>&1; then echo "build-brief --gradle ./gradlew"; elif command -v rtk >/dev/null 2>&1; then echo "rtk ./gradlew"; else echo "./gradlew"; fi)
 
-.PHONY: help setup setup-ai-tools update-android-skills build install clean test konsist ui-test screenshot-record screenshot-verify screenshot-clean lint format check check-duplicates check-unused-deps benchmark-micro benchmark-macro generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse new-feature-module
+.PHONY: help setup setup-ai-tools update-android-skills build install clean test konsist ui-test screenshot-record screenshot-verify screenshot-clean lint format check check-duplicates check-unused-deps benchmark-micro benchmark-macro generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse new-feature-module new-dev-app
 
 help: ## Show this help message.
 	@echo "\n📊 BillionBeers Makefile Help"
@@ -132,6 +134,10 @@ update-docs: ## Update README.md with the latest library versions from the catal
 new-feature-module: ## Scaffold a feature/<NAME> module. Usage: make new-feature-module NAME=favorites [PASCAL=Favorites]
 	@chmod +x scripts/new-feature-module.sh
 	@./scripts/new-feature-module.sh "$(NAME)" "$(PASCAL)"
+
+new-dev-app: ## Scaffold a standalone app-dev-<FEATURE> module. Usage: make new-dev-app FEATURE=beerdetail [PASCAL=BeerDetail] [GRADLE_PATH=:feature:beerdetail]
+	@chmod +x scripts/new-dev-app.sh
+	@./scripts/new-dev-app.sh "$(FEATURE)" "$(PASCAL)" "$(GRADLE_PATH)"
 
 # Helper Scripts
 install-profiler: ## Install gradle-profiler via Homebrew.

--- a/docs/adr/0004-dev-apps-dont-support-dynamic-features.md
+++ b/docs/adr/0004-dev-apps-dont-support-dynamic-features.md
@@ -1,0 +1,66 @@
+# 0004: Dev-app modules don't support dynamic features
+
+## Status
+
+Accepted
+
+## Context
+
+MASTER_PLAN.md Phase 3 calls for `app-dev-<feature>` modules: standalone applications that
+compile only one feature module + fakes, for a seconds-scale build/install loop instead of the
+full `:app`. `app-dev-beerslist` (`:feature:beerslist`, a regular feature module) proved this out
+successfully. `scripts/new-dev-app.sh` and `.claude/skills/new-dev-app/SKILL.md` generalized the
+pattern into a reusable generator.
+
+The natural next test was `:feature:beerdetail` - a **dynamic feature**
+(`com.android.dynamic-feature`, installed on demand via Play Feature Delivery). Attempting to
+generate `app-dev-beerdetail` surfaced a structural AGP limitation, not just a slower build. Full
+investigation, error output, and what was tried: `docs/beerdetail_dev_app.md`.
+
+## Decision
+
+`app-dev-<feature>` dev-apps only support regular feature modules. Dynamic feature modules are
+explicitly unsupported: `scripts/new-dev-app.sh` detects the target module's
+`billionbeers.android.dynamic.feature` plugin application and refuses to scaffold, and
+`.claude/skills/new-dev-app/SKILL.md` instructs against attempting a workaround without the
+user's explicit go-ahead.
+
+## Why
+
+A dynamic feature module's Gradle convention plugin
+(`billionbeers.android.dynamic.feature.gradle.kts`) hardcodes `implementation(project(":app"))` -
+this is not incidental, it's how AGP models the Play Feature Delivery base/split relationship: a
+dynamic feature is compiled as a split APK belonging to exactly one base application, declared on
+both sides (`dynamicFeatures += setOf(...)` on the base, `implementation(project(":base"))` on the
+split). AGP enforces this at the resource-linking step of `assembleDebug`/`bundleDebug`:
+
+```
+This application (com.simtop.billionbeers.devbeerdetail) is not configured to use dynamic features.
+```
+
+`compileDebugKotlin` succeeding first is a trap, not a sign of progress - plain Kotlin/javac
+compilation has no awareness of the dynamic-feature/base-app contract, so a dev-app for a dynamic
+feature can look like it's working right up until the assemble step.
+
+Even setting the hard assemble failure aside, `:feature:beerdetail`'s own
+`implementation(project(":app"))` means merely resolving `app-dev-beerdetail`'s task graph pulls
+in 84 tasks under `:app:`, `:beer_data:`, `:beer_network:`, and `:beer_database:` - the entire real
+app's dependency closure. So even a hypothetical fix for the assemble failure wouldn't deliver the
+seconds-scale build this pattern exists for.
+
+## Cost accepted
+
+No fast dev-loop for dynamic features. Today that's exactly one screen
+(`:feature:beerdetail`) - iterating on it still requires the full `:app` build/install (or
+Paparazzi screenshot tests, which already cover this screen's layout without needing a running
+app at all).
+
+## Consequences
+
+- `docs/beerdetail_dev_app.md` records two real (not attempted) paths if this becomes painful
+  enough to revisit: extracting beerdetail's presentational composables into a plain library
+  module both the dynamic feature and a dev-app could depend on (the structurally correct fix,
+  real module-boundary work), or source-duplicating the composable into the dev-app (works
+  immediately, drifts out of sync silently, should stay a last resort).
+- If a second dynamic feature is ever added and the same need comes up twice, that's the signal
+  to actually do the module-extraction fix rather than route around it per-feature again.

--- a/docs/beerdetail_dev_app.md
+++ b/docs/beerdetail_dev_app.md
@@ -1,0 +1,90 @@
+# Why there's no app-dev-beerdetail (yet)
+
+Context for anyone (human or AI) who wants to revisit this. Short version: `:feature:beerdetail`
+is a dynamic feature module, and AGP structurally forbids any application other than its one
+declared base app from depending on it. This isn't a build-speed inconvenience like it would be
+for a regular feature module - it's a hard failure. See also
+`docs/adr/0004-dev-apps-dont-support-dynamic-features.md` for the settled decision this doc backs.
+
+## How this was discovered
+
+While building `scripts/new-dev-app.sh` and `.claude/skills/new-dev-app/SKILL.md` (the
+`app-dev-<feature>` generator, first proven out on `app-dev-beerslist`), the natural next test was
+generating `app-dev-beerdetail` for `:feature:beerdetail`.
+
+1. `scripts/new-dev-app.sh beerdetail BeerDetail :feature:beerdetail` scaffolded the module fine
+   (build.gradle.kts, manifest, Application, DevAppGraph, etc. - same shape as beerslist's).
+2. `:app-dev-beerdetail:compileDebugKotlin` **succeeded**. This is misleading - Kotlin/javac
+   compilation doesn't know or care about AGP's dynamic-feature/base-app relationship, so this
+   step gives false confidence.
+3. Investigating how to host the real screen surfaced a second issue first: `BeerDetailProviderImpl`
+   (the `DynamicFeatureContentProvider` reflectively loaded by the real app) delegates to
+   `BeerDetailScreenImpl`, which does:
+   ```kotlin
+   val appGraph = (context.applicationContext as BillionBeersApplication).appGraph
+   val component = createGraphFactory<FeatureDetailComponent.Factory>().create(appGraph as DynamicDependencies)
+   ```
+   `BillionBeersApplication` and `com.simtop.billionbeers.di.DynamicDependencies` are `:app`-module
+   types. A standalone application module can never depend on `:app` (Gradle/AGP don't support an
+   application module depending on another application module), so `BeerDetailScreenImpl` can't be
+   called from a dev-app either. The workaround tried: call `ComposeBeerDetail(beer, onBackClick,
+   onToggleAvailability)` directly instead - the pure presentational composable underneath the
+   ViewModel, with no DI and no `:app` dependency. That part of the fix is fine and would work on
+   its own.
+4. `:app-dev-beerdetail:assembleDebug` **failed**:
+   ```
+   This application (com.simtop.billionbeers.devbeerdetail) is not configured to use dynamic features.
+   Please ensure dynamic features are configured in the build file.
+   ```
+   This is the real, unavoidable blocker. `feature/beerdetail/build.gradle.kts` applies the
+   `billionbeers.android.dynamic.feature` convention plugin
+   (`build-logic/convention/src/main/kotlin/billionbeers.android.dynamic.feature.gradle.kts`),
+   which hardcodes `implementation(project(":app"))` - a dynamic-feature module is compiled as a
+   split APK of exactly one base application, declared via that dependency plus the base app's own
+   `android { dynamicFeatures += setOf(...) }`. AGP enforces this relationship at the
+   resource-linking step of `assembleDebug`/`bundleDebug`, not just at runtime. There is no Gradle
+   property or plugin config that relaxes this - it's how Play Feature Delivery's base/split model
+   works.
+5. Confirmed the (separate, secondary) build-time cost too: even just resolving
+   `:app-dev-beerdetail:compileDebugKotlin`'s task graph pulls in 84 tasks under `:app:`,
+   `:beer_data:`, `:beer_network:`, and `:beer_database:` - because `:feature:beerdetail`'s own
+   `implementation(project(":app"))` transitively drags in everything `:app` depends on. So even
+   setting the assemble failure aside, this would never have been the fast, isolated build the
+   dev-app pattern is meant to deliver.
+
+## What was tried and reverted
+
+- `app-dev-beerdetail/` was generated, given a `MainActivity` hosting `ComposeBeerDetail` directly
+  with a hand-built sample `Beer` and local `mutableStateOf` for the availability toggle, and an
+  empty `di/DevFakesModule.kt` (no repository needed at that presentational level). This compiled
+  but could not assemble, per the error above, so it was removed from
+  `phase3-new-dev-app-generator`. A raw (unfinished, pre-this-investigation) copy of the generated
+  scaffold is preserved on branch `phase3-dev-app-beerdetail-scaffold` for reference.
+- `scripts/new-dev-app.sh` now detects `dynamic.feature`/`dynamic-feature` in the target module's
+  `build.gradle.kts` and refuses to scaffold, pointing here.
+
+## Possible future paths (not attempted)
+
+1. **Extract beerdetail's presentational composables into a plain library module.** E.g. a new
+   `:feature:beerdetail:ui` (or similar) module with no dynamic-feature plugin, no `:app`
+   dependency - just `ComposeBeerDetail` and friends. `:feature:beerdetail` itself would depend on
+   it (for the real app), and a dev-app could too (for the sandbox). This is the structurally
+   correct fix, but it's real module-boundary work: deciding exactly where the api/impl split
+   falls, whether `BeerDetailViewModel` moves too or stays behind in the dynamic feature, and
+   updating Konsist rules if any assume `:feature:beerdetail` is self-contained.
+2. **Source-duplicate the composable file into the dev-app.** Copy `ComposeBeerDetail.kt`'s
+   content directly into `app-dev-beerdetail`, with a comment pointing back at the real file as the
+   source of truth. Works immediately, no architecture change, but the copy silently drifts out of
+   sync with the real file over time - exactly the kind of thing this project's Konsist/screenshot
+   discipline exists to prevent for production code, so this should probably never be promoted
+   past "quick local hack."
+3. **Don't bother for beerdetail specifically.** Given option 1 is the only durable fix and is
+   nontrivial, it may simply not be worth it for a single screen - revisit if a second dynamic
+   feature is added and the same need comes up twice.
+
+## Takeaway for the generator/skill
+
+`scripts/new-dev-app.sh` and `.claude/skills/new-dev-app/SKILL.md` both now treat "target is a
+dynamic feature" as a hard stop, not a workaround to route around. Don't re-attempt the
+`ComposeBeerDetail`-direct approach without first solving the `assembleDebug` blocker (option 1 or
+2 above) - it compiles fine and will look like progress right up until `assembleDebug`.

--- a/scripts/new-dev-app.sh
+++ b/scripts/new-dev-app.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+set -euo pipefail
+
+# Scaffolds a new standalone "app-dev-<feature>" module: a minimal Android application that
+# compiles only one feature module (+ fakes), for a seconds-scale build/install loop instead of
+# the full :app. See app-dev-beerslist/README.md for the pattern this script replicates.
+#
+# Usage:
+#   scripts/new-dev-app.sh <feature> [PascalName] [gradlePath]
+#
+# Examples:
+#   scripts/new-dev-app.sh beerdetail
+#   scripts/new-dev-app.sh beerdetail BeerDetail :feature:beerdetail
+#
+# <feature>    lowercase suffix used for the module dir (app-dev-<feature>) and package
+#              (com.simtop.billionbeers.dev<feature>). Required.
+# [PascalName] class-name prefix (Dev<PascalName>Application, etc). Defaults to <feature> with
+#              just its first letter capitalized - pass this explicitly for multi-word names
+#              (e.g. "beerdetail" -> "BeerDetail", not the default "Beerdetail").
+# [gradlePath] the feature module's Gradle project path. Defaults to ":feature:<feature>".
+
+FEATURE="${1:-}"
+if [ -z "$FEATURE" ]; then
+  echo "Usage: scripts/new-dev-app.sh <feature> [PascalName] [gradlePath]" >&2
+  echo "Example: scripts/new-dev-app.sh beerdetail BeerDetail :feature:beerdetail" >&2
+  exit 1
+fi
+
+DEFAULT_PASCAL="$(tr '[:lower:]' '[:upper:]' <<< "${FEATURE:0:1}")${FEATURE:1}"
+PASCAL="${2:-$DEFAULT_PASCAL}"
+GRADLE_PATH="${3:-:feature:$FEATURE}"
+
+MODULE_DIR="app-dev-$FEATURE"
+PACKAGE="com.simtop.billionbeers.dev$FEATURE"
+PACKAGE_PATH="com/simtop/billionbeers/dev$FEATURE"
+APP_CLASS="Dev${PASCAL}Application"
+
+if [ -d "$MODULE_DIR" ]; then
+  echo "error: $MODULE_DIR already exists" >&2
+  exit 1
+fi
+
+GRADLE_PATH_DIR="$(echo "$GRADLE_PATH" | tr ':' '/' | sed 's#^/##')"
+if [ ! -d "$GRADLE_PATH_DIR" ]; then
+  echo "warning: $GRADLE_PATH_DIR does not look like an existing module directory - continuing anyway" >&2
+fi
+
+# Dynamic feature modules (billionbeers.android.dynamic.feature) hardcode
+# implementation(project(":app")) and can only ever attach to that one base app - AGP rejects
+# any other application depending on them at resource-link time ("this application is not
+# configured to use dynamic features"), not just at runtime. There is no config flag around
+# this. See docs/beerdetail_dev_app.md for the full investigation and possible workarounds.
+if [ -f "$GRADLE_PATH_DIR/build.gradle.kts" ] && grep -q "dynamic.feature\|dynamic-feature" "$GRADLE_PATH_DIR/build.gradle.kts"; then
+  echo "error: $GRADLE_PATH is a dynamic feature module - this script cannot make a" >&2
+  echo "standalone dev-app depend on it (AGP hard-blocks it at assembleDebug, not just a" >&2
+  echo "build-speed cost). See docs/beerdetail_dev_app.md for context and possible workarounds." >&2
+  exit 1
+fi
+
+SRC_DIR="$MODULE_DIR/src/main/java/$PACKAGE_PATH"
+DI_DIR="$SRC_DIR/di"
+mkdir -p "$DI_DIR"
+
+cat > "$MODULE_DIR/build.gradle.kts" <<EOF
+plugins {
+  id("billionbeers.android.application")
+  id("billionbeers.android.compose")
+  id("billionbeers.android.metro")
+}
+
+android {
+  namespace = "$PACKAGE"
+
+  defaultConfig {
+    applicationId = "$PACKAGE"
+    versionCode = 1
+    versionName = "1.0"
+  }
+}
+
+dependencies {
+  // Only the module under active development, plus its fakes - keep this list as small as
+  // possible so this assembles in seconds. Add whichever fakes module(s) $FEATURE needs.
+  implementation(project("$GRADLE_PATH"))
+  implementation(project(":beerdomain:api"))
+  implementation(project(":beerdomain:fakes"))
+  implementation(project(":core"))
+  implementation(project(":core:designsystem"))
+  implementation(project(":navigation"))
+  implementation(project(":presentation_utils"))
+
+  implementation(libs.androidPlayCore)
+  implementation(libs.androidPlayCoreKtx)
+  implementation(libs.androidxActivityCompose)
+  implementation(libs.kotlinx.serialization.json)
+}
+EOF
+
+cat > "$MODULE_DIR/src/main/AndroidManifest.xml" <<EOF
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:name=".${APP_CLASS}"
+        android:allowBackup="false"
+        android:label="Dev: $PASCAL"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity
+            android:name=".MainActivity"
+            android:theme="@style/AppTheme.NoActionBar"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>
+EOF
+
+cat > "$SRC_DIR/${APP_CLASS}.kt" <<EOF
+package $PACKAGE
+
+import android.app.Application
+import $PACKAGE.di.DevAppGraph
+import com.simtop.core.di.GraphProvider
+import dev.zacsweers.metro.createGraphFactory
+import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
+
+class $APP_CLASS : Application(), GraphProvider {
+  lateinit var appGraph: DevAppGraph
+
+  override val metroViewModelFactory: MetroViewModelFactory
+    get() = appGraph.metroViewModelFactory
+
+  override fun onCreate() {
+    super.onCreate()
+    appGraph = createGraphFactory<DevAppGraph.Factory>().create(this)
+  }
+}
+EOF
+
+# MainActivity is deliberately left as a TODO scaffold: every feature's screen has a different
+# entry-point signature (BeersListScreen just takes an onBeerClick callback; BeerDetail needs a
+# Beer instance and is normally loaded reflectively from a dynamic feature), so this can't be
+# templated correctly without knowing which feature is being wired up.
+cat > "$SRC_DIR/MainActivity.kt" <<EOF
+package $PACKAGE
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.CompositionLocalProvider
+import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
+import com.simtop.presentation_utils.core.LocalSplitInstallManager
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
+
+class MainActivity : ComponentActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    val appGraph = (applicationContext as $APP_CLASS).appGraph
+    enableEdgeToEdge()
+    setContent {
+      CompositionLocalProvider(
+        LocalMetroViewModelFactory provides appGraph.metroViewModelFactory,
+        LocalSplitInstallManager provides appGraph.splitInstallManager,
+      ) {
+        BillionBeersTheme {
+          // TODO: host $PASCAL's real screen here, e.g.:
+          //   ${PASCAL}Screen(onBackClick = {})
+          // If the screen needs data its ViewModel doesn't fetch itself (like BeerDetail's Beer
+          // parameter), construct a sample instance here or seed it via a fake repository in
+          // di/DevFakesModule.kt instead.
+        }
+      }
+    }
+  }
+}
+EOF
+
+cat > "$DI_DIR/DevAppGraph.kt" <<EOF
+package $PACKAGE.di
+
+import android.content.Context
+import com.google.android.play.core.splitinstall.SplitInstallManager
+import com.simtop.core.di.ApplicationContext
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
+import dev.zacsweers.metrox.viewmodel.MetroViewModelMultibindings
+
+@DependencyGraph(AppScope::class)
+interface DevAppGraph : MetroViewModelMultibindings {
+  val metroViewModelFactory: MetroViewModelFactory
+  val splitInstallManager: SplitInstallManager
+
+  @DependencyGraph.Factory
+  fun interface Factory {
+    fun create(@Provides @ApplicationContext context: Context): DevAppGraph
+  }
+}
+EOF
+
+# Every standalone app graph needs its own copy: Metro's multibinding maps don't cross
+# application-module boundaries.
+cat > "$DI_DIR/ViewModelMapsModule.kt" <<EOF
+package $PACKAGE.di
+
+import androidx.lifecycle.ViewModel
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Multibinds
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import kotlin.reflect.KClass
+
+@ContributesTo(AppScope::class)
+interface ViewModelMapsModule {
+  @Multibinds(allowEmpty = true) fun viewModels(): Map<KClass<out ViewModel>, ViewModel>
+
+  @Multibinds(allowEmpty = true)
+  fun assistedViewModels(): Map<KClass<out ViewModel>, ViewModelAssistedFactory>
+
+  @Multibinds(allowEmpty = true)
+  fun manualAssistedViewModels():
+    Map<KClass<out ManualViewModelAssistedFactory>, ManualViewModelAssistedFactory>
+}
+EOF
+
+cat > "$DI_DIR/SplitInstallModule.kt" <<EOF
+package $PACKAGE.di
+
+import android.content.Context
+import com.google.android.play.core.splitinstall.SplitInstallManager
+import com.google.android.play.core.splitinstall.SplitInstallManagerFactory
+import com.simtop.core.di.ApplicationContext
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesTo
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+
+@ContributesTo(AppScope::class)
+interface SplitInstallModule {
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun provideSplitInstallManager(@ApplicationContext context: Context): SplitInstallManager {
+    return SplitInstallManagerFactory.create(context)
+  }
+}
+EOF
+
+# Left as a commented-out stub - every feature depends on different repositories, so there's no
+# single correct fake binding to generate here.
+cat > "$DI_DIR/DevFakesModule.kt" <<EOF
+package $PACKAGE.di
+
+// TODO: bind $PASCAL's repositories to fakes here, e.g.:
+//
+// import com.simtop.beerdomain.domain.repositories.BeersRepository
+// import com.simtop.beerdomain.fakes.FakeBeersRepository
+// import dev.zacsweers.metro.AppScope
+// import dev.zacsweers.metro.ContributesTo
+// import dev.zacsweers.metro.Provides
+// import dev.zacsweers.metro.SingleIn
+//
+// @ContributesTo(AppScope::class)
+// interface DevFakesModule {
+//   @Provides
+//   @SingleIn(AppScope::class)
+//   fun provideBeersRepository(): BeersRepository = FakeBeersRepository(initialBeers = sampleBeers)
+// }
+EOF
+
+cat > "$MODULE_DIR/README.md" <<EOF
+# $MODULE_DIR
+
+Standalone dev-app for \`$GRADLE_PATH\`, stamped out by \`scripts/new-dev-app.sh\`. See
+\`app-dev-beerslist/README.md\` for the pattern this replicates in full.
+
+## Still TODO after generation
+
+1. **di/DevFakesModule.kt**: bind whatever repositories $PASCAL depends on to fakes (uncomment
+   and adapt the template, or write a new fake if one doesn't exist in a \`:fakes\` module yet).
+2. **MainActivity.kt**: replace the TODO block with the real call to $PASCAL's screen composable.
+3. If \`$GRADLE_PATH\` is a dynamic feature (like \`:feature:beerdetail\`), its screen is normally
+   loaded reflectively via \`DynamicFeatureContentProvider\` - for this dev-app you can most
+   likely call the underlying \`@Composable\` screen function directly instead, since there's no
+   split-install to gate here (check what the feature's provider implementation wraps).
+
+## Regenerating
+
+Delete \`$MODULE_DIR/\` and its \`include(":$MODULE_DIR")\` line in \`settings.gradle.kts\`, then
+rerun: \`scripts/new-dev-app.sh $FEATURE $PASCAL $GRADLE_PATH\`
+EOF
+
+if ! grep -q "include(\":$MODULE_DIR\")" settings.gradle.kts; then
+  awk -v line="include(\":$MODULE_DIR\")" '
+    { print }
+    /include\(":app"\)/ && !done { print line; done=1 }
+  ' settings.gradle.kts > settings.gradle.kts.tmp
+  mv settings.gradle.kts.tmp settings.gradle.kts
+fi
+
+echo "Created $MODULE_DIR and registered it in settings.gradle.kts."
+echo "Next steps:"
+echo "  1. Fill in $DI_DIR/DevFakesModule.kt"
+echo "  2. Fill in $SRC_DIR/MainActivity.kt"
+echo "  3. ./gradlew :$MODULE_DIR:installDebug"


### PR DESCRIPTION
## Summary
- `scripts/new-dev-app.sh` (wired to `make new-dev-app FEATURE=... [PASCAL=...] [GRADLE_PATH=...]`) scaffolds a standalone `app-dev-<feature>` module, generalizing the `app-dev-beerslist` pattern (MASTER_PLAN.md Phase 3 module-template item) so future dev-apps don't need to be hand-built each time.
- `.claude/skills/new-dev-app/SKILL.md` automates *finishing* the generated scaffold: investigates the target feature's real screen entry point and ViewModel dependencies, wires fakes, hosts the real screen, verifies on-device.
- Dogfooding the skill against `:feature:beerdetail` surfaced a hard AGP limitation: dynamic feature modules can't work with this pattern at all. `billionbeers.android.dynamic.feature` hardcodes `implementation(project(":app"))`, so AGP rejects any other application depending on it at `assembleDebug`'s resource-linking step — `compileDebugKotlin` succeeding first is misleading. The script now detects this (checks the target's `build.gradle.kts` for the dynamic-feature plugin) and refuses to scaffold.
- `docs/beerdetail_dev_app.md` records the full investigation (error output, what was tried, possible future fixes) and `docs/adr/0004-dev-apps-dont-support-dynamic-features.md` records the settled decision.
- A raw, unfinished `app-dev-beerdetail` scaffold (generated before the dynamic-feature limitation was discovered) is preserved for reference on branch `phase3-dev-app-beerdetail-scaffold` (not part of this PR).

## Test plan
- [x] `make test`
- [x] `make screenshot-verify`
- [x] `make konsist`
- [x] Ran the script end-to-end for `:feature:beerslist` (regular feature) — scaffolds correctly, matches the existing `app-dev-beerslist` shape.
- [x] Ran the script for `:feature:beerdetail` (dynamic feature) — confirmed it refuses cleanly with no directory created.
- [x] Manually followed the skill's own instructions to finish an `app-dev-beerdetail` scaffold, which is how the dynamic-feature blocker was found (`compileDebugKotlin` passed, `assembleDebug` failed with AGP's dynamic-feature error, confirmed via logcat/build output — not just assumed).