### PR TITLE
feat: persist paging position in a paging_state table (Paging 2.0 1b)

### DIFF
--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
@@ -40,7 +40,8 @@ class BeersPagerFactoryImpl(
       },
       classifyError = { it.toFetchBeersError() },
       storage = BeersPagingStorage(repository, surface),
-      // Exact resume: the paging_state bookmark records the first uncached page, written in the same
+      // Exact resume: the paging_state bookmark records the first uncached page, written in the
+      // same
       // transaction as the rows. It falls back to the row-count estimate (N fully cached pages ->
       // page N+1) only when no bookmark exists yet - a fresh install, or a cache written before
       // paging_state existed (the v1->v2 migration gap). Either way "load more" resumes after

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
@@ -5,6 +5,7 @@ import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.core.core.LanguageProvider
 import com.simtop.core.core.PageResult
 import com.simtop.core.core.Pager
 import com.simtop.core.core.PagingMediator
@@ -16,10 +17,16 @@ import kotlinx.coroutines.flow.Flow
 import retrofit2.HttpException
 
 @Inject
-class BeersPagerFactoryImpl(private val repository: BeersRepository) : BeersPagerFactory {
+class BeersPagerFactoryImpl(
+  private val repository: BeersRepository,
+  private val languageProvider: LanguageProvider,
+) : BeersPagerFactory {
 
-  override fun create(): Pager<Beer, FetchBeersError> =
-    PagingMediator(
+  override fun create(): Pager<Beer, FetchBeersError> {
+    // One paged surface, keyed by language so a future language switch can invalidate it (Phase 4);
+    // for now the key just scopes the bookmark. Read (resume) and write (store) share this value.
+    val surface = CATALOG_SURFACE_PREFIX + languageProvider.currentLanguageCode()
+    return PagingMediator(
       initialKey = FIRST_PAGE,
       fetchRemote = { page ->
         val beerPage = repository.getBeersPageFromApi(page)
@@ -32,15 +39,18 @@ class BeersPagerFactoryImpl(private val repository: BeersRepository) : BeersPage
         PageResult(items = beerPage.items, nextKey = nextKey, totalCount = total)
       },
       classifyError = { it.toFetchBeersError() },
-      storage = BeersPagingStorage(repository),
-      // The Room cache both outlives this pager (warm launch) and survives refresh (the storage
-      // upserts, never deletes). Either way the next unseen page comes after everything cached -
-      // N fully cached pages mean page N+1 - otherwise "load more" would silently re-fetch every
-      // cached page over the network before the list could grow.
+      storage = BeersPagingStorage(repository, surface),
+      // Exact resume: the paging_state bookmark records the first uncached page, written in the same
+      // transaction as the rows. It falls back to the row-count estimate (N fully cached pages ->
+      // page N+1) only when no bookmark exists yet - a fresh install, or a cache written before
+      // paging_state existed (the v1->v2 migration gap). Either way "load more" resumes after
+      // everything cached instead of silently re-fetching cached pages over the network.
       nextKeyFromStorage = {
-        repository.countDBEntries() / BeersService.DEFAULT_ITEMS_PER_PAGE + FIRST_PAGE
+        repository.pagingNextKey(surface)
+          ?: (repository.countDBEntries() / BeersService.DEFAULT_ITEMS_PER_PAGE + FIRST_PAGE)
       },
     )
+  }
 
   private fun Throwable.toFetchBeersError(): FetchBeersError =
     when (this) {
@@ -56,6 +66,7 @@ class BeersPagerFactoryImpl(private val repository: BeersRepository) : BeersPage
 
   private companion object {
     const val FIRST_PAGE = 1
+    const val CATALOG_SURFACE_PREFIX = "catalog:"
   }
 }
 
@@ -74,11 +85,16 @@ class BeersPagerFactoryImpl(private val repository: BeersRepository) : BeersPage
  * storage whose observe/write/count queries are keyed by that surface's parameters - it must not
  * reuse this one, or the two screens' data and resume positions would bleed into each other.
  */
-private class BeersPagingStorage(private val repository: BeersRepository) : PagingStorage<Beer> {
+private class BeersPagingStorage(
+  private val repository: BeersRepository,
+  private val surface: String,
+) : PagingStorage<Int, Beer> {
 
   override val data: Flow<List<Beer>> = repository.observeBeers()
 
-  override suspend fun storeFirstPage(page: List<Beer>) = repository.insertAllToDB(page)
+  override suspend fun storeFirstPage(page: PageResult<Int, Beer>) =
+    repository.insertPage(page.items, surface, page.nextKey, page.totalCount)
 
-  override suspend fun append(page: List<Beer>) = repository.insertAllToDB(page)
+  override suspend fun append(page: PageResult<Int, Beer>) =
+    repository.insertPage(page.items, surface, page.nextKey, page.totalCount)
 }

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
@@ -47,6 +47,22 @@ class BeersRepositoryImpl(
   override suspend fun insertAllToDB(beers: List<Beer>) =
     beersLocalSource.insertAllToDB(beers.map { beersMapper.fromBeerToBeerDbModel(it) })
 
+  override suspend fun insertPage(
+    beers: List<Beer>,
+    surface: String,
+    nextKey: Int?,
+    totalCount: Int?,
+  ) =
+    beersLocalSource.insertPageToDB(
+      beers.map { beersMapper.fromBeerToBeerDbModel(it) },
+      surface,
+      nextKey,
+      totalCount,
+    )
+
+  override suspend fun pagingNextKey(surface: String): Int? =
+    beersLocalSource.getPagingState(surface)?.nextKey
+
   override fun observeBeers(): Flow<List<Beer>> =
     beersLocalSource.getAllBeersFromDB().map { list ->
       list.map { beersMapper.fromBeerDbModelToBeer(it) }

--- a/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersLocalSource.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersLocalSource.kt
@@ -2,12 +2,14 @@ package com.simtop.beer_data.fakes
 
 import com.simtop.beer_database.localsources.BeersLocalSource
 import com.simtop.beer_database.models.BeerDbModel
+import com.simtop.beer_database.models.PagingStateDbModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
 class FakeBeersLocalSource : BeersLocalSource {
 
   private val beersFlow = MutableStateFlow<List<BeerDbModel>>(emptyList())
+  private val pagingState = mutableMapOf<String, PagingStateDbModel>()
 
   // Helper to inspect state
   fun getBeers(): List<BeerDbModel> = beersFlow.value
@@ -29,6 +31,26 @@ class FakeBeersLocalSource : BeersLocalSource {
     }
     beersFlow.value = current
   }
+
+  // Mirrors BeersDao.insertPage: upsert the rows and merge the bookmark monotonically in one step.
+  override suspend fun insertPageToDB(
+    beers: List<BeerDbModel>,
+    surface: String,
+    nextKey: Int?,
+    totalCount: Int?,
+  ) {
+    insertAllToDB(beers)
+    val existing = pagingState[surface]
+    pagingState[surface] =
+      PagingStateDbModel(
+        surface = surface,
+        nextKey = listOfNotNull(existing?.nextKey, nextKey).maxOrNull(),
+        totalCount = totalCount ?: existing?.totalCount,
+        refreshedAt = 0L,
+      )
+  }
+
+  override suspend fun getPagingState(surface: String): PagingStateDbModel? = pagingState[surface]
 
   override suspend fun updateBeer(primaryKey: String, availability: Boolean) {
     val current = beersFlow.value.toMutableList()

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -113,7 +113,8 @@ class BeersPagerFactoryImplTest {
   @Test
   fun `load more resumes from the stored bookmark, not the row-count estimate`() =
     runTest(testDispatcher) {
-      // Pages 1-2 fetched previously; page 2 was partial, so only 30 rows cached but next page is 3.
+      // Pages 1-2 fetched previously; page 2 was partial, so only 30 rows cached but next page is
+      // 3.
       repository.insertPage(
         (1..30).map { Beer.empty.copy(id = "$it") },
         surface = "catalog:en",
@@ -129,7 +130,8 @@ class BeersPagerFactoryImplTest {
       expectThat(beersRemoteSource.requestedPages.toList()).isEqualTo(listOf(3))
     }
 
-  // Regression guard for the monotonic next_key policy: a refresh re-fetching page 1 must not rewind
+  // Regression guard for the monotonic next_key policy: a refresh re-fetching page 1 must not
+  // rewind
   // a warm cache's bookmark, or "load more" would re-walk pages the cache already holds.
   @Test
   fun `refresh does not rewind the stored bookmark`() =

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -36,7 +36,7 @@ class BeersPagerFactoryImplTest {
     beersLocalSource = FakeBeersLocalSource()
     val beersMapper = BeersMapper(LanguageProvider { "en" }, NoOpLogger())
     repository = BeersRepositoryImpl(beersRemoteSource, beersLocalSource, beersMapper)
-    factory = BeersPagerFactoryImpl(repository)
+    factory = BeersPagerFactoryImpl(repository, LanguageProvider { "en" })
   }
 
   // Regression test: availability is treated as local-only (the server value only seeds first
@@ -106,6 +106,47 @@ class BeersPagerFactoryImplTest {
 
       expectThat(beersRemoteSource.requestedPages.toList()).isEqualTo(listOf(1, 2))
       expectThat(repository.countDBEntries()).isEqualTo(26)
+    }
+
+  // The paging_state bookmark is exact where the row-count estimate is not: a partial page leaves
+  // fewer rows than pages fetched, so resume must trust the stored next_key, not rows/pageSize.
+  @Test
+  fun `load more resumes from the stored bookmark, not the row-count estimate`() =
+    runTest(testDispatcher) {
+      // Pages 1-2 fetched previously; page 2 was partial, so only 30 rows cached but next page is 3.
+      repository.insertPage(
+        (1..30).map { Beer.empty.copy(id = "$it") },
+        surface = "catalog:en",
+        nextKey = 3,
+        totalCount = null,
+      )
+      beersRemoteSource.setBeersResponse(listOf(apiItem(id = "31")))
+      val pager = factory.create()
+
+      pager.loadNextPage()
+
+      // Row-count estimate would wrongly say page 2 (30/25 + 1); the bookmark says 3.
+      expectThat(beersRemoteSource.requestedPages.toList()).isEqualTo(listOf(3))
+    }
+
+  // Regression guard for the monotonic next_key policy: a refresh re-fetching page 1 must not rewind
+  // a warm cache's bookmark, or "load more" would re-walk pages the cache already holds.
+  @Test
+  fun `refresh does not rewind the stored bookmark`() =
+    runTest(testDispatcher) {
+      // Warm cache already reached page 6 (25 rows of page 1 present, bookmark points past page 5).
+      repository.insertPage(
+        (1..25).map { Beer.empty.copy(id = "$it") },
+        surface = "catalog:en",
+        nextKey = 6,
+        totalCount = 206,
+      )
+      beersRemoteSource.setBeersResponse((1..25).map { apiItem(id = "$it") }, totalCount = 206)
+      val pager = factory.create()
+
+      pager.loadFirstPage() // refresh: page 1 fetched, its own nextKey would be 2
+
+      expectThat(repository.pagingNextKey("catalog:en")).isEqualTo(6)
     }
 
   @Test

--- a/beer_database/build.gradle.kts
+++ b/beer_database/build.gradle.kts
@@ -4,9 +4,17 @@ plugins {
   id("billionbeers.android.metro")
 }
 
-android { namespace = "com.simtop.beer_database" }
+android {
+  namespace = "com.simtop.beer_database"
+  // The shared convention points every module at the app's MockTestRunner (Metro/mockk graph),
+  // which doesn't exist here. This module's instrumented tests are plain Room migration checks, so
+  // use the stock runner.
+  defaultConfig { testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner" }
+}
 
 dependencies {
   implementation(project(":core"))
   implementation(libs.kotlinx.serialization.json)
+  // MigrationTestHelper; the Room Gradle plugin exposes the exported schemas to the test.
+  androidTestImplementation(libs.roomTesting)
 }

--- a/beer_database/schemas/com.simtop.beer_database.database.BeersDatabase/2.json
+++ b/beer_database/schemas/com.simtop.beer_database.database.BeersDatabase/2.json
@@ -1,0 +1,113 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "c4a6e48d32c767e530c897c18ca470b7",
+    "entities": [
+      {
+        "tableName": "beers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `tagline` TEXT NOT NULL, `description` TEXT NOT NULL, `image_url` TEXT NOT NULL, `abv` REAL NOT NULL, `ibu` REAL NOT NULL, `food_pairing` TEXT NOT NULL, `availability` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "abv",
+            "columnName": "abv",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ibu",
+            "columnName": "ibu",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "foodPairing",
+            "columnName": "food_pairing",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "availability",
+            "columnName": "availability",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "paging_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surface` TEXT NOT NULL, `next_key` INTEGER, `total_count` INTEGER, `refreshed_at` INTEGER NOT NULL, PRIMARY KEY(`surface`))",
+        "fields": [
+          {
+            "fieldPath": "surface",
+            "columnName": "surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextKey",
+            "columnName": "next_key",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalCount",
+            "columnName": "total_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "refreshedAt",
+            "columnName": "refreshed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "surface"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c4a6e48d32c767e530c897c18ca470b7')"
+    ]
+  }
+}

--- a/beer_database/src/androidTest/java/com/simtop/beer_database/database/BeersDaoPagingStateTest.kt
+++ b/beer_database/src/androidTest/java/com/simtop/beer_database/database/BeersDaoPagingStateTest.kt
@@ -1,0 +1,71 @@
+package com.simtop.beer_database.database
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.simtop.beer_database.models.BeerDbModel
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exercises the real [BeersDao.insertPage] against Room (the JVM tests only cover the fake mirror):
+ * the page rows and the bookmark are written together, and [PagingStateDbModel.nextKey] advances
+ * but never rewinds.
+ */
+@RunWith(AndroidJUnit4::class)
+class BeersDaoPagingStateTest {
+
+  private lateinit var db: BeersDatabase
+  private lateinit var dao: BeersDao
+
+  @Before
+  fun setUp() {
+    db =
+      Room.inMemoryDatabaseBuilder(
+          ApplicationProvider.getApplicationContext(),
+          BeersDatabase::class.java,
+        )
+        .build()
+    dao = db.beersDao()
+  }
+
+  @After fun tearDown() = db.close()
+
+  private fun beer(id: String) =
+    BeerDbModel(id, "Beer $id", "", "", "", 0.0, 0.0, "[]", availability = true)
+
+  @Test
+  fun insertPage_writesRowsAndBookmarkTogether() = runBlocking {
+    dao.insertPage(listOf(beer("1")), surface = "catalog:en", nextKey = 2, totalCount = 206, 0L)
+
+    assertEquals(1, dao.getCount())
+    val state = dao.getPagingState("catalog:en")
+    assertEquals(2, state?.nextKey)
+    assertEquals(206, state?.totalCount)
+  }
+
+  @Test
+  fun insertPage_advancesBookmarkButNeverRewinds() = runBlocking {
+    dao.insertPage(listOf(beer("1")), surface = "catalog:en", nextKey = 2, totalCount = 206, 0L)
+    // A later page advances the bookmark...
+    dao.insertPage(listOf(beer("2")), surface = "catalog:en", nextKey = 5, totalCount = 206, 1L)
+    assertEquals(5, dao.getPagingState("catalog:en")?.nextKey)
+
+    // ...but a refresh re-writing an earlier page must not rewind it (monotonic merge).
+    dao.insertPage(listOf(beer("1")), surface = "catalog:en", nextKey = 2, totalCount = 206, 2L)
+    assertEquals(5, dao.getPagingState("catalog:en")?.nextKey)
+  }
+
+  @Test
+  fun insertPage_scopesBookmarksBySurface() = runBlocking {
+    dao.insertPage(listOf(beer("1")), surface = "catalog:en", nextKey = 2, totalCount = 206, 0L)
+    dao.insertPage(listOf(beer("2")), surface = "catalog:fr", nextKey = 9, totalCount = 300, 0L)
+
+    assertEquals(2, dao.getPagingState("catalog:en")?.nextKey)
+    assertEquals(9, dao.getPagingState("catalog:fr")?.nextKey)
+  }
+}

--- a/beer_database/src/androidTest/java/com/simtop/beer_database/database/BeersDatabaseMigrationTest.kt
+++ b/beer_database/src/androidTest/java/com/simtop/beer_database/database/BeersDatabaseMigrationTest.kt
@@ -1,0 +1,61 @@
+package com.simtop.beer_database.database
+
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Guards the project's first migration: [MIGRATION_1_2] must add `paging_state` while leaving the
+ * cached `beers` (and the user-owned `availability` column) intact. Schema validation against the
+ * exported `2.json` also catches any drift between the migration SQL and the entity definition.
+ */
+@RunWith(AndroidJUnit4::class)
+class BeersDatabaseMigrationTest {
+
+  @get:Rule
+  val helper =
+    MigrationTestHelper(InstrumentationRegistry.getInstrumentation(), BeersDatabase::class.java)
+
+  @Test
+  fun migrate1To2_keepsBeers_andAddsPagingState() {
+    val dbName = "migration-test"
+
+    // v1: seed one beer whose availability was locally edited to false.
+    helper.createDatabase(dbName, 1).apply {
+      execSQL(
+        "INSERT INTO beers " +
+          "(id, name, tagline, description, image_url, abv, ibu, food_pairing, availability) " +
+          "VALUES ('1', 'Beer 1', '', '', '', 0.0, 0.0, '[]', 0)"
+      )
+      close()
+    }
+
+    // Run the real migration; `true` validates the resulting schema matches the exported 2.json.
+    val db = helper.runMigrationsAndValidate(dbName, 2, true, MIGRATION_1_2)
+
+    // The cached beer (and its edited availability) survived the upgrade.
+    db.query("SELECT id, availability FROM beers").use { cursor ->
+      assertTrue(cursor.moveToFirst())
+      assertEquals("1", cursor.getString(0))
+      assertEquals(0, cursor.getInt(1))
+    }
+
+    // The new paging_state table exists and accepts a bookmark row.
+    db.execSQL(
+      "INSERT INTO paging_state (surface, next_key, total_count, refreshed_at) " +
+        "VALUES ('catalog:en', 3, 206, 0)"
+    )
+    db.query("SELECT next_key, total_count FROM paging_state WHERE surface = 'catalog:en'").use {
+      cursor ->
+      assertTrue(cursor.moveToFirst())
+      assertEquals(3, cursor.getInt(0))
+      assertEquals(206, cursor.getInt(1))
+    }
+    db.close()
+  }
+}

--- a/beer_database/src/main/java/com/simtop/beer_database/database/BeersDao.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/database/BeersDao.kt
@@ -4,7 +4,9 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Upsert
 import com.simtop.beer_database.models.BeerDbModel
+import com.simtop.beer_database.models.PagingStateDbModel
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -80,4 +82,37 @@ abstract class BeersDao {
   @Query("DELETE FROM beers") abstract suspend fun deleteAll()
 
   @Query("SELECT COUNT(id) FROM beers") abstract suspend fun getCount(): Int
+
+  @Query("SELECT * FROM paging_state WHERE surface = :surface")
+  abstract suspend fun getPagingState(surface: String): PagingStateDbModel?
+
+  @Upsert abstract suspend fun upsertPagingState(state: PagingStateDbModel)
+
+  /**
+   * Writes a fetched page and its paging bookmark atomically, so [PagingStateDbModel.nextKey] can
+   * never point past — or short of — the rows actually stored (the PR #57 divergence class).
+   * [nextKey] is merged monotonically: a refresh re-fetching page 1 (`nextKey = 2`) must not rewind
+   * a warm cache that already reached a later page, so the stored value only ever advances. A null
+   * incoming [nextKey] (last page) leaves the bookmark untouched — end-of-pagination is decided by
+   * the fetch's total-count math, not by persisting a null key.
+   */
+  @androidx.room.Transaction
+  open suspend fun insertPage(
+    beers: List<BeerDbModel>,
+    surface: String,
+    nextKey: Int?,
+    totalCount: Int?,
+    refreshedAt: Long,
+  ) {
+    insertAll(beers)
+    val existing = getPagingState(surface)
+    upsertPagingState(
+      PagingStateDbModel(
+        surface = surface,
+        nextKey = listOfNotNull(existing?.nextKey, nextKey).maxOrNull(),
+        totalCount = totalCount ?: existing?.totalCount,
+        refreshedAt = refreshedAt,
+      )
+    )
+  }
 }

--- a/beer_database/src/main/java/com/simtop/beer_database/database/BeersDatabase.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/database/BeersDatabase.kt
@@ -3,8 +3,9 @@ package com.simtop.beer_database.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.simtop.beer_database.models.BeerDbModel
+import com.simtop.beer_database.models.PagingStateDbModel
 
-@Database(entities = [BeerDbModel::class], version = 1)
+@Database(entities = [BeerDbModel::class, PagingStateDbModel::class], version = 2)
 abstract class BeersDatabase : RoomDatabase() {
   abstract fun beersDao(): BeersDao
 }

--- a/beer_database/src/main/java/com/simtop/beer_database/database/Migrations.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/database/Migrations.kt
@@ -1,0 +1,25 @@
+package com.simtop.beer_database.database
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * v1 → v2: the project's first migration. Purely additive — it creates the `paging_state`
+ * bookmark table and leaves `beers` (and the user-owned availability column) untouched, so an
+ * in-place upgrade preserves the cache. The `CREATE TABLE` statement mirrors Room's generated
+ * schema for [com.simtop.beer_database.models.PagingStateDbModel] exactly; the migration test
+ * (schemas are exported) guards against drift.
+ */
+val MIGRATION_1_2 =
+  object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+      db.execSQL(
+        "CREATE TABLE IF NOT EXISTS `paging_state` (" +
+          "`surface` TEXT NOT NULL, " +
+          "`next_key` INTEGER, " +
+          "`total_count` INTEGER, " +
+          "`refreshed_at` INTEGER NOT NULL, " +
+          "PRIMARY KEY(`surface`))"
+      )
+    }
+  }

--- a/beer_database/src/main/java/com/simtop/beer_database/database/Migrations.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/database/Migrations.kt
@@ -4,11 +4,11 @@ import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
- * v1 → v2: the project's first migration. Purely additive — it creates the `paging_state`
- * bookmark table and leaves `beers` (and the user-owned availability column) untouched, so an
- * in-place upgrade preserves the cache. The `CREATE TABLE` statement mirrors Room's generated
- * schema for [com.simtop.beer_database.models.PagingStateDbModel] exactly; the migration test
- * (schemas are exported) guards against drift.
+ * v1 → v2: the project's first migration. Purely additive — it creates the `paging_state` bookmark
+ * table and leaves `beers` (and the user-owned availability column) untouched, so an in-place
+ * upgrade preserves the cache. The `CREATE TABLE` statement mirrors Room's generated schema for
+ * [com.simtop.beer_database.models.PagingStateDbModel] exactly; the migration test (schemas are
+ * exported) guards against drift.
  */
 val MIGRATION_1_2 =
   object : Migration(1, 2) {

--- a/beer_database/src/main/java/com/simtop/beer_database/di/BeersDatabaseModule.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/di/BeersDatabaseModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room.Room
 import com.simtop.beer_database.database.BeersDao
 import com.simtop.beer_database.database.BeersDatabase
+import com.simtop.beer_database.database.MIGRATION_1_2
+import com.simtop.core.BuildConfig
 import com.simtop.core.core.BEERS_DB_NAME
 import com.simtop.core.di.ApplicationContext
 import dev.zacsweers.metro.AppScope
@@ -17,7 +19,15 @@ interface BeersDatabaseModule {
   @Provides
   @SingleIn(AppScope::class)
   fun provideDatabase(@ApplicationContext app: Context): BeersDatabase =
-    Room.databaseBuilder(app, BeersDatabase::class.java, BEERS_DB_NAME).build()
+    Room.databaseBuilder(app, BeersDatabase::class.java, BEERS_DB_NAME)
+      // Real, additive v1 -> v2 migration keeps the cache (and local availability edits) across
+      // release upgrades. The destructive fallback is a debug-only dev net for schema churn on a
+      // throwaway DB - it must never run in release, where it would wipe user data. `isDebug` reuses
+      // :core's BuildConfig (already enabled there, precedent: NetworkingModule) rather than turning
+      // buildConfig on in this library module.
+      .addMigrations(MIGRATION_1_2)
+      .apply { if (BuildConfig.DEBUG) fallbackToDestructiveMigration(dropAllTables = true) }
+      .build()
 
   @Provides
   @SingleIn(AppScope::class)

--- a/beer_database/src/main/java/com/simtop/beer_database/di/BeersDatabaseModule.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/di/BeersDatabaseModule.kt
@@ -22,9 +22,9 @@ interface BeersDatabaseModule {
     Room.databaseBuilder(app, BeersDatabase::class.java, BEERS_DB_NAME)
       // Real, additive v1 -> v2 migration keeps the cache (and local availability edits) across
       // release upgrades. The destructive fallback is a debug-only dev net for schema churn on a
-      // throwaway DB - it must never run in release, where it would wipe user data. `isDebug` reuses
-      // :core's BuildConfig (already enabled there, precedent: NetworkingModule) rather than turning
-      // buildConfig on in this library module.
+      // throwaway DB - it must never run in release, where it would wipe user data. The debug flag
+      // reuses :core's BuildConfig (already enabled there, precedent: NetworkingModule) instead of
+      // turning buildConfig on in this library module.
       .addMigrations(MIGRATION_1_2)
       .apply { if (BuildConfig.DEBUG) fallbackToDestructiveMigration(dropAllTables = true) }
       .build()

--- a/beer_database/src/main/java/com/simtop/beer_database/localsources/BeersLocalSource.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/localsources/BeersLocalSource.kt
@@ -2,6 +2,7 @@ package com.simtop.beer_database.localsources
 
 import com.simtop.beer_database.database.BeersDatabase
 import com.simtop.beer_database.models.BeerDbModel
+import com.simtop.beer_database.models.PagingStateDbModel
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.flow.Flow
 
@@ -16,6 +17,20 @@ interface BeersLocalSource {
    */
   suspend fun insertAllToDB(beers: List<BeerDbModel>)
 
+  /**
+   * Same keyed upsert as [insertAllToDB], but also records the paging bookmark for [surface] in the
+   * *same transaction* so resume position can't diverge from the stored rows. See
+   * [com.simtop.beer_database.database.BeersDao.insertPage].
+   */
+  suspend fun insertPageToDB(
+    beers: List<BeerDbModel>,
+    surface: String,
+    nextKey: Int?,
+    totalCount: Int?,
+  )
+
+  suspend fun getPagingState(surface: String): PagingStateDbModel?
+
   suspend fun updateBeer(primaryKey: String, availability: Boolean)
 
   suspend fun deleteAllFromDB()
@@ -29,6 +44,15 @@ class BeersLocalSourceImpl(private val db: BeersDatabase) : BeersLocalSource {
   override fun getAllBeersFromDB(): Flow<List<BeerDbModel>> = db.beersDao().getAllBeers()
 
   override suspend fun insertAllToDB(beers: List<BeerDbModel>) = db.beersDao().insertAll(beers)
+
+  override suspend fun insertPageToDB(
+    beers: List<BeerDbModel>,
+    surface: String,
+    nextKey: Int?,
+    totalCount: Int?,
+  ) = db.beersDao().insertPage(beers, surface, nextKey, totalCount, System.currentTimeMillis())
+
+  override suspend fun getPagingState(surface: String) = db.beersDao().getPagingState(surface)
 
   override suspend fun updateBeer(primaryKey: String, availability: Boolean) =
     db.beersDao().updateBeer(primaryKey, availability)

--- a/beer_database/src/main/java/com/simtop/beer_database/models/PagingStateDbModel.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/models/PagingStateDbModel.kt
@@ -1,0 +1,20 @@
+package com.simtop.beer_database.models
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * Per-surface paging bookmark, written in the same transaction as the page's rows so position never
+ * diverges from data. [surface] scopes one paged list (e.g. `"catalog:en"`); [nextKey] is the first
+ * page not yet cached (kept monotonic non-decreasing so a refresh over a warm cache never rewinds
+ * it); [totalCount] is the server's `X-Total-Count`. A row is only ever *read* here in Phase 1 -
+ * acting on a surface mismatch (language switch) is deferred.
+ */
+@Entity(tableName = "paging_state")
+data class PagingStateDbModel(
+  @PrimaryKey @ColumnInfo(name = "surface") val surface: String,
+  @ColumnInfo(name = "next_key") val nextKey: Int?,
+  @ColumnInfo(name = "total_count") val totalCount: Int?,
+  @ColumnInfo(name = "refreshed_at") val refreshedAt: Long,
+)

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -28,6 +28,21 @@ interface BeersRepository {
    */
   suspend fun insertAllToDB(beers: List<Beer>)
 
+  /**
+   * Same keyed upsert as [insertAllToDB], but also records the paging bookmark for [surface] (the
+   * resume [nextKey] and [totalCount]) in the *same* transaction, so the pager's position can never
+   * diverge from the rows actually stored. [nextKey] is merged monotonically - a refresh re-fetching
+   * an earlier page never rewinds a warm cache's bookmark.
+   */
+  suspend fun insertPage(beers: List<Beer>, surface: String, nextKey: Int?, totalCount: Int?)
+
+  /**
+   * The stored resume key for [surface] - the first page not yet cached - or null when no bookmark
+   * has been recorded yet (fresh install, or a cache written before paging_state existed). Callers
+   * fall back to a row-count estimate in that case.
+   */
+  suspend fun pagingNextKey(surface: String): Int?
+
   suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit>
 
   /** Fetches one page from the API, carrying the server total for end-detection and "N of M" UI. */

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -31,8 +31,8 @@ interface BeersRepository {
   /**
    * Same keyed upsert as [insertAllToDB], but also records the paging bookmark for [surface] (the
    * resume [nextKey] and [totalCount]) in the *same* transaction, so the pager's position can never
-   * diverge from the rows actually stored. [nextKey] is merged monotonically - a refresh re-fetching
-   * an earlier page never rewinds a warm cache's bookmark.
+   * diverge from the rows actually stored. [nextKey] is merged monotonically - a refresh
+   * re-fetching an earlier page never rewinds a warm cache's bookmark.
    */
   suspend fun insertPage(beers: List<Beer>, surface: String, nextKey: Int?, totalCount: Int?)
 

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
@@ -55,6 +55,26 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
     beersFlow.value = current
   }
 
+  private val pagingNextKeys = mutableMapOf<String, Int?>()
+
+  /** Test helper: seed a stored resume bookmark for [surface] as a warm cache would leave. */
+  fun setPagingNextKey(surface: String, nextKey: Int?) {
+    pagingNextKeys[surface] = nextKey
+  }
+
+  /** Mirrors the DAO: upsert the rows and merge the bookmark monotonically in one step. */
+  override suspend fun insertPage(
+    beers: List<Beer>,
+    surface: String,
+    nextKey: Int?,
+    totalCount: Int?,
+  ) {
+    insertAllToDB(beers)
+    pagingNextKeys[surface] = listOfNotNull(pagingNextKeys[surface], nextKey).maxOrNull()
+  }
+
+  override suspend fun pagingNextKey(surface: String): Int? = pagingNextKeys[surface]
+
   override suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit> {
     exceptionToThrow?.let {
       return Either.Left(UpdateAvailabilityError.Unknown(it))

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
@@ -80,32 +80,36 @@ interface Pager<Value : Any, out E : Any> {
  * favorites) needs its own storage whose queries are keyed by that surface's fetch parameters. Two
  * surfaces must never page one unscoped shared table.
  */
-interface PagingStorage<Value : Any> {
+interface PagingStorage<Key : Any, Value : Any> {
   val data: Flow<List<Value>>
 
   /**
    * The new first page, after a successful initial load or refresh. May be empty. Implementations
    * choose what "store" means - replace everything (in-memory) or merge/upsert into existing rows
    * (DB SSOT); the mediator does not assume [data] equals this page afterwards.
+   *
+   * The whole [PageResult] is passed, not just the items, so a persistent storage can record the
+   * resume key ([PageResult.nextKey]) and [PageResult.totalCount] in the *same* write as the rows -
+   * position never diverging from data. In-memory storage ignores that metadata.
    */
-  suspend fun storeFirstPage(page: List<Value>)
+  suspend fun storeFirstPage(page: PageResult<Key, Value>)
 
-  /** A successfully fetched subsequent page. Never empty. */
-  suspend fun append(page: List<Value>)
+  /** A successfully fetched subsequent page. Its [PageResult.items] are never empty. */
+  suspend fun append(page: PageResult<Key, Value>)
 }
 
 /** Network-only storage: pages accumulate in memory and vanish with the pager. */
-class InMemoryPagingStorage<Value : Any> : PagingStorage<Value> {
+class InMemoryPagingStorage<Key : Any, Value : Any> : PagingStorage<Key, Value> {
   private val pages = MutableStateFlow<List<Value>>(emptyList())
 
   override val data: Flow<List<Value>> = pages.asStateFlow()
 
-  override suspend fun storeFirstPage(page: List<Value>) {
-    pages.value = page
+  override suspend fun storeFirstPage(page: PageResult<Key, Value>) {
+    pages.value = page.items
   }
 
-  override suspend fun append(page: List<Value>) {
-    pages.update { current -> current + page }
+  override suspend fun append(page: PageResult<Key, Value>) {
+    pages.update { current -> current + page.items }
   }
 }
 
@@ -154,7 +158,7 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
   private val initialKey: Key,
   private val fetchRemote: suspend (key: Key) -> PageResult<Key, Value>,
   private val classifyError: (Throwable) -> E,
-  private val storage: PagingStorage<Value> = InMemoryPagingStorage(),
+  private val storage: PagingStorage<Key, Value> = InMemoryPagingStorage(),
   private val nextKeyFromStorage: (suspend () -> Key)? = null,
 ) : Pager<Value, E> {
 
@@ -207,8 +211,8 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
 
       val result = fetchRemote(key)
       val items = result.items
-      if (isFirstPage) storage.storeFirstPage(items)
-      else if (items.isNotEmpty()) storage.append(items)
+      if (isFirstPage) storage.storeFirstPage(result)
+      else if (items.isNotEmpty()) storage.append(result)
 
       // Empty-page probe: the fallback end signal when the server reports no total (nextKey stays
       // non-null) - preserves the pre-2.0 behaviour for a header-less backend.

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
@@ -19,23 +19,23 @@ import org.junit.Test
 class PagingMediatorTest {
 
   /** Storage that records every write so tests can assert on ordering and content. */
-  private class RecordingStorage : PagingStorage<String> {
+  private class RecordingStorage : PagingStorage<Int, String> {
     val events = mutableListOf<String>()
     val stored = MutableStateFlow<List<String>>(emptyList())
     var failWrites = false
 
     override val data: Flow<List<String>> = stored
 
-    override suspend fun storeFirstPage(page: List<String>) {
+    override suspend fun storeFirstPage(page: PageResult<Int, String>) {
       events += "storeFirstPage"
       if (failWrites) throw RuntimeException("write failed")
-      stored.value = page
+      stored.value = page.items
     }
 
-    override suspend fun append(page: List<String>) {
+    override suspend fun append(page: PageResult<Int, String>) {
       events += "append"
       if (failWrites) throw RuntimeException("write failed")
-      stored.update { current -> current + page }
+      stored.update { current -> current + page.items }
     }
   }
 
@@ -279,14 +279,14 @@ class PagingMediatorTest {
   }
 
   /** Non-replacing storage mirroring a DB upsert: every write merges instead of replacing. */
-  private class UpsertingStorage : PagingStorage<String> {
+  private class UpsertingStorage : PagingStorage<Int, String> {
     val stored = MutableStateFlow<List<String>>(emptyList())
 
     override val data: Flow<List<String>> = stored
 
-    override suspend fun storeFirstPage(page: List<String>) = upsert(page)
+    override suspend fun storeFirstPage(page: PageResult<Int, String>) = upsert(page.items)
 
-    override suspend fun append(page: List<String>) = upsert(page)
+    override suspend fun append(page: PageResult<Int, String>) = upsert(page.items)
 
     private fun upsert(page: List<String>) {
       stored.update { current -> current + page.filterNot(current::contains) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,6 +76,7 @@ androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-
 roomRuntime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
 roomCompiler = { module = "androidx.room:room-compiler", version.ref = "androidx-room" }
 roomKtx = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
+roomTesting = { module = "androidx.room:room-testing", version.ref = "androidx-room" }
 roomGradlePlugin = { module = "androidx.room:room-gradle-plugin", version.ref = "androidx-room" }
 
 # Compose (managed by BOM)


### PR DESCRIPTION
Paging 2.0 sub-PR 1b: exact, crash-safe resume via a persisted paging bookmark.

Before this, "load more" recovered its position from a `rowCount / pageSize` estimate.
That's wrong the moment a page is partial or the cache has gaps, and it lives only in
memory. 1b adds a `paging_state` table that records, per surface, the first page not yet
cached — written in the *same* transaction as the page's rows, so position can never
diverge from data (the PR #57 bug class).

**Storage seam.** `PagingStorage` gains a `Key` type param and its writes take the whole
`PageResult` (items + nextKey + totalCount) instead of a bare list, so a persistent
storage can record the bookmark alongside the rows. `InMemoryPagingStorage` ignores the
metadata.

**paging_state (Room v2).** New `paging_state(surface, next_key, total_count, refreshed_at)`
entity + DAO. A `@Transaction insertPage` upserts the rows and merges the bookmark
monotonically: a refresh re-fetching page 1 never rewinds a warm cache that already
reached a later page, and a null last-page key leaves the bookmark untouched (end-of-list
stays driven by the total-count math from 1a).

**Resume, with a safe fallback.** The factory reads `paging_state.next_key` for exact
resume and **falls back to the old row-count estimate only when no bookmark exists yet** —
a fresh install, or a cache written before this table existed. That last case matters: the
v1→v2 migration creates `paging_state` empty, so without the fallback every existing user
would re-walk their whole cache over the network on first warm start.

**Migration.** Real, additive `MIGRATION_1_2` (creates `paging_state`, leaves `beers`
untouched) for release correctness, plus a debug-only `fallbackToDestructiveMigration` dev
net (gated on `core.BuildConfig.DEBUG`, no BuildConfig needed in this library module).

**Tests.** JVM: bookmark beats a deliberately-wrong row-count estimate; refresh doesn't
rewind the bookmark. Instrumented (this module's first androidTest — stock runner + Room
`MigrationTestHelper`, schemas are exported): the migration keeps beers and adds
paging_state and validates against the generated v2 schema; three DAO tests exercise the
real transactional `insertPage` (write-together, advance-not-rewind, surface scoping).

Second slice of Phase 1; 1c (events + footer + rate-limit) and 1d (contract/warm-fixture
tests) follow.
