### PR TITLE
Paging 2.0 Phase 0: header envelope + availability seeding

### DIFF
--- a/app/src/androidTest/java/com/simtop/billionbeers/di/LocalDataSourceTest2.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/di/LocalDataSourceTest2.kt
@@ -84,6 +84,24 @@ class LocalDataSourceTest {
       assertEquals(result[0].availability, false)
     }
   }
+
+  @Test
+  fun refreshSeedsAvailabilityOnFirstInsertButNeverOverwritesIt() {
+    runBlocking {
+      // First insert seeds availability from the (server-derived) fetched row.
+      val seeded = fakeDbBeerList[0].copy(availability = false)
+      localSource.insertAllToDB(listOf(seeded))
+      assertEquals(false, localSource.getAllBeersFromDB().first()[0].availability)
+
+      // A later refresh returns the same id flipped to available = true with a fresh name.
+      localSource.insertAllToDB(listOf(seeded.copy(availability = true, name = "Refreshed")))
+      val result = localSource.getAllBeersFromDB().first()
+
+      // Availability is authoritative locally and survives; the other columns still refresh.
+      assertEquals(false, result[0].availability)
+      assertEquals("Refreshed", result[0].name)
+    }
+  }
 }
 
 val fakeBeersApiResponseItem2 =

--- a/app/src/test/java/com/simtop/billionbeers/TestMockWebService.kt
+++ b/app/src/test/java/com/simtop/billionbeers/TestMockWebService.kt
@@ -43,8 +43,15 @@ abstract class TestMockWebService {
     mockServer.shutdown()
   }
 
-  open fun mockHttpResponse(fileName: String, responseCode: Int) =
-    mockServer.enqueue(MockResponse().setResponseCode(responseCode).setBody(getJson(fileName)))
+  open fun mockHttpResponse(
+    fileName: String,
+    responseCode: Int,
+    headers: Map<String, String> = emptyMap(),
+  ) {
+    val response = MockResponse().setResponseCode(responseCode).setBody(getJson(fileName))
+    headers.forEach { (name, value) -> response.addHeader(name, value) }
+    mockServer.enqueue(response)
+  }
 
   private fun getJson(filename: String): String {
     val resourcesDirectory = File("src/test/resources/json/${filename}")

--- a/app/src/test/java/com/simtop/billionbeers/data/BeersRemoteSourceTest.kt
+++ b/app/src/test/java/com/simtop/billionbeers/data/BeersRemoteSourceTest.kt
@@ -1,8 +1,9 @@
 package com.simtop.billionbeers.data
 
 import com.simtop.beer_network.fixtures.FAKE_JSON
-import com.simtop.beer_network.fixtures.fakeBeerApiResponse
+import com.simtop.beer_network.remotesources.BeersRemoteSourceImpl
 import com.simtop.billionbeers.TestMockWebService
+import com.simtop.core.core.LanguageProvider
 import java.net.HttpURLConnection
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeEqualTo
@@ -10,32 +11,40 @@ import org.junit.Test
 
 class BeersRemoteSourceTest : TestMockWebService() {
 
-  @Test
-  fun `when service succeeds we get a success response`() {
-    // Arrange
+  private val remoteSource by lazy { BeersRemoteSourceImpl(apiService, LanguageProvider { "en" }) }
 
-    val expectedResult = fakeBeerApiResponse
+  @Test
+  fun `returns the parsed body and total count from the X-Total-Count header`() {
+    mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_OK, mapOf("X-Total-Count" to "206"))
+
+    val page = runBlocking { remoteSource.getListOfBeers(1) }
+
+    page.items.map { it.id } shouldBeEqualTo listOf("1")
+    page.totalCount shouldBeEqualTo 206
+  }
+
+  @Test
+  fun `total count is null when the header is absent`() {
     mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_OK)
 
-    // Act
+    val page = runBlocking { remoteSource.getListOfBeers(1) }
 
-    val response = runBlocking { apiService.getListOfBeers(1) }
+    page.totalCount shouldBeEqualTo null
+  }
 
-    // Assert
+  @Test
+  fun `total count is null when the header is malformed`() {
+    mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_OK, mapOf("X-Total-Count" to "not-a-number"))
 
-    response.toString() shouldBeEqualTo expectedResult.toString()
+    val page = runBlocking { remoteSource.getListOfBeers(1) }
+
+    page.totalCount shouldBeEqualTo null
   }
 
   @Test(expected = Exception::class)
-  fun `when service fails succeeds we throw an exception`() {
-    // Arrange
-
+  fun `throws when the service fails`() {
     mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_UNAVAILABLE)
 
-    // Act
-
-    runBlocking { apiService.getListOfBeers(1) }
-
-    // Assert
+    runBlocking { remoteSource.getListOfBeers(1) }
   }
 }

--- a/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
@@ -31,6 +31,9 @@ constructor(private val languageProvider: LanguageProvider, private val logger: 
       abv = response?.abv ?: 0.0,
       ibu = response?.ibu ?: 0.0,
       foodPairing = response?.foodPairing ?: emptyList(),
+      // Seeds the row's initial availability on first insert only (the keyed upsert never rewrites
+      // availability for an existing id, so a user's later edit survives refresh).
+      availability = response?.available ?: true,
     )
   }
 

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
@@ -51,14 +51,14 @@ class BeersPagerFactoryImpl(private val repository: BeersRepository) : BeersPage
 }
 
 /**
- * Room-backed SSOT storage for the single full-catalog beers surface. Availability is a local-only
- * field (the API doesn't have it), so every write - refresh included - goes through the keyed
- * upsert that updates all columns *except* availability. Refresh deliberately never deletes rows: a
- * delete-and-reinsert would reset every locally edited availability back to the default. The
- * accepted trade-off is that beers removed server-side linger in the cache until the next
- * reinstall/clear-data. Because [storeFirstPage] merges instead of replacing, the factory pairs
- * this storage with a `nextKeyFromStorage` so the pager's position tracks the cache, not the
- * session.
+ * Room-backed SSOT storage for the single full-catalog beers surface. Availability is treated as a
+ * local-only field: the server's `available` only seeds a row on first insert, so every write -
+ * refresh included - goes through the keyed upsert that updates all columns *except* availability.
+ * Refresh deliberately never deletes rows: a delete-and-reinsert would reset every locally edited
+ * (or seeded) availability back to the default. The accepted trade-off is that beers removed
+ * server-side linger in the cache until the next reinstall/clear-data. Because [storeFirstPage]
+ * merges instead of replacing, the factory pairs this storage with a `nextKeyFromStorage` so the
+ * pager's position tracks the cache, not the session.
  *
  * Scoping: this storage owns the whole beers table only because the catalog list is the app's one
  * paged surface. A second, differently-filtered paged surface (search, favorites) must get its own

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
@@ -24,7 +24,9 @@ class BeersRepositoryImpl(
 ) : BeersRepository {
 
   override suspend fun getListOfBeerFromApi(page: Int): List<Beer> =
-    beersRemoteSource.getListOfBeers(page).map { beersMapper.fromBeersApiResponseItemToBeer(it) }
+    beersRemoteSource.getListOfBeers(page).items.map {
+      beersMapper.fromBeersApiResponseItemToBeer(it)
+    }
 
   @Suppress("TooGenericExceptionCaught")
   override suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit> {

--- a/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersRemoteSource.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersRemoteSource.kt
@@ -1,18 +1,21 @@
 package com.simtop.beer_data.fakes
 
 import com.simtop.beer_network.models.BeersApiResponseItem
+import com.simtop.beer_network.models.BeersPage
 import com.simtop.beer_network.remotesources.BeersRemoteSource
 
 class FakeBeersRemoteSource : BeersRemoteSource {
 
   private var beersResponse: List<BeersApiResponseItem> = emptyList()
+  private var totalCount: Int? = null
   private var shouldThrowError = false
   private var exceptionToThrow: Exception = Exception("Fake Remote Error")
 
   val requestedPages = mutableListOf<Int>()
 
-  fun setBeersResponse(beers: List<BeersApiResponseItem>) {
+  fun setBeersResponse(beers: List<BeersApiResponseItem>, totalCount: Int? = null) {
     beersResponse = beers
+    this.totalCount = totalCount
   }
 
   fun setShouldThrowError(
@@ -23,11 +26,11 @@ class FakeBeersRemoteSource : BeersRemoteSource {
     exceptionToThrow = exception
   }
 
-  override suspend fun getListOfBeers(page: Int): List<BeersApiResponseItem> {
+  override suspend fun getListOfBeers(page: Int): BeersPage {
     requestedPages += page
     if (shouldThrowError) {
       throw exceptionToThrow
     }
-    return beersResponse
+    return BeersPage(items = beersResponse, totalCount = totalCount)
   }
 }

--- a/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
@@ -138,6 +138,20 @@ class BeersMapperTest {
   }
 
   @Test
+  fun `fromBeersApiResponseItemToBeer seeds availability from the server available field`() {
+    val beer = mapper.fromBeersApiResponseItemToBeer(fullResponse().copy(available = false))
+
+    expectThat(beer.availability).isEqualTo(false)
+  }
+
+  @Test
+  fun `fromBeersApiResponseItemToBeer defaults availability to true when available is absent`() {
+    val beer = mapper.fromBeersApiResponseItemToBeer(fullResponse().copy(available = null))
+
+    expectThat(beer.availability).isEqualTo(true)
+  }
+
+  @Test
   fun `fromBeerToBeerDbModel converts a Beer into a BeerDbModel`() {
     val beer =
       Beer(

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -39,8 +39,9 @@ class BeersPagerFactoryImplTest {
     factory = BeersPagerFactoryImpl(repository)
   }
 
-  // Regression test: availability only exists locally (the API has no such field), so a
-  // pull-to-refresh re-delivering the same beers must not reset a locally edited availability.
+  // Regression test: availability is treated as local-only (the server value only seeds first
+  // insert), so a pull-to-refresh re-delivering the same beers must not reset a locally edited
+  // value.
   @Test
   fun `refresh keeps locally edited availability`() =
     runTest(testDispatcher) {

--- a/beer_database/src/main/java/com/simtop/beer_database/database/BeersDao.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/database/BeersDao.kt
@@ -19,8 +19,9 @@ abstract class BeersDao {
   //    @Insert(onConflict = OnConflictStrategy.REPLACE)
   //    abstract suspend fun insertAll(beers: List<BeerDbModel>)
 
-  // More complex update to handle pull to refresh doesn't affect to availability field
-  // which doesn't come from the network
+  // Pull-to-refresh update that deliberately omits the availability column: the server's
+  // `available`
+  // only seeds a row on first insert, and a user's later edit is authoritative and must survive.
   @Query(
     """
         UPDATE beers

--- a/beer_database/src/main/java/com/simtop/beer_database/localsources/BeersLocalSource.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/localsources/BeersLocalSource.kt
@@ -9,8 +9,9 @@ interface BeersLocalSource {
   fun getAllBeersFromDB(): Flow<List<BeerDbModel>>
 
   /**
-   * Keyed upsert: new ids are inserted; existing ids get every column updated *except*
-   * `availability`, which is local-only (the API has no such field) and must survive refreshes. See
+   * Keyed upsert: new ids are inserted (their `availability` seeded from the fetched row); existing
+   * ids get every column updated *except* `availability`, which is treated as local-only and must
+   * survive refreshes. The server's `available` field therefore only seeds first inserts. See
    * [com.simtop.beer_database.database.BeersDao.insertAll].
    */
   suspend fun insertAllToDB(beers: List<BeerDbModel>)

--- a/beer_network/src/main/java/com/simtop/beer_network/models/BeersApiResponseItem.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/models/BeersApiResponseItem.kt
@@ -10,6 +10,9 @@ data class BeersApiResponseItem(
   val abv: Double? = null,
   val ibu: Double? = null,
   val image: EmbeddedImage? = null,
+  // Only ever seeds a row's initial availability on first insert; the local edit stays
+  // authoritative.
+  val available: Boolean? = null,
   val translations: List<Translation>? = null,
   @SerialName("food_pairing") val foodPairing: List<String>? = null,
 )

--- a/beer_network/src/main/java/com/simtop/beer_network/models/BeersPage.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/models/BeersPage.kt
@@ -1,0 +1,9 @@
+package com.simtop.beer_network.models
+
+/**
+ * Remote paging envelope: the fetched items plus the server's total-count header.
+ *
+ * [totalCount] is nullable on purpose — the pager must keep working if `X-Total-Count` ever
+ * disappears or arrives malformed, falling back to the empty-page probe for end detection.
+ */
+data class BeersPage(val items: List<BeersApiResponseItem>, val totalCount: Int?)

--- a/beer_network/src/main/java/com/simtop/beer_network/network/BeersService.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/network/BeersService.kt
@@ -1,16 +1,18 @@
 package com.simtop.beer_network.network
 
 import com.simtop.beer_network.models.BeersApiResponseItem
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface BeersService {
+  // Returns Response<…> so the remote source can read the X-Total-Count header, not just the body.
   @GET("beers")
   suspend fun getListOfBeers(
     @Query("_page") page: Int,
     @Query("_limit") perPage: Int = DEFAULT_ITEMS_PER_PAGE,
     @Query("translations.language.code") languageCode: String = DEFAULT_LANGUAGE_CODE,
-  ): List<BeersApiResponseItem>
+  ): Response<List<BeersApiResponseItem>>
 
   companion object {
     const val DEFAULT_ITEMS_PER_PAGE = 25

--- a/beer_network/src/main/java/com/simtop/beer_network/remotesources/BeersRemoteSource.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/remotesources/BeersRemoteSource.kt
@@ -1,12 +1,12 @@
 package com.simtop.beer_network.remotesources
 
-import com.simtop.beer_network.models.BeersApiResponseItem
+import com.simtop.beer_network.models.BeersPage
 import com.simtop.beer_network.network.BeersService
 import com.simtop.core.core.LanguageProvider
 import dev.zacsweers.metro.Inject
 
 interface BeersRemoteSource {
-  suspend fun getListOfBeers(page: Int): List<BeersApiResponseItem>
+  suspend fun getListOfBeers(page: Int): BeersPage
 }
 
 class BeersRemoteSourceImpl
@@ -14,10 +14,15 @@ class BeersRemoteSourceImpl
 constructor(private val service: BeersService, private val languageProvider: LanguageProvider) :
   BeersRemoteSource {
 
-  override suspend fun getListOfBeers(page: Int): List<BeersApiResponseItem> {
-    return service.getListOfBeers(
-      page = page,
-      languageCode = languageProvider.currentLanguageCode(),
-    )
+  override suspend fun getListOfBeers(page: Int): BeersPage {
+    val response =
+      service.getListOfBeers(page = page, languageCode = languageProvider.currentLanguageCode())
+    // Malformed or absent header → null; the pager falls back to the empty-page probe.
+    val totalCount = response.headers()[HEADER_TOTAL_COUNT]?.toIntOrNull()
+    return BeersPage(items = response.body().orEmpty(), totalCount = totalCount)
+  }
+
+  private companion object {
+    const val HEADER_TOTAL_COUNT = "X-Total-Count"
   }
 }

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -21,8 +21,9 @@ interface BeersRepository {
 
   /**
    * Keyed upsert: rows are inserted, or updated column-by-column if the id already exists.
-   * [Beer.availability] is local-only (the API has no such field), so an upsert of freshly fetched
-   * beers never overwrites a locally edited availability.
+   * [Beer.availability] is treated as local-only: the server does expose an `available` field, but
+   * it only *seeds* a row's initial value on first insert. An upsert of freshly fetched beers never
+   * overwrites the availability of an existing id, so a locally edited value stays authoritative.
    */
   suspend fun insertAllToDB(beers: List<Beer>)
 


### PR DESCRIPTION
Phase 0 groundwork for Paging 2.0 (`rod/PAGING_2_0.md`), grounded in the 2026-07-11 live API audit. §4.1 (N+1 removal) already landed separately; this PR is the Phase 0 remainder. Two independent commits, disjoint file sets.

## §4.3 — Expose `X-Total-Count` via a typed `BeersPage` envelope
- `BeersService.getListOfBeers` now returns `Response<List<…>>` so the remote source can read headers.
- `BeersRemoteSource` parses `X-Total-Count` into `BeersPage(items, totalCount)`.
- `totalCount` is **nullable by design** — if the header ever vanishes or is malformed, the pager falls back to the empty-page probe. It is **not** threaded into the domain yet; consuming it (`PageResult` → `PagingState.Success(totalCount)`) is Phase 1.
- Tests: MockWebServer coverage for the header **present / absent / garbage** cases (§7.5).

## §4.2 — Seed `available` from the server on first insert only
- The live API **does** expose `available` (present on all 206 beers; **64 are `false`** — previously mislabeled available by the hardcoded `true`).
- `BeersApiResponseItem` gains `available`; `BeersMapper` seeds `Beer.availability` from it (falling back to `true`).
- The keyed upsert already omits `availability` for existing ids, so **only first inserts are seeded and a user's later edit stays authoritative**.
- Corrects the now-false "the API has no such field" claims across the repository / DAO / local source / pager KDoc.
- Tests: mapper unit tests for the seed + an **instrumented** test asserting a refresh never overwrites a seeded/edited availability.

## Filter verification (no code)
`typology.id=` / `brewery.id=` verified live (§5.3 caveat cleared): both filter correctly, `X-Total-Count` matches the walked count, and a bogus UUID returns `0` (param honored, not silently ignored) — Phase 3 browse can rely on them.

## Verification
`make test` and `make lint` green. The instrumented `LocalDataSourceTest` class passes 6/6 on an emulator. No UI changes, so no screenshot tests.