### PR TITLE
fix: keep the shimmer on BeerImage until the image loads

### DIFF
--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/custom_views/ComposeBeersListItem.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/custom_views/ComposeBeersListItem.kt
@@ -6,10 +6,16 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -18,14 +24,15 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import coil3.request.error
-import coil3.request.placeholder
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.billionbeers.catalog_annotations.CatalogComponent
 import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
 import com.simtop.billionbeers.core.designsystem.component.noRippleClickable
+import com.simtop.billionbeers.core.designsystem.component.shimmerBrush
 import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
 import com.simtop.presentation_utils.R
 
@@ -124,23 +131,31 @@ fun ComposeBeersListItem(beer: Beer = Beer.empty, onClick: ((Beer) -> Unit)? = n
 @CatalogComponent(tab = "Utilities")
 @Composable
 fun BeerImage(imageUrl: String, contentDescription: String? = null) {
+  // Keeps the list item's skeleton shimmer alive on the tile until Coil resolves, so the image
+  // crossfades in from the shimmer instead of flashing a static placeholder first.
+  var isLoading by remember { mutableStateOf(true) }
+  val background = if (isLoading) shimmerBrush() else SolidColor(Color.LightGray.copy(alpha = 0.3f))
+
   Box(
     modifier =
       Modifier.size(BillionBeersTheme.spacing.extraHuge + BillionBeersTheme.spacing.medium)
         .clip(
           RoundedCornerShape(BillionBeersTheme.spacing.small + BillionBeersTheme.spacing.extraSmall)
         )
-        .background(Color.LightGray.copy(alpha = 0.3f))
+        .background(background)
   ) {
     AsyncImage(
       model =
         ImageRequest.Builder(LocalContext.current)
           .data(imageUrl)
           .crossfade(true)
-          .placeholder(R.drawable.blue_image)
           .error(R.drawable.blue_image)
           .build(),
       contentDescription = contentDescription,
+      // Bottle shots are tall and narrow; Fit shows the whole bottle inside the square tile
+      // (Crop would zoom into the label and cut the bottle off).
+      contentScale = ContentScale.Fit,
+      onState = { state -> isLoading = state is AsyncImagePainter.State.Loading },
       modifier = Modifier.matchParentSize(),
     )
   }

--- a/presentation_utils/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_presentation_utilsScreenshotTest_snapshot[ComposeBeersListItemPreview_0]_composebeerslistitempreview_0.png
+++ b/presentation_utils/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_presentation_utilsScreenshotTest_snapshot[ComposeBeersListItemPreview_0]_composebeerslistitempreview_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a27c6b1901398b91caed55a14cd4a7f3b84d677000584318e9de66efedf1b783
-size 17817
+oid sha256:9af74dee38a9cb23991d1fd305a2a03170f31772d30cda5d67f6917cfcafef4b
+size 17487

--- a/presentation_utils/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_presentation_utilsScreenshotTest_snapshot[ComposeBeersListItemPreview_1]_composebeerslistitempreview_1.png
+++ b/presentation_utils/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_presentation_utilsScreenshotTest_snapshot[ComposeBeersListItemPreview_1]_composebeerslistitempreview_1.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a73a1a4da1c3b001f324f53721dad449742bb0cbaaebe01a6d8fb0385ca24d6
-size 19132
+oid sha256:d63557e78d67e20168411898f0359f8ba817ee4051e8d014087b8743f2db80c5
+size 18495


### PR DESCRIPTION
Loading the list played a double transition: the skeleton faded out, the static blue placeholder appeared, then the real image crossfaded in. `BeerImage` now keeps the same shimmer brush the skeleton uses on the tile until Coil reports a terminal state (`onState`), so the image crossfades in straight from the shimmer. The blue drawable remains only as the error fallback.

Also makes `ContentScale.Fit` explicit with a comment — it is the right scale for tall, narrow bottle shots in the square tile (Crop would zoom into the label and cut the bottle off) and shouldn't be "fixed" later.

Goldens for the two list-item previews are re-recorded (shimmer tile instead of blue placeholder while loading).
