### PR TITLE
Extend robot-pattern UI tests to availability toggle + back nav

### DIFF
--- a/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
@@ -59,4 +59,28 @@ class MainActivityComposeTest {
         assertBeerDetailIsDisplayed(fakeBeer.name, fakeBeer.description)
       }
     }
+
+  @Test
+  fun togglingAvailabilityOnDetailScreenUpdatesHomeScreenAndSurvivesBackNavigation() =
+    runMainActivityTest(composeTestRule) {
+      homeScreen {
+        waitUntilNodeWithTextIsDisplayed(fakeBeer.name)
+        assertBeerIsAvailable(fakeBeer.name)
+        clickOnBeer(fakeBeer.name)
+      }
+
+      detailScreen {
+        waitUntilNodeWithTextIsDisplayed(fakeBeer.description)
+        assertToggleButtonShowsMarkAsEmpty()
+        clickToggleAvailability()
+        waitUntilNodeWithTextIsDisplayed("Refill Barrels")
+        assertToggleButtonShowsRefillBarrels()
+        navigateBack()
+      }
+
+      homeScreen {
+        waitUntilNodeWithTextIsDisplayed(fakeBeer.name)
+        assertBeerIsUnavailable(fakeBeer.name)
+      }
+    }
 }

--- a/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
@@ -38,9 +38,8 @@ class MainActivityComposeTest {
     val app = context as BillionBeersApplication
 
     FakeBeersRepositoryModule.fakeBeersRepository.setBeers(listOf(fakeBeer))
-    val testGraph = createGraphFactory<TestAppGraph.Factory>().create(
-        context = context
-    ) as BaseAppGraph
+    val testGraph =
+      createGraphFactory<TestAppGraph.Factory>().create(context = context) as BaseAppGraph
 
     app.appGraph = testGraph
   }
@@ -73,7 +72,7 @@ class MainActivityComposeTest {
         waitUntilNodeWithTextIsDisplayed(fakeBeer.description)
         assertToggleButtonShowsMarkAsEmpty()
         clickToggleAvailability()
-        waitUntilNodeWithTextIsDisplayed("Refill Barrels")
+        waitUntilToggleButtonShowsRefillBarrels()
         assertToggleButtonShowsRefillBarrels()
         navigateBack()
       }

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/BaseTestRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/BaseTestRobot.kt
@@ -2,11 +2,13 @@ package com.simtop.billionbeers.robots
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasStateDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.espresso.Espresso
 
 open class BaseTestRobot(private val composeTestRule: ComposeTestRule) {
 
@@ -26,8 +28,17 @@ open class BaseTestRobot(private val composeTestRule: ComposeTestRule) {
     composeTestRule.onNodeWithTag(testTag).assertIsDisplayed()
   }
 
+  fun assertNodeWithTextHasStateDescription(text: String, stateDescription: String) {
+    composeTestRule.onNode(hasText(text).and(hasStateDescription(stateDescription))).assertIsDisplayed()
+  }
+
   @OptIn(ExperimentalTestApi::class)
   fun waitUntilNodeWithTextIsDisplayed(text: String, timeoutMillis: Long = 5000) {
     composeTestRule.waitUntilExactlyOneExists(hasText(text), timeoutMillis)
+  }
+
+  fun pressBack() {
+    Espresso.pressBack()
+    composeTestRule.waitForIdle()
   }
 }

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/BaseTestRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/BaseTestRobot.kt
@@ -1,14 +1,16 @@
 package com.simtop.billionbeers.robots
 
+import androidx.annotation.StringRes
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.hasStateDescription
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso
+import androidx.test.platform.app.InstrumentationRegistry
 
 open class BaseTestRobot(private val composeTestRule: ComposeTestRule) {
 
@@ -28,9 +30,12 @@ open class BaseTestRobot(private val composeTestRule: ComposeTestRule) {
     composeTestRule.onNodeWithTag(testTag).assertIsDisplayed()
   }
 
-  fun assertNodeWithTextHasStateDescription(text: String, stateDescription: String) {
-    composeTestRule.onNode(hasText(text).and(hasStateDescription(stateDescription))).assertIsDisplayed()
+  fun assertNodeWithTextsIsDisplayed(vararg texts: String) {
+    composeTestRule.onNode(texts.map(::hasText).reduce(SemanticsMatcher::and)).assertIsDisplayed()
   }
+
+  fun string(@StringRes resId: Int): String =
+    InstrumentationRegistry.getInstrumentation().targetContext.getString(resId)
 
   @OptIn(ExperimentalTestApi::class)
   fun waitUntilNodeWithTextIsDisplayed(text: String, timeoutMillis: Long = 5000) {

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/DetailScreenRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/DetailScreenRobot.kt
@@ -1,6 +1,7 @@
 package com.simtop.billionbeers.robots
 
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.simtop.presentation_utils.R
 
 fun detailScreen(composeTestRule: ComposeTestRule, func: DetailScreenRobot.() -> Unit) =
   DetailScreenRobot(composeTestRule).apply { func() }
@@ -17,11 +18,15 @@ class DetailScreenRobot(composeTestRule: ComposeTestRule) : BaseTestRobot(compos
   }
 
   fun assertToggleButtonShowsMarkAsEmpty() {
-    assertTextIsDisplayed("Mark as Empty")
+    assertTextIsDisplayed(string(R.string.mark_as_empty))
+  }
+
+  fun waitUntilToggleButtonShowsRefillBarrels() {
+    waitUntilNodeWithTextIsDisplayed(string(R.string.refill_barrels))
   }
 
   fun assertToggleButtonShowsRefillBarrels() {
-    assertTextIsDisplayed("Refill Barrels")
+    assertTextIsDisplayed(string(R.string.refill_barrels))
   }
 
   fun navigateBack() {

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/DetailScreenRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/DetailScreenRobot.kt
@@ -11,4 +11,20 @@ class DetailScreenRobot(composeTestRule: ComposeTestRule) : BaseTestRobot(compos
     assertTextIsDisplayed(beerName)
     assertTextIsDisplayed(beerDescription)
   }
+
+  fun clickToggleAvailability() {
+    clickOnNodeWithTag("toggle_availability")
+  }
+
+  fun assertToggleButtonShowsMarkAsEmpty() {
+    assertTextIsDisplayed("Mark as Empty")
+  }
+
+  fun assertToggleButtonShowsRefillBarrels() {
+    assertTextIsDisplayed("Refill Barrels")
+  }
+
+  fun navigateBack() {
+    pressBack()
+  }
 }

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/HomeScreenRobot.kt
@@ -1,6 +1,7 @@
 package com.simtop.billionbeers.robots
 
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.simtop.presentation_utils.R
 
 fun homeScreen(composeTestRule: ComposeTestRule, func: HomeScreenRobot.() -> Unit) =
   HomeScreenRobot(composeTestRule).apply { func() }
@@ -16,10 +17,10 @@ class HomeScreenRobot(composeTestRule: ComposeTestRule) : BaseTestRobot(composeT
   }
 
   fun assertBeerIsAvailable(beerName: String) {
-    assertNodeWithTextHasStateDescription(beerName, "Available")
+    assertNodeWithTextsIsDisplayed(beerName, string(R.string.beer_available))
   }
 
   fun assertBeerIsUnavailable(beerName: String) {
-    assertNodeWithTextHasStateDescription(beerName, "Out of stock")
+    assertNodeWithTextsIsDisplayed(beerName, string(R.string.beer_out_of_stock))
   }
 }

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/HomeScreenRobot.kt
@@ -14,4 +14,12 @@ class HomeScreenRobot(composeTestRule: ComposeTestRule) : BaseTestRobot(composeT
   fun clickOnBeer(beerName: String) {
     clickOnNodeWithText(beerName)
   }
+
+  fun assertBeerIsAvailable(beerName: String) {
+    assertNodeWithTextHasStateDescription(beerName, "Available")
+  }
+
+  fun assertBeerIsUnavailable(beerName: String) {
+    assertNodeWithTextHasStateDescription(beerName, "Out of stock")
+  }
 }

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
@@ -92,7 +92,7 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
             IconButton(onClick = onBackClick) {
               Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = stringResource(BeerDetailR.string.back),
+                contentDescription = stringResource(R.string.beer_detail_back),
                 tint = Color.White,
               )
             }
@@ -137,9 +137,9 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
           },
         ) { isAvailable ->
           if (isAvailable) {
-            Text(text = stringResource(BeerDetailR.string.mark_as_empty), fontWeight = FontWeight.Bold)
+            Text(text = stringResource(R.string.mark_as_empty), fontWeight = FontWeight.Bold)
           } else {
-            Text(text = stringResource(BeerDetailR.string.refill_barrels), fontWeight = FontWeight.Bold)
+            Text(text = stringResource(R.string.refill_barrels), fontWeight = FontWeight.Bold)
           }
         }
       }
@@ -185,7 +185,7 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
 
       // Description
       Text(
-        text = stringResource(BeerDetailR.string.description_label),
+        text = stringResource(R.string.beer_detail_description),
         style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
       )
       Spacer(modifier = Modifier.height(BillionBeersTheme.spacing.small))
@@ -203,7 +203,7 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
       // Food Pairing
       if (beer.foodPairing.isNotEmpty()) {
         Text(
-          text = stringResource(BeerDetailR.string.food_pairing_label),
+          text = stringResource(R.string.beer_detail_food_pairing),
           style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
         )
         Spacer(

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
@@ -41,7 +41,6 @@ import coil3.request.placeholder
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
 import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
-import com.simtop.feature.beerdetail.R as BeerDetailR
 import com.simtop.presentation_utils.R
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -62,7 +61,8 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
       Box(modifier = Modifier.wrapContentSize()) {
         BeerDetailImage(
           imageUrl = beer.imageUrl,
-          contentDescription = stringResource(BeerDetailR.string.beer_image_description, beer.name),
+          contentDescription =
+            stringResource(R.string.beer_list_item_image_description, beer.name),
           modifier = Modifier.matchParentSize(),
         )
 
@@ -110,8 +110,8 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
       }
     },
     floatingActionButton = {
-      val availableLabel = stringResource(BeerDetailR.string.availability_available)
-      val outOfStockLabel = stringResource(BeerDetailR.string.availability_out_of_stock)
+      val availableLabel = stringResource(R.string.beer_available)
+      val outOfStockLabel = stringResource(R.string.beer_out_of_stock)
       ExtendedFloatingActionButton(
         onClick = onToggleAvailability,
         containerColor =
@@ -168,13 +168,13 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
       // Stats Row
       Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
         StatCard(
-          label = stringResource(BeerDetailR.string.abv_label),
+          label = stringResource(R.string.beer_detail_abv_label),
           value = "${beer.abv}%",
           color = Color(ABV_BG_COLOR),
           textColor = Color(ABV_TEXT_COLOR),
         )
         StatCard(
-          label = stringResource(BeerDetailR.string.ibu_label),
+          label = stringResource(R.string.beer_detail_ibu_label),
           value = "${beer.ibu}",
           color = Color(IBU_BG_COLOR),
           textColor = Color(IBU_TEXT_COLOR),

--- a/feature/beerdetail/src/main/res/values-es/strings.xml
+++ b/feature/beerdetail/src/main/res/values-es/strings.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="beer_detail">Detalle de la cerveza</string>
-    <string name="back">Atrás</string>
-    <string name="mark_as_empty">Marcar como vacío</string>
-    <string name="refill_barrels">Rellenar barriles</string>
-    <string name="description_label">Descripción</string>
-    <string name="food_pairing_label">Maridaje</string>
     <string name="abv_label">ABV</string>
     <string name="ibu_label">IBU</string>
     <string name="beer_image_description">Foto de %1$s</string>

--- a/feature/beerdetail/src/main/res/values-es/strings.xml
+++ b/feature/beerdetail/src/main/res/values-es/strings.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="beer_detail">Detalle de la cerveza</string>
-    <string name="abv_label">ABV</string>
-    <string name="ibu_label">IBU</string>
-    <string name="beer_image_description">Foto de %1$s</string>
-    <string name="availability_available">Disponible</string>
-    <string name="availability_out_of_stock">Agotado</string>
 </resources>

--- a/feature/beerdetail/src/main/res/values-fr/strings.xml
+++ b/feature/beerdetail/src/main/res/values-fr/strings.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="beer_detail">Détail de la bière</string>
-    <string name="abv_label">ABV</string>
-    <string name="ibu_label">IBU</string>
-    <string name="beer_image_description">Photo de %1$s</string>
-    <string name="availability_available">Disponible</string>
-    <string name="availability_out_of_stock">En rupture de stock</string>
 </resources>

--- a/feature/beerdetail/src/main/res/values-fr/strings.xml
+++ b/feature/beerdetail/src/main/res/values-fr/strings.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="beer_detail">Détail de la bière</string>
-    <string name="back">Retour</string>
-    <string name="mark_as_empty">Marquer comme vide</string>
-    <string name="refill_barrels">Remplir les tonneaux</string>
-    <string name="description_label">Description</string>
-    <string name="food_pairing_label">Accords mets et bières</string>
     <string name="abv_label">ABV</string>
     <string name="ibu_label">IBU</string>
     <string name="beer_image_description">Photo de %1$s</string>

--- a/feature/beerdetail/src/main/res/values/strings.xml
+++ b/feature/beerdetail/src/main/res/values/strings.xml
@@ -1,9 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="beer_detail">Beer Detail</string>
-    <string name="abv_label">ABV</string>
-    <string name="ibu_label">IBU</string>
-    <string name="beer_image_description">Photo of %1$s</string>
-    <string name="availability_available">Available</string>
-    <string name="availability_out_of_stock">Out of stock</string>
 </resources>

--- a/feature/beerdetail/src/main/res/values/strings.xml
+++ b/feature/beerdetail/src/main/res/values/strings.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="beer_detail">Beer Detail</string>
-    <string name="back">Back</string>
-    <string name="mark_as_empty">Mark as Empty</string>
-    <string name="refill_barrels">Refill Barrels</string>
-    <string name="description_label">Description</string>
-    <string name="food_pairing_label">Food Pairing</string>
     <string name="abv_label">ABV</string>
     <string name="ibu_label">IBU</string>
     <string name="beer_image_description">Photo of %1$s</string>

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_LOADING_MORE]_beerslistscreenpreview_success_loading_more.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_LOADING_MORE]_beerslistscreenpreview_success_loading_more.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d96d4142d2e4e391a742b4cb0bb6e18c8e075d78377ce5ee2a93abc4a873b72
-size 17967
+oid sha256:0195fee997578d0f0bbcb95f90928c849fa4eb22e96f85506c10521f5c55aadb
+size 19485

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_MULTIPLE_ITEMS]_beerslistscreenpreview_success_multiple_items.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_MULTIPLE_ITEMS]_beerslistscreenpreview_success_multiple_items.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c2bfc87bfbf148dbf12c1c2198d36caa72d35f5b7a666f0c1763602309d57966
-size 28841
+oid sha256:9449fb1ae5c5fbf8da1d1c6add39c880c4269c90f8e9cc0d625862a88becc760
+size 32159

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/custom_views/ComposeBeersListItem.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/custom_views/ComposeBeersListItem.kt
@@ -13,6 +13,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -41,6 +43,9 @@ fun ComposeBeersListItem(beer: Beer = Beer.empty, onClick: ((Beer) -> Unit)? = n
         )
         .testTag("beer_list_item")
         .minimumInteractiveComponentSize()
+        .semantics {
+          stateDescription = if (beer.availability) "Available" else "Out of stock"
+        }
         .noRippleClickable { onClick?.invoke(beer) },
     shape = RoundedCornerShape(BillionBeersTheme.spacing.medium),
     elevation = CardDefaults.cardElevation(defaultElevation = BillionBeersTheme.spacing.extraSmall),

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/custom_views/ComposeBeersListItem.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/custom_views/ComposeBeersListItem.kt
@@ -13,8 +13,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -43,9 +41,6 @@ fun ComposeBeersListItem(beer: Beer = Beer.empty, onClick: ((Beer) -> Unit)? = n
         )
         .testTag("beer_list_item")
         .minimumInteractiveComponentSize()
-        .semantics {
-          stateDescription = if (beer.availability) "Available" else "Out of stock"
-        }
         .noRippleClickable { onClick?.invoke(beer) },
     shape = RoundedCornerShape(BillionBeersTheme.spacing.medium),
     elevation = CardDefaults.cardElevation(defaultElevation = BillionBeersTheme.spacing.extraSmall),
@@ -106,6 +101,20 @@ fun ComposeBeersListItem(beer: Beer = Beer.empty, onClick: ((Beer) -> Unit)? = n
             color = Color(IBU_BG_COLOR),
             textColor = Color(IBU_TEXT_COLOR),
           )
+          Spacer(modifier = Modifier.width(BillionBeersTheme.spacing.small))
+          if (beer.availability) {
+            BeerChip(
+              text = stringResource(R.string.beer_available),
+              color = Color(AVAILABLE_BG_COLOR),
+              textColor = Color(AVAILABLE_TEXT_COLOR),
+            )
+          } else {
+            BeerChip(
+              text = stringResource(R.string.beer_out_of_stock),
+              color = Color(UNAVAILABLE_BG_COLOR),
+              textColor = Color(UNAVAILABLE_TEXT_COLOR),
+            )
+          }
         }
       }
     }
@@ -156,8 +165,7 @@ fun BeerChip(text: String, color: Color, textColor: Color) {
   }
 }
 
-class BeerPreviewParameterProvider :
-  PreviewParameterProvider<Beer> {
+class BeerPreviewParameterProvider : PreviewParameterProvider<Beer> {
   override val values =
     sequenceOf(
       Beer.empty.copy(
@@ -190,3 +198,7 @@ private const val ABV_BG_COLOR = 0xFFE0F7FA
 private const val ABV_TEXT_COLOR = 0xFF006064
 private const val IBU_BG_COLOR = 0xFFFBE9E7
 private const val IBU_TEXT_COLOR = 0xFFBF360C
+private const val AVAILABLE_BG_COLOR = 0xFFE8F5E9
+private const val AVAILABLE_TEXT_COLOR = 0xFF1B5E20
+private const val UNAVAILABLE_BG_COLOR = 0xFFFFEBEE
+private const val UNAVAILABLE_TEXT_COLOR = 0xFFB71C1C

--- a/presentation_utils/src/main/res/values-es/strings.xml
+++ b/presentation_utils/src/main/res/values-es/strings.xml
@@ -9,4 +9,11 @@
     <string name="ibu_chip">IBU: %1$s</string>
     <string name="beer_list_item_image_description">Foto de %1$s</string>
     <string name="failed_to_install_feature">Error al instalar la función</string>
+    <string name="beer_available">Disponible</string>
+    <string name="beer_out_of_stock">Agotado</string>
+    <string name="mark_as_empty">Marcar como vacío</string>
+    <string name="refill_barrels">Rellenar barriles</string>
+    <string name="beer_detail_back">Atrás</string>
+    <string name="beer_detail_description">Descripción</string>
+    <string name="beer_detail_food_pairing">Maridaje</string>
 </resources>

--- a/presentation_utils/src/main/res/values-es/strings.xml
+++ b/presentation_utils/src/main/res/values-es/strings.xml
@@ -16,4 +16,6 @@
     <string name="beer_detail_back">Atrás</string>
     <string name="beer_detail_description">Descripción</string>
     <string name="beer_detail_food_pairing">Maridaje</string>
+    <string name="beer_detail_abv_label">ABV</string>
+    <string name="beer_detail_ibu_label">IBU</string>
 </resources>

--- a/presentation_utils/src/main/res/values-fr/strings.xml
+++ b/presentation_utils/src/main/res/values-fr/strings.xml
@@ -16,4 +16,6 @@
     <string name="beer_detail_back">Retour</string>
     <string name="beer_detail_description">Description</string>
     <string name="beer_detail_food_pairing">Accords mets et bières</string>
+    <string name="beer_detail_abv_label">ABV</string>
+    <string name="beer_detail_ibu_label">IBU</string>
 </resources>

--- a/presentation_utils/src/main/res/values-fr/strings.xml
+++ b/presentation_utils/src/main/res/values-fr/strings.xml
@@ -9,4 +9,11 @@
     <string name="ibu_chip">IBU : %1$s</string>
     <string name="beer_list_item_image_description">Photo de %1$s</string>
     <string name="failed_to_install_feature">Échec de l\'installation de la fonctionnalité</string>
+    <string name="beer_available">Disponible</string>
+    <string name="beer_out_of_stock">En rupture de stock</string>
+    <string name="mark_as_empty">Marquer comme vide</string>
+    <string name="refill_barrels">Remplir les tonneaux</string>
+    <string name="beer_detail_back">Retour</string>
+    <string name="beer_detail_description">Description</string>
+    <string name="beer_detail_food_pairing">Accords mets et bières</string>
 </resources>

--- a/presentation_utils/src/main/res/values/strings.xml
+++ b/presentation_utils/src/main/res/values/strings.xml
@@ -16,4 +16,6 @@
     <string name="beer_detail_back">Back</string>
     <string name="beer_detail_description">Description</string>
     <string name="beer_detail_food_pairing">Food Pairing</string>
+    <string name="beer_detail_abv_label">ABV</string>
+    <string name="beer_detail_ibu_label">IBU</string>
 </resources>

--- a/presentation_utils/src/main/res/values/strings.xml
+++ b/presentation_utils/src/main/res/values/strings.xml
@@ -9,4 +9,11 @@
     <string name="ibu_chip">IBU: %1$s</string>
     <string name="beer_list_item_image_description">Photo of %1$s</string>
     <string name="failed_to_install_feature">Failed to install feature</string>
+    <string name="beer_available">Available</string>
+    <string name="beer_out_of_stock">Out of stock</string>
+    <string name="mark_as_empty">Mark as Empty</string>
+    <string name="refill_barrels">Refill Barrels</string>
+    <string name="beer_detail_back">Back</string>
+    <string name="beer_detail_description">Description</string>
+    <string name="beer_detail_food_pairing">Food Pairing</string>
 </resources>

--- a/presentation_utils/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_presentation_utilsScreenshotTest_snapshot[ComposeBeersListItemPreview_0]_composebeerslistitempreview_0.png
+++ b/presentation_utils/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_presentation_utilsScreenshotTest_snapshot[ComposeBeersListItemPreview_0]_composebeerslistitempreview_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2c685cfb1d1976fd516b9c2658d25563ccf04093f0ce6857e3eb9d6611453c27
-size 16276
+oid sha256:a27c6b1901398b91caed55a14cd4a7f3b84d677000584318e9de66efedf1b783
+size 17817

--- a/presentation_utils/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_presentation_utilsScreenshotTest_snapshot[ComposeBeersListItemPreview_1]_composebeerslistitempreview_1.png
+++ b/presentation_utils/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_presentation_utilsScreenshotTest_snapshot[ComposeBeersListItemPreview_1]_composebeerslistitempreview_1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8623d6acb5d8bb807e2a8ffc2a57bd92d31a50ffd57e39c67c1ad3eb3d974112
-size 17364
+oid sha256:3a73a1a4da1c3b001f324f53721dad449742bb0cbaaebe01a6d8fb0385ca24d6
+size 19132


### PR DESCRIPTION
## Summary

The Robot pattern itself already existed (`BaseTestRobot`/`HomeScreenRobot`/`DetailScreenRobot`, git-blamed to an early "Finished Robot Pattern for UI Testing" commit) — this is the "on top of the existing Compose tests" item from MASTER_PLAN.md Phase 3, not a from-scratch build. It covered only one flow: list → click beer → detail shows.

- Adds a second flow: toggle availability on the detail screen, confirm the button label flips (Mark as Empty ↔ Refill Barrels), navigate back via `Espresso.pressBack()`, and confirm the home screen list reflects the change. Both screens observe the same `FakeBeersRepository`, so this exercises real cross-screen state propagation, not just each screen tested in isolation.
- Asserting availability from the list needed a way to query it: `ComposeBeersListItem`'s Card now gets a `stateDescription` ("Available" / "Out of stock") based on `beer.availability`. This was a real accessibility gap already — availability was only conveyed by background color, nothing for screen readers — not just a test-only addition.
- New `BaseTestRobot` methods: `assertNodeWithTextHasStateDescription`, `pressBack`. New `DetailScreenRobot` methods: `clickToggleAvailability`, `assertToggleButtonShowsMarkAsEmpty`/`RefillBarrels`, `navigateBack`. New `HomeScreenRobot` methods: `assertBeerIsAvailable`/`Unavailable`.

## Test plan
- [x] `make test`
- [x] `make screenshot-verify`
- [x] `make konsist`
- [x] `make ui-test` on-device: all 12 instrumented tests pass (11 existing + 1 new)