### PR TITLE
fix: compile BeersMapperBenchmark against the injectable BeersMapper

### DIFF
--- a/benchmark/microbenchmark/build.gradle.kts
+++ b/benchmark/microbenchmark/build.gradle.kts
@@ -34,4 +34,6 @@ dependencies {
     "implementation"(project(":beerdomain:api"))
     "implementation"(project(":beer_database"))
     "implementation"(project(":beer_network"))
+    // BeersMapper's constructor takes LanguageProvider/Logger from core-common.
+    "implementation"(project(":core-common"))
 }

--- a/benchmark/microbenchmark/src/androidTest/java/com/simtop/benchmark/microbenchmark/BeersMapperBenchmark.kt
+++ b/benchmark/microbenchmark/src/androidTest/java/com/simtop/benchmark/microbenchmark/BeersMapperBenchmark.kt
@@ -5,6 +5,8 @@ import androidx.benchmark.junit4.measureRepeated
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.simtop.beer_data.mappers.BeersMapper
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.core.core.DefaultLanguageProvider
+import com.simtop.core.core.NoOpLogger
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -13,6 +15,8 @@ import org.junit.runner.RunWith
 class BeersMapperBenchmark {
     @get:Rule
     val benchmarkRule = BenchmarkRule()
+
+    private val mapper = BeersMapper(DefaultLanguageProvider(), NoOpLogger())
 
     private val beer = Beer(
         id = "1",
@@ -28,7 +32,7 @@ class BeersMapperBenchmark {
     @Test
     fun benchmarkFromBeerToBeerDbModel() {
         benchmarkRule.measureRepeated {
-            BeersMapper.fromBeerToBeerDbModel(beer)
+            mapper.fromBeerToBeerDbModel(beer)
         }
     }
 }


### PR DESCRIPTION
`BeersMapper` became an `@Inject class` taking `LanguageProvider` and `Logger`, but `BeersMapperBenchmark` still called `BeersMapper.fromBeerToBeerDbModel(...)` statically. Nothing in the normal build or test flow compiles the microbenchmark androidTest source set, so the breakage was invisible until compiling it directly.

The benchmark now instantiates `BeersMapper(DefaultLanguageProvider(), NoOpLogger())`, and the module gains the missing `:core-common` dependency those types live in. Verified with `:benchmark:microbenchmark:compileReleaseAndroidTestSources`.
