### PR TITLE
fix: draw beer detail and catalog edge-to-edge behind system bars

### DIFF
--- a/catalog/src/main/AndroidManifest.xml
+++ b/catalog/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity
             android:name=".MainActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/catalog/src/main/java/com/simtop/billionbeers/catalog/MainActivity.kt
+++ b/catalog/src/main/java/com/simtop/billionbeers/catalog/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.simtop.billionbeers.catalog
 
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -26,6 +28,12 @@ import java.util.ServiceLoader
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
+    // Lets the NavigationBar bottom bar draw its own color to the screen edge instead of the
+    // system adding a translucent contrast scrim behind 3-button navigation.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      window.isNavigationBarContrastEnforced = false
+    }
     setContent { BillionBeersTheme { CatalogApp() } }
   }
 }
@@ -98,7 +106,9 @@ fun CatalogApp() {
     NavHost(
       navController = navController,
       startDestination = "list",
-      modifier = Modifier.padding(padding),
+      // consumeWindowInsets stops the demo route's own TopAppBar from re-applying the status bar
+      // inset that the Scaffold padding already covers.
+      modifier = Modifier.padding(padding).consumeWindowInsets(padding),
     ) {
       composable("list") {
         LazyColumn(modifier = Modifier.fillMaxSize()) {

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
@@ -53,10 +53,7 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
     if (ValueAnimator.getDurationScale() == 0f) 0 else AVAILABILITY_ANIMATION_DURATION_MS
 
   Scaffold(
-    contentWindowInsets = WindowInsets(BillionBeersTheme.spacing.default),
-    modifier =
-      Modifier.padding(bottom = BillionBeersTheme.spacing.medium)
-        .nestedScroll(scrollBehavior.nestedScrollConnection),
+    modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
     topBar = {
       Box(modifier = Modifier.wrapContentSize()) {
         BeerDetailImage(

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailPreview]_composebeerdetailpreview.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailPreview]_composebeerdetailpreview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:58aeeaf337720d52b2ee2f31fd41c37613de853c531e3f4873adb4407f7e9d93
-size 69153
+oid sha256:6a3556391cc7d969fca02adb8fb3064426093916b1fb6a4f7967b2043fbaba79
+size 69162

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -129,7 +129,11 @@ fun BeersListContent(
           Text(
             text = stringResource(R.string.billion_beers_list),
             // Long-press reveals the debug drawer's floating trigger - see LocalDebugDrawerToggle.
-            modifier = Modifier.combinedClickable(onClick = {}, onLongClick = toggleDebugDrawer),
+            // Only clickable when a debug host provides a toggle; release keeps a plain label.
+            modifier =
+              toggleDebugDrawer?.let { toggle ->
+                Modifier.combinedClickable(onClick = {}, onLongClick = toggle)
+              } ?: Modifier,
           )
         }
       )

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/core/LocalDebugDrawerToggle.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/core/LocalDebugDrawerToggle.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 /**
  * Long-pressing the top bar title calls this to show/hide the debug drawer's floating trigger
  * (app/src/debug's DebugDrawerHost provides the real toggle) - keeps it out of the way until
- * needed, rather than always floating over the content. Defaults to a no-op so screens compile and
- * preview without a debug host in the tree (release builds, Paparazzi, etc).
+ * needed, rather than always floating over the content. Defaults to null so trees without a debug
+ * host (release builds, Paparazzi, etc.) don't turn the title into a silent touch target.
  */
-val LocalDebugDrawerToggle = staticCompositionLocalOf<() -> Unit> { {} }
+val LocalDebugDrawerToggle = staticCompositionLocalOf<(() -> Unit)?> { null }


### PR DESCRIPTION
The detail screen zeroed the Scaffold's `contentWindowInsets` and faked bottom clearance with a fixed 16dp padding on the whole Scaffold, leaving the FAB and the end of the scroll content behind the gesture/nav bar — exactly what the Play Console edge-to-edge check flags. Restoring the default insets fixes the FAB offset and content padding, and lets the screen draw to the true bottom edge.

The catalog app never opted into edge-to-edge: it now calls `enableEdgeToEdge()`, disables the nav-bar contrast scrim (its bottom `NavigationBar` is opaque and should own the edge), consumes the Scaffold insets so the demo route's `TopAppBar` stops re-applying the status-bar inset on Android 15+, and sets `adjustResize` for the search field.

Also fixes the list title being a silent touch target in release: `LocalDebugDrawerToggle` is now nullable and the title only gets `combinedClickable` when a debug host actually provides a toggle.

The beer detail golden is re-recorded for the inset change (FAB raised above the nav bar, scaffold fills to the bottom edge).
