### PR TITLE
feat: server-driven end detection via PageResult + totalCount (Paging 2.0 1a)

### DIFF
--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
@@ -5,6 +5,7 @@ import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.core.core.PageResult
 import com.simtop.core.core.Pager
 import com.simtop.core.core.PagingMediator
 import com.simtop.core.core.PagingStorage
@@ -20,8 +21,16 @@ class BeersPagerFactoryImpl(private val repository: BeersRepository) : BeersPage
   override fun create(): Pager<Beer, FetchBeersError> =
     PagingMediator(
       initialKey = FIRST_PAGE,
-      nextKey = { currentKey, _ -> currentKey + 1 },
-      fetchRemote = { page -> repository.getListOfBeerFromApi(page) },
+      fetchRemote = { page ->
+        val beerPage = repository.getBeersPageFromApi(page)
+        // With a known total we can end exactly (no wasted empty fetch); without it, keep advancing
+        // and let the mediator's empty-page probe find the end.
+        val total = beerPage.totalCount
+        val nextKey =
+          if (total != null && page * BeersService.DEFAULT_ITEMS_PER_PAGE >= total) null
+          else page + 1
+        PageResult(items = beerPage.items, nextKey = nextKey, totalCount = total)
+      },
       classifyError = { it.toFetchBeersError() },
       storage = BeersPagingStorage(repository),
       // The Room cache both outlives this pager (warm launch) and survives refresh (the storage

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.simtop.beer_database.localsources.BeersLocalSource
 import com.simtop.beer_network.remotesources.BeersRemoteSource
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeerPage
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.Either
 import dev.zacsweers.metro.AppScope
@@ -23,10 +24,13 @@ class BeersRepositoryImpl(
   private val beersMapper: BeersMapper,
 ) : BeersRepository {
 
-  override suspend fun getListOfBeerFromApi(page: Int): List<Beer> =
-    beersRemoteSource.getListOfBeers(page).items.map {
-      beersMapper.fromBeersApiResponseItemToBeer(it)
-    }
+  override suspend fun getBeersPageFromApi(page: Int): BeerPage {
+    val remotePage = beersRemoteSource.getListOfBeers(page)
+    return BeerPage(
+      items = remotePage.items.map { beersMapper.fromBeersApiResponseItemToBeer(it) },
+      totalCount = remotePage.totalCount,
+    )
+  }
 
   @Suppress("TooGenericExceptionCaught")
   override suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit> {

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -55,7 +55,7 @@ class BeersPagerFactoryImplTest {
       pager.loadFirstPage() // pull-to-refresh: same server payload, no availability in it
 
       expectThat(repository.getBeerById("1")?.availability).isEqualTo(false)
-      expectThat(pager.pagingState.value).isEqualTo(PagingState.Success)
+      expectThat(pager.pagingState.value).isEqualTo(PagingState.Success())
     }
 
   @Test
@@ -117,7 +117,7 @@ class BeersPagerFactoryImplTest {
 
       first.loadFirstPage()
 
-      expectThat(first.pagingState.value).isEqualTo(PagingState.Success)
+      expectThat(first.pagingState.value).isEqualTo(PagingState.Success())
       expectThat(second.pagingState.value).isEqualTo(PagingState.Idle)
     }
 

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
@@ -35,7 +35,7 @@ class BeersRepositoryTest {
   }
 
   @Test
-  fun `getListOfBeerFromApi maps beers using the embedded image url without a second request`() =
+  fun `getBeersPageFromApi maps beers with the embedded image url and carries the total count`() =
     runTest(testDispatcher) {
       // Arrange
       val remoteBeer =
@@ -48,15 +48,16 @@ class BeersRepositoryTest {
           translations = emptyList(),
           foodPairing = emptyList(),
         )
-      beersRemoteSource.setBeersResponse(listOf(remoteBeer))
+      beersRemoteSource.setBeersResponse(listOf(remoteBeer), totalCount = 206)
 
       // Act
-      val result = beersRepository.getListOfBeerFromApi(1)
+      val result = beersRepository.getBeersPageFromApi(1)
 
-      // Assert: the embedded url is used, and only the single list request was made.
-      expectThat(result.size).isEqualTo(1)
-      expectThat(result[0].id).isEqualTo("3")
-      expectThat(result[0].imageUrl).isEqualTo("https://embedded.url/image.jpg")
+      // Assert: the embedded url is used, the total count flows through, one request only.
+      expectThat(result.items.size).isEqualTo(1)
+      expectThat(result.items[0].id).isEqualTo("3")
+      expectThat(result.items[0].imageUrl).isEqualTo("https://embedded.url/image.jpg")
+      expectThat(result.totalCount).isEqualTo(206)
       expectThat(beersRemoteSource.requestedPages.toList()).isEqualTo(listOf(1))
     }
 

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/BeerPage.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/BeerPage.kt
@@ -1,0 +1,8 @@
+package com.simtop.beerdomain.domain.models
+
+/**
+ * A page of beers fetched from the API plus the server-reported total ([totalCount], from
+ * `X-Total-Count`). [totalCount] is nullable: the pager keeps working without it (empty-page
+ * probe), and the UI can render "N of [totalCount]" when present.
+ */
+data class BeerPage(val items: List<Beer>, val totalCount: Int?)

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -2,6 +2,7 @@ package com.simtop.beerdomain.domain.repositories
 
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeerPage
 import com.simtop.core.core.Either
 import kotlinx.coroutines.flow.Flow
 
@@ -29,5 +30,6 @@ interface BeersRepository {
 
   suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit>
 
-  suspend fun getListOfBeerFromApi(page: Int): List<Beer>
+  /** Fetches one page from the API, carrying the server total for end-detection and "N of M" UI. */
+  suspend fun getBeersPageFromApi(page: Int): BeerPage
 }

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
@@ -2,6 +2,7 @@ package com.simtop.beerdomain.fakes
 
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeerPage
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.Either
 import kotlinx.coroutines.flow.Flow
@@ -70,7 +71,9 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
     return Either.Right(Unit)
   }
 
-  override suspend fun getListOfBeerFromApi(page: Int): List<Beer> {
-    return emptyList()
+  var apiPage: BeerPage = BeerPage(emptyList(), null)
+
+  override suspend fun getBeersPageFromApi(page: Int): BeerPage {
+    return apiPage
   }
 }

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
@@ -16,7 +16,12 @@ sealed class PagingState<out E : Any> {
 
   data object LoadingNextPage : PagingState<Nothing>()
 
-  data object Success : PagingState<Nothing>()
+  /**
+   * A page loaded successfully. [totalCount] is the server-reported size of the whole result (from
+   * `X-Total-Count`), or null when the server didn't report it - the UI can render "N of
+   * [totalCount]".
+   */
+  data class Success(val totalCount: Int? = null) : PagingState<Nothing>()
 
   /**
    * A page failed to load. [isFirstPage] tells the UI which affordance fits: a full-screen error
@@ -26,6 +31,19 @@ sealed class PagingState<out E : Any> {
 
   data object EndOfPagination : PagingState<Nothing>()
 }
+
+/**
+ * One fetched page. The fetch owns key math now (it has the server headers): [nextKey] is the key
+ * of the page after this one, or null if this is the last page - letting the mediator end
+ * pagination *without* a wasted known-empty fetch. [totalCount] carries `X-Total-Count` through to
+ * [PagingState.Success]; both stay nullable so a header-less server falls back to the empty-page
+ * probe.
+ */
+data class PageResult<Key : Any, Value : Any>(
+  val items: List<Value>,
+  val nextKey: Key?,
+  val totalCount: Int? = null,
+)
 
 /**
  * What a screen needs from a paginated source: the accumulated [data], the load [pagingState], and
@@ -107,8 +125,10 @@ class InMemoryPagingStorage<Value : Any> : PagingStorage<Value> {
  * ```kotlin
  * val pager: Pager<Beer, FetchBeersError> = PagingMediator(
  *   initialKey = 1,
- *   nextKey = { key, page -> if (page.size < PAGE_SIZE) null else key + 1 },
- *   fetchRemote = { page -> api.getBeers(page) },
+ *   fetchRemote = { page ->
+ *     val res = api.getBeers(page) // items + X-Total-Count
+ *     PageResult(res.items, nextKey = if (page * PAGE_SIZE >= res.total) null else page + 1, res.total)
+ *   },
  *   classifyError = { it.toFetchBeersError() },
  *   storage = roomBackedStorage, // omit for in-memory paging
  * )
@@ -118,6 +138,8 @@ class InMemoryPagingStorage<Value : Any> : PagingStorage<Value> {
  * @param Value The type of the data being paged.
  * @param E The caller's typed error for a failed load, produced from the caught [Throwable] by
  *   [classifyError] - callers get to `when` over real failure modes instead of a raw message.
+ * @param fetchRemote Fetches a page and returns a [PageResult]: the items plus the caller-computed
+ *   [PageResult.nextKey] (null ends pagination with no extra fetch) and optional total count.
  * @param nextKeyFromStorage Derives the key of the first page *not yet represented in [storage]*
  *   from what storage currently holds (e.g. `rowCount / pageSize + 1`). Required whenever the
  *   storage outlives the pager (a warm cache) or [PagingStorage.storeFirstPage] merges instead of
@@ -130,8 +152,7 @@ class InMemoryPagingStorage<Value : Any> : PagingStorage<Value> {
  */
 class PagingMediator<Key : Any, Value : Any, E : Any>(
   private val initialKey: Key,
-  private val nextKey: (currentKey: Key, lastPage: List<Value>) -> Key?,
-  private val fetchRemote: suspend (key: Key) -> List<Value>,
+  private val fetchRemote: suspend (key: Key) -> PageResult<Key, Value>,
   private val classifyError: (Throwable) -> E,
   private val storage: PagingStorage<Value> = InMemoryPagingStorage(),
   private val nextKeyFromStorage: (suspend () -> Key)? = null,
@@ -184,10 +205,14 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
     try {
       _pagingState.value = if (isFirstPage) PagingState.Loading else PagingState.LoadingNextPage
 
-      val page = fetchRemote(key)
-      if (isFirstPage) storage.storeFirstPage(page) else if (page.isNotEmpty()) storage.append(page)
+      val result = fetchRemote(key)
+      val items = result.items
+      if (isFirstPage) storage.storeFirstPage(items)
+      else if (items.isNotEmpty()) storage.append(items)
 
-      if (page.isEmpty()) {
+      // Empty-page probe: the fallback end signal when the server reports no total (nextKey stays
+      // non-null) - preserves the pre-2.0 behaviour for a header-less backend.
+      if (items.isEmpty()) {
         endPagination()
         return
       }
@@ -195,15 +220,11 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
       // After a first-page store the storage - not the fetched page - is the authority on
       // position: a merging storage may still hold pages beyond the one just fetched.
       currentKey =
-        if (isFirstPage) {
-          nextKeyFromStorage?.invoke() ?: nextKey(key, page)
-        } else {
-          nextKey(key, page)
-        }
+        if (isFirstPage) nextKeyFromStorage?.invoke() ?: result.nextKey else result.nextKey
       if (currentKey == null) {
         endPagination()
       } else {
-        _pagingState.value = PagingState.Success
+        _pagingState.value = PagingState.Success(result.totalCount)
       }
     } catch (e: CancellationException) {
       throw e

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
@@ -50,12 +50,12 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { current, _ -> current + 1 },
         fetchRemote = { key ->
           fetchedKeys += key
           storage.events += "fetch $key"
           if (key in failOn) throw RuntimeException("fetch $key failed")
-          pages(key)
+          val items = pages(key)
+          PageResult(items, nextKey = if (items.isEmpty()) null else key + 1)
         },
         classifyError = { it.message ?: "unknown" },
         storage = storage,
@@ -76,7 +76,7 @@ class PagingMediatorTest {
       harness.mediator.loadFirstPage()
 
       assertEquals(PagingState.Loading, awaitItem())
-      assertEquals(PagingState.Success, awaitItem())
+      assertEquals(PagingState.Success(), awaitItem())
     }
     assertEquals(listOf("item 1"), harness.storage.stored.value)
   }
@@ -87,12 +87,12 @@ class PagingMediatorTest {
     harness.mediator.loadFirstPage()
 
     harness.mediator.pagingState.test {
-      assertEquals(PagingState.Success, awaitItem())
+      assertEquals(PagingState.Success(), awaitItem())
 
       harness.mediator.loadNextPage()
 
       assertEquals(PagingState.LoadingNextPage, awaitItem())
-      assertEquals(PagingState.Success, awaitItem())
+      assertEquals(PagingState.Success(), awaitItem())
     }
     assertEquals(listOf("item 1", "item 2"), harness.storage.stored.value)
   }
@@ -157,8 +157,8 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { _, lastPage -> if (lastPage.size < 2) null else 2 },
-        fetchRemote = { listOf("only item") }, // short page: fewer items than page size
+        // Short page with an explicit null nextKey: ends without a wasted empty-page fetch.
+        fetchRemote = { PageResult(listOf("only item"), nextKey = null) },
         classifyError = { "unused" },
         storage = storage,
       )
@@ -177,7 +177,7 @@ class PagingMediatorTest {
 
     harness.mediator.loadFirstPage()
 
-    assertEquals(PagingState.Success, harness.mediator.pagingState.value)
+    assertEquals(PagingState.Success(), harness.mediator.pagingState.value)
     assertEquals(listOf(1, 2, 1), harness.fetchedKeys)
   }
 
@@ -188,11 +188,10 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { current, _ -> current + 1 },
         fetchRemote = {
           fetchCount++
           gate.await()
-          listOf("item")
+          PageResult(listOf("item"), nextKey = 2)
         },
         classifyError = { "unused" },
       )
@@ -206,7 +205,7 @@ class PagingMediatorTest {
     advanceUntilIdle()
 
     assertEquals(1, fetchCount)
-    assertEquals(PagingState.Success, mediator.pagingState.value)
+    assertEquals(PagingState.Success(), mediator.pagingState.value)
   }
 
   @Test
@@ -215,7 +214,6 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { current, _ -> current + 1 },
         fetchRemote = { throw CancellationException("cancelled") },
         classifyError = {
           classified = true
@@ -301,10 +299,9 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { current, _ -> current + 1 },
         fetchRemote = { key ->
           fetchedKeys += key
-          listOf("item $key")
+          PageResult(listOf("item $key"), nextKey = key + 1)
         },
         classifyError = { "unused" },
         nextKeyFromStorage = { 4 }, // e.g. three full pages already sit in storage
@@ -322,10 +319,9 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { current, _ -> current + 1 },
         fetchRemote = { key ->
           fetchedKeys += key
-          listOf("item $key")
+          PageResult(listOf("item $key"), nextKey = key + 1)
         },
         classifyError = { "unused" },
         nextKeyFromStorage = { 2 }, // in-memory default storage: one page stored after first load
@@ -344,10 +340,9 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { current, _ -> current + 1 },
         fetchRemote = { key ->
           fetchedKeys += key
-          listOf("item $key")
+          PageResult(listOf("item $key"), nextKey = key + 1)
         },
         classifyError = { "unused" },
         storage = storage,
@@ -370,10 +365,9 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { current, _ -> current + 1 },
         fetchRemote = { key ->
           fetchedKeys += key
-          listOf("item $key")
+          PageResult(listOf("item $key"), nextKey = key + 1)
         },
         classifyError = { it.message ?: "unknown" },
         nextKeyFromStorage = {
@@ -399,8 +393,10 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { current, _ -> current + 1 },
-        fetchRemote = { page -> if (refreshed) listOf("new $page") else listOf("item $page") },
+        fetchRemote = { page ->
+          val items = if (refreshed) listOf("new $page") else listOf("item $page")
+          PageResult(items, nextKey = page + 1)
+        },
         classifyError = { "unused" },
       )
 
@@ -425,13 +421,12 @@ class PagingMediatorTest {
     val mediator =
       PagingMediator<Int, String, String>(
         initialKey = 1,
-        nextKey = { current, _ -> current + 1 },
-        fetchRemote = {
+        fetchRemote = { page ->
           if (isFirstCall) {
             isFirstCall = false
-            listOf("stale")
+            PageResult(listOf("stale"), nextKey = page + 1)
           } else {
-            emptyList()
+            PageResult(emptyList(), nextKey = null)
           }
         },
         classifyError = { "unused" },

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -126,15 +126,25 @@ fun BeersListContent(
     topBar = {
       TopAppBar(
         title = {
-          Text(
-            text = stringResource(R.string.billion_beers_list),
-            // Long-press reveals the debug drawer's floating trigger - see LocalDebugDrawerToggle.
-            // Only clickable when a debug host provides a toggle; release keeps a plain label.
-            modifier =
-              toggleDebugDrawer?.let { toggle ->
-                Modifier.combinedClickable(onClick = {}, onLongClick = toggle)
-              } ?: Modifier,
-          )
+          // The label is clickable to reveal the debug drawer; the count line only appears once the
+          // server total is known, so states without a total render exactly as before.
+          val titleModifier =
+            toggleDebugDrawer?.let { toggle ->
+              Modifier.combinedClickable(onClick = {}, onLongClick = toggle)
+            } ?: Modifier
+          val loaded = (viewState as? CommonUiState.Success)?.data
+          val total = loaded?.totalCount
+          if (total != null) {
+            Column(modifier = titleModifier) {
+              Text(text = stringResource(R.string.billion_beers_list))
+              Text(
+                text = stringResource(R.string.beers_count_of_total, loaded.beers.size, total),
+                style = MaterialTheme.typography.labelMedium,
+              )
+            }
+          } else {
+            Text(text = stringResource(R.string.billion_beers_list), modifier = titleModifier)
+          }
         }
       )
     },

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
@@ -34,6 +34,10 @@ class BeersListViewModel(
   // the app-scoped repository stays a stateless data accessor.
   private val pager = beersPagerFactory.create()
 
+  // Last server-reported total (X-Total-Count). Lives here, not only in the UI model, so a beers
+  // emission that arrives before/after a Success can still render "N of total".
+  private var lastTotalCount: Int? = null
+
   private val _beerListViewState =
     MutableStateFlow<CommonUiState<BeersListUiModel>>(CommonUiState.Loading)
   val beerListViewState: StateFlow<CommonUiState<BeersListUiModel>> =
@@ -58,7 +62,18 @@ class BeersListViewModel(
           } else {
             currentState
           }
-        is PagingState.Success,
+        is PagingState.Success ->
+          if (currentUiModel != null) {
+            CommonUiState.Success(
+              currentUiModel.copy(
+                isLoadingNextPage = false,
+                isRefreshing = false,
+                totalCount = pagingState.totalCount ?: currentUiModel.totalCount,
+              )
+            )
+          } else {
+            currentState
+          }
         is PagingState.EndOfPagination ->
           if (currentUiModel != null) {
             CommonUiState.Success(
@@ -125,6 +140,7 @@ class BeersListViewModel(
                 isRefreshing =
                   if (currentState is CommonUiState.Success) currentState.data.isRefreshing
                   else false,
+                totalCount = lastTotalCount,
               )
             )
         }
@@ -134,7 +150,12 @@ class BeersListViewModel(
 
   private fun observePaging() {
     pager.pagingState
-      .onEach { pagingState -> pagingHandler.handlePagingState(pagingState) }
+      .onEach { pagingState ->
+        if (pagingState is PagingState.Success) {
+          pagingState.totalCount?.let { lastTotalCount = it }
+        }
+        pagingHandler.handlePagingState(pagingState)
+      }
       .launchIn(viewModelScope)
   }
 
@@ -151,4 +172,7 @@ data class BeersListUiModel(
   val beers: List<Beer> = emptyList(),
   val isLoadingNextPage: Boolean = false,
   val isRefreshing: Boolean = false,
+  // Server-reported catalog size (X-Total-Count); null until the server reports it. Renders "N of
+  // M".
+  val totalCount: Int? = null,
 )

--- a/feature/beerslist/src/main/res/values-es/strings.xml
+++ b/feature/beerslist/src/main/res/values-es/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="billion_beers_list">"Lista de mil millones de cervezas"</string>
+    <string name="beers_count_of_total">%1$d de %2$d</string>
 </resources>

--- a/feature/beerslist/src/main/res/values-fr/strings.xml
+++ b/feature/beerslist/src/main/res/values-fr/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="billion_beers_list">"Liste de milliards de bières"</string>
+    <string name="beers_count_of_total">%1$d sur %2$d</string>
 </resources>

--- a/feature/beerslist/src/main/res/values/strings.xml
+++ b/feature/beerslist/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="billion_beers_list">"Billion Beers List"</string>
+    <string name="beers_count_of_total">%1$d of %2$d</string>
 </resources>

--- a/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
+++ b/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
@@ -83,12 +83,29 @@ class BeersListViewModelTest {
         expectThat((loadingNextPageState as CommonUiState.Success).data.isLoadingNextPage).isTrue()
 
         // Simulate PagingState Success
-        pager.setPagingState(PagingState.Success)
+        pager.setPagingState(PagingState.Success())
 
         // Expect update with isLoadingNextPage = false
         val finalState = awaitItem()
         expectThat(finalState).isA<CommonUiState.Success<BeersListUiModel>>()
         expectThat((finalState as CommonUiState.Success).data.isLoadingNextPage).isFalse()
+      }
+    }
+
+  @Test
+  fun `totalCount reported by Success is exposed on the ui model for N of M`() =
+    runTest(testDispatcher) {
+      fakeBeersRepository.setBeers(listOf(Beer.empty.copy(id = "1")))
+      val viewModel = buildViewModel()
+      val pager = fakeBeersPagerFactory.pager
+
+      viewModel.beerListViewState.test {
+        expectThat(awaitItem()).isA<CommonUiState.Success<BeersListUiModel>>()
+
+        pager.setPagingState(PagingState.Success(totalCount = 206))
+
+        val state = awaitItem()
+        expectThat((state as CommonUiState.Success).data.totalCount).isEqualTo(206)
       }
     }
 
@@ -129,7 +146,7 @@ class BeersListViewModelTest {
         expectThat(refreshing).isA<CommonUiState.Success<BeersListUiModel>>()
         expectThat((refreshing as CommonUiState.Success).data.isRefreshing).isTrue()
 
-        pager.setPagingState(PagingState.Success)
+        pager.setPagingState(PagingState.Success())
 
         val done = awaitItem()
         expectThat(done).isA<CommonUiState.Success<BeersListUiModel>>()


### PR DESCRIPTION
Paging 2.0 sub-PR 1a: server-driven end-of-pagination + "N of M".

The pager stops guessing where the catalog ends. `PagingMediator.fetchRemote` now
returns `PageResult(items, nextKey, totalCount)` instead of a bare list, so the
fetch — the only layer that sees the `X-Total-Count` header — owns key math: a null
`nextKey` ends pagination immediately, without the wasted known-empty fetch the old
"probe past the end" approach required. A header-less backend still works: `nextKey`
stays non-null and the empty-page probe remains the fallback end signal.

`PagingState.Success` now carries the total, threaded through the view model to the
beers list header as "N of 206". It renders only when the total is known, so any
state without a total (previews, header-less servers) is visually unchanged — the
Paparazzi baselines are untouched.

Data layer: `BeersRepository.getBeersPageFromApi(page): BeerPage(items, totalCount)`
replaces the bare-list fetch.

First slice of Phase 1; 1b–1d (paging_state table + migration, events channel +
footer + rate-limit handling, contract test) follow.
