### PR TITLE
feat: load-more retry footer, end caption, and rate-limit handling (Paging 2.0 1c)

### DIFF
--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
@@ -59,6 +59,7 @@ class BeersPagerFactoryImpl(
         when (code()) {
           HttpURLConnection.HTTP_NOT_FOUND -> FetchBeersError.NotFound
           HttpURLConnection.HTTP_FORBIDDEN -> FetchBeersError.Forbidden
+          HTTP_TOO_MANY_REQUESTS -> FetchBeersError.RateLimited
           else -> FetchBeersError.Unknown(this)
         }
       is IOException -> FetchBeersError.Network
@@ -68,6 +69,8 @@ class BeersPagerFactoryImpl(
   private companion object {
     const val FIRST_PAGE = 1
     const val CATALOG_SURFACE_PREFIX = "catalog:"
+    // No HttpURLConnection constant exists for 429.
+    const val HTTP_TOO_MANY_REQUESTS = 429
   }
 }
 

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -15,8 +15,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import retrofit2.HttpException
+import retrofit2.Response
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
@@ -175,6 +178,19 @@ class BeersPagerFactoryImplTest {
       expectThat(pager.pagingState.value)
         .isEqualTo(PagingState.Error(FetchBeersError.Network, isFirstPage = true))
       expectThat(repository.countDBEntries()).isEqualTo(0)
+    }
+
+  @Test
+  fun `HTTP 429 is classified as RateLimited`() =
+    runTest(testDispatcher) {
+      val http429 = HttpException(Response.error<Any>(429, "".toResponseBody(null)))
+      beersRemoteSource.setShouldThrowError(true, http429)
+      val pager = factory.create()
+
+      pager.loadFirstPage()
+
+      expectThat(pager.pagingState.value)
+        .isEqualTo(PagingState.Error(FetchBeersError.RateLimited, isFirstPage = true))
     }
 
   @Test

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/errors/FetchBeersError.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/errors/FetchBeersError.kt
@@ -7,5 +7,8 @@ sealed interface FetchBeersError {
 
   data object Forbidden : FetchBeersError
 
+  /** HTTP 429: the backend is rate-limiting us. Recoverable - the same retry path applies. */
+  data object RateLimited : FetchBeersError
+
   data class Unknown(val cause: Throwable) : FetchBeersError
 }

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersPagerFactory.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersPagerFactory.kt
@@ -14,8 +14,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
- * A [Pager] whose [data] is whatever flow the test wires in and whose [pagingState]/[events] are set
- * directly with [setPagingState]/[emitEvent] - load calls are only recorded, never fetch anything.
+ * A [Pager] whose [data] is whatever flow the test wires in and whose [pagingState]/[events] are
+ * set directly with [setPagingState]/[emitEvent] - load calls are only recorded, never fetch
+ * anything.
  */
 class FakePager<Value : Any, E : Any>(override val data: Flow<List<Value>>) : Pager<Value, E> {
 

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersPagerFactory.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersPagerFactory.kt
@@ -4,20 +4,26 @@ import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.core.core.Pager
+import com.simtop.core.core.PagingEvent
 import com.simtop.core.core.PagingState
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
- * A [Pager] whose [data] is whatever flow the test wires in and whose [pagingState] is set directly
- * with [setPagingState] - load calls are only recorded, never fetch anything.
+ * A [Pager] whose [data] is whatever flow the test wires in and whose [pagingState]/[events] are set
+ * directly with [setPagingState]/[emitEvent] - load calls are only recorded, never fetch anything.
  */
 class FakePager<Value : Any, E : Any>(override val data: Flow<List<Value>>) : Pager<Value, E> {
 
   private val _pagingState = MutableStateFlow<PagingState<E>>(PagingState.Idle)
   override val pagingState: StateFlow<PagingState<E>> = _pagingState.asStateFlow()
+
+  private val _events = Channel<PagingEvent<E>>(Channel.UNLIMITED)
+  override val events: Flow<PagingEvent<E>> = _events.receiveAsFlow()
 
   var loadFirstPageCallCount = 0
     private set
@@ -27,6 +33,10 @@ class FakePager<Value : Any, E : Any>(override val data: Flow<List<Value>>) : Pa
 
   fun setPagingState(state: PagingState<E>) {
     _pagingState.value = state
+  }
+
+  fun emitEvent(event: PagingEvent<E>) {
+    _events.trySend(event)
   }
 
   override suspend fun loadFirstPage() {

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
@@ -1,10 +1,13 @@
 package com.simtop.core.core
 
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -46,9 +49,24 @@ data class PageResult<Key : Any, Value : Any>(
 )
 
 /**
- * What a screen needs from a paginated source: the accumulated [data], the load [pagingState], and
- * the two entry points. Consumers (ViewModels, fakes) depend on this, not on [PagingMediator], so
- * tests can drive paging states directly with a hand-rolled fake.
+ * A one-shot paging event - something that happened once and must be consumed exactly once (a
+ * transient toast), as opposed to [PagingState], which is the current condition and is safe to
+ * replay to every new collector. Delivered over a channel, not a [StateFlow], precisely so a
+ * config-change re-collect doesn't re-fire it.
+ */
+sealed class PagingEvent<out E : Any> {
+  /**
+   * A *subsequent* page (not the first) failed to load. The first-page failure stays in
+   * [PagingState.Error] as a full-screen condition; this fires only when there is already a list on
+   * screen, so the UI can surface a transient notice while keeping the list and its footer retry.
+   */
+  data class LoadMoreFailed<out E : Any>(val error: E) : PagingEvent<E>()
+}
+
+/**
+ * What a screen needs from a paginated source: the accumulated [data], the load [pagingState], the
+ * one-shot [events], and the two entry points. Consumers (ViewModels, fakes) depend on this, not on
+ * [PagingMediator], so tests can drive paging states directly with a hand-rolled fake.
  *
  * A pager instance holds per-screen state (current page, end-of-list), so it must be owned by the
  * screen's ViewModel - never by an app-scoped singleton shared across screens.
@@ -56,6 +74,9 @@ data class PageResult<Key : Any, Value : Any>(
 interface Pager<Value : Any, out E : Any> {
   val data: Flow<List<Value>>
   val pagingState: StateFlow<PagingState<E>>
+
+  /** One-shot events (e.g. a failed "load more"); see [PagingEvent]. Cold until collected. */
+  val events: Flow<PagingEvent<E>>
 
   /** Loads (or reloads, acting as refresh) the first page. Waits for any in-flight load. */
   suspend fun loadFirstPage()
@@ -165,6 +186,12 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
   private val _pagingState = MutableStateFlow<PagingState<E>>(PagingState.Idle)
   override val pagingState: StateFlow<PagingState<E>> = _pagingState.asStateFlow()
 
+  // Conflated: for a failed "load more" only the latest matters, so a resumed screen shows one
+  // toast, not a backlog. trySend never suspends and never fails with this overflow policy.
+  private val _events =
+    Channel<PagingEvent<E>>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+  override val events: Flow<PagingEvent<E>> = _events.receiveAsFlow()
+
   override val data: Flow<List<Value>> = storage.data
 
   private val mutex = Mutex()
@@ -233,7 +260,11 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
     } catch (e: CancellationException) {
       throw e
     } catch (e: Exception) {
-      _pagingState.value = PagingState.Error(classifyError(e), isFirstPage)
+      val error = classifyError(e)
+      // A subsequent-page failure keeps the list, so it also fires a one-shot event for a transient
+      // notice; a first-page failure is the full-screen Error condition and needs no event.
+      if (!isFirstPage) _events.trySend(PagingEvent.LoadMoreFailed(error))
+      _pagingState.value = PagingState.Error(error, isFirstPage)
     }
   }
 

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
@@ -125,6 +125,35 @@ class PagingMediatorTest {
   }
 
   @Test
+  fun `next page failure also emits a one-shot LoadMoreFailed event`() = runTest {
+    val harness = Harness()
+    harness.mediator.loadFirstPage()
+    harness.failOnKey(2)
+
+    harness.mediator.events.test {
+      harness.mediator.loadNextPage()
+
+      assertEquals(PagingEvent.LoadMoreFailed("fetch 2 failed"), awaitItem())
+    }
+  }
+
+  @Test
+  fun `first page failure emits no LoadMoreFailed event`() = runTest {
+    val harness = Harness()
+    harness.failOnKey(1)
+
+    harness.mediator.events.test {
+      harness.mediator.loadFirstPage()
+
+      expectNoEvents()
+    }
+    assertEquals(
+      PagingState.Error("fetch 1 failed", isFirstPage = true),
+      harness.mediator.pagingState.value,
+    )
+  }
+
+  @Test
   fun `key only advances on success so retry refetches the failed page`() = runTest {
     val harness = Harness()
     harness.mediator.loadFirstPage()

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
@@ -56,6 +57,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
 import com.simtop.billionbeers.core.designsystem.component.shimmerBrush
@@ -84,6 +88,20 @@ private val BeerSaver: Saver<Beer?, String> =
 @Composable
 fun BeersListScreen(viewModel: BeersListViewModel = metroViewModel(), onBeerClick: (Beer) -> Unit) {
   val rawState by viewModel.beerListViewState.collectAsState()
+  val context = LocalContext.current
+  val lifecycleOwner = LocalLifecycleOwner.current
+  val loadMoreFailedMessage = stringResource(R.string.beers_load_more_failed)
+
+  // One-shot toast when a "load more" fails; the footer owns the retry affordance.
+  LaunchedEffect(viewModel, lifecycleOwner) {
+    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+      viewModel.events.collect { event ->
+        when (event) {
+          BeersListEvent.ShowLoadMoreError -> showToast(context, loadMoreFailedMessage)
+        }
+      }
+    }
+  }
 
   // State to track if we are installing the feature for a specific beer - saved across process
   // death so the install flow resumes instead of silently dropping the in-flight navigation.
@@ -95,6 +113,7 @@ fun BeersListScreen(viewModel: BeersListViewModel = metroViewModel(), onBeerClic
     onScrollToBottom = { viewModel.onScrollToBottom() },
     onRefresh = { viewModel.refresh() },
     onRetry = { viewModel.refresh() },
+    onRetryLoadMore = { viewModel.onRetryLoadMore() },
   )
 
   // Handle dynamic feature loading overlay
@@ -119,6 +138,7 @@ fun BeersListContent(
   onScrollToBottom: () -> Unit,
   onRefresh: () -> Unit,
   onRetry: () -> Unit,
+  onRetryLoadMore: () -> Unit,
 ) {
   val context = LocalContext.current
   val toggleDebugDrawer = LocalDebugDrawerToggle.current
@@ -196,11 +216,17 @@ fun BeersListContent(
           ) {
             val listState = rememberLazyListState()
 
-            InfiniteListHandler(
-              listState = listState,
-              isLoadingNextPage = state.data.isLoadingNextPage,
-              onLoadMore = onScrollToBottom,
-            )
+            // Suspend auto-load while the retry footer is up: the user is parked at the bottom
+            // after
+            // a failure, so an unconditional scroll trigger would bypass the Retry button and, on a
+            // 429, auto-loop. Tapping Retry clears the footer and re-arms the handler.
+            if (state.data.footer !is ListFooter.Retry) {
+              InfiniteListHandler(
+                listState = listState,
+                isLoadingNextPage = state.data.isLoadingNextPage,
+                onLoadMore = onScrollToBottom,
+              )
+            }
 
             val layoutDirection = LocalLayoutDirection.current
             val navBarsPadding = WindowInsets.navigationBars.asPaddingValues()
@@ -221,24 +247,63 @@ fun BeersListContent(
                 ComposeBeersListItem(beer = beers[index], onClick = onBeerClick)
               }
 
-              if (state.data.isLoadingNextPage) {
-                item(key = "loading_footer") {
-                  Box(
-                    modifier = Modifier.fillMaxWidth().padding(BillionBeersTheme.spacing.large),
-                    contentAlignment = Alignment.Center,
-                  ) {
-                    CircularProgressIndicator(
-                      modifier = Modifier.size(BillionBeersTheme.spacing.extraLarge),
-                      strokeWidth = 3.dp,
-                    )
-                  }
-                }
+              // Bottom-of-list affordance: spinner while loading, a retry row after a failed
+              // "load more", or the end caption once the whole catalog is in.
+              when {
+                state.data.isLoadingNextPage -> item(key = "loading_footer") { LoadingMoreFooter() }
+                state.data.footer is ListFooter.Retry ->
+                  item(key = "retry_footer") { LoadMoreRetryFooter(onRetry = onRetryLoadMore) }
+                state.data.footer is ListFooter.EndReached ->
+                  item(key = "end_footer") { EndOfListFooter(beerCount = beers.size) }
+                else -> Unit
               }
             }
           }
         }
       }
     }
+  }
+}
+
+@Composable
+private fun LoadingMoreFooter() {
+  Box(
+    modifier = Modifier.fillMaxWidth().padding(BillionBeersTheme.spacing.large),
+    contentAlignment = Alignment.Center,
+  ) {
+    CircularProgressIndicator(
+      modifier = Modifier.size(BillionBeersTheme.spacing.extraLarge),
+      strokeWidth = 3.dp,
+    )
+  }
+}
+
+@Composable
+private fun LoadMoreRetryFooter(onRetry: () -> Unit) {
+  Column(
+    modifier = Modifier.fillMaxWidth().padding(BillionBeersTheme.spacing.medium),
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(
+      text = stringResource(R.string.beers_load_more_failed),
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    TextButton(onClick = onRetry) { Text(text = stringResource(R.string.beers_load_more_retry)) }
+  }
+}
+
+@Composable
+private fun EndOfListFooter(beerCount: Int) {
+  Box(
+    modifier = Modifier.fillMaxWidth().padding(BillionBeersTheme.spacing.large),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(
+      text = stringResource(R.string.beers_end_of_list, beerCount),
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
   }
 }
 
@@ -295,6 +360,42 @@ class BeersListPreviewParameterProvider :
             )
         )
       ),
+      SUCCESS_LOAD_MORE_FAILED(
+        CommonUiState.Success(
+          data =
+            BeersListUiModel(
+              beers =
+                listOf(
+                  Beer.empty.copy(
+                    name = "Buzz",
+                    tagline = "A Real Bitter Experience.",
+                    abv = 4.5,
+                    ibu = 60.0,
+                    availability = true,
+                  )
+                ),
+              footer = ListFooter.Retry,
+            )
+        )
+      ),
+      SUCCESS_END_OF_LIST(
+        CommonUiState.Success(
+          data =
+            BeersListUiModel(
+              beers =
+                listOf(
+                  Beer.empty.copy(
+                    name = "Buzz",
+                    tagline = "A Real Bitter Experience.",
+                    abv = 4.5,
+                    ibu = 60.0,
+                    availability = true,
+                  )
+                ),
+              footer = ListFooter.EndReached,
+            )
+        )
+      ),
     }
   }
 
@@ -314,6 +415,7 @@ fun BeersListScreenPreview(
       onScrollToBottom = {},
       onRefresh = {},
       onRetry = {},
+      onRetryLoadMore = {},
     )
   }
 }

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
@@ -61,7 +61,9 @@ class BeersListViewModel(
         is PagingState.Loading ->
           if (currentUiModel != null) {
             // A list is already on screen, so this Loading is a refresh in progress.
-            CommonUiState.Success(currentUiModel.copy(isRefreshing = true, footer = ListFooter.Hidden))
+            CommonUiState.Success(
+              currentUiModel.copy(isRefreshing = true, footer = ListFooter.Hidden)
+            )
           } else {
             CommonUiState.Loading
           }
@@ -88,7 +90,8 @@ class BeersListViewModel(
           }
         is PagingState.EndOfPagination ->
           if (currentUiModel != null) {
-            // The whole catalog is loaded: show the end-of-list caption instead of a footer spinner.
+            // The whole catalog is loaded: show the end-of-list caption instead of a footer
+            // spinner.
             CommonUiState.Success(
               currentUiModel.copy(
                 isLoadingNextPage = false,

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
@@ -8,17 +8,21 @@ import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.CommonUiState
 import com.simtop.core.core.CoroutineDispatcherProvider
+import com.simtop.core.core.PagingEvent
 import com.simtop.core.core.PagingHandler
 import com.simtop.core.core.PagingState
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 
 @ContributesIntoMap(AppScope::class)
@@ -43,6 +47,11 @@ class BeersListViewModel(
   val beerListViewState: StateFlow<CommonUiState<BeersListUiModel>> =
     _beerListViewState.asStateFlow()
 
+  // One-shot UI effects (a transient toast on load-more failure). Channel-backed so a config change
+  // re-collecting the flow doesn't replay a stale toast; mirrors the BeerDetail events pattern.
+  private val _events = Channel<BeersListEvent>(Channel.BUFFERED)
+  val events: Flow<BeersListEvent> = _events.receiveAsFlow()
+
   private val pagingHandler =
     PagingHandler<CommonUiState<BeersListUiModel>, FetchBeersError>(_beerListViewState) {
       currentState,
@@ -52,13 +61,15 @@ class BeersListViewModel(
         is PagingState.Loading ->
           if (currentUiModel != null) {
             // A list is already on screen, so this Loading is a refresh in progress.
-            CommonUiState.Success(currentUiModel.copy(isRefreshing = true))
+            CommonUiState.Success(currentUiModel.copy(isRefreshing = true, footer = ListFooter.Hidden))
           } else {
             CommonUiState.Loading
           }
         is PagingState.LoadingNextPage ->
           if (currentUiModel != null) {
-            CommonUiState.Success(currentUiModel.copy(isLoadingNextPage = true))
+            CommonUiState.Success(
+              currentUiModel.copy(isLoadingNextPage = true, footer = ListFooter.Hidden)
+            )
           } else {
             currentState
           }
@@ -68,6 +79,7 @@ class BeersListViewModel(
               currentUiModel.copy(
                 isLoadingNextPage = false,
                 isRefreshing = false,
+                footer = ListFooter.Hidden,
                 totalCount = pagingState.totalCount ?: currentUiModel.totalCount,
               )
             )
@@ -76,17 +88,27 @@ class BeersListViewModel(
           }
         is PagingState.EndOfPagination ->
           if (currentUiModel != null) {
+            // The whole catalog is loaded: show the end-of-list caption instead of a footer spinner.
             CommonUiState.Success(
-              currentUiModel.copy(isLoadingNextPage = false, isRefreshing = false)
+              currentUiModel.copy(
+                isLoadingNextPage = false,
+                isRefreshing = false,
+                footer = ListFooter.EndReached,
+              )
             )
           } else {
             currentState
           }
         is PagingState.Error ->
           if (currentUiModel != null) {
-            // For pagination error, we might want to show a snackbar but keep the data
+            // A load-more failure keeps the list and offers a retry row; the transient toast is
+            // driven separately off the pager's one-shot events.
             CommonUiState.Success(
-              currentUiModel.copy(isLoadingNextPage = false, isRefreshing = false)
+              currentUiModel.copy(
+                isLoadingNextPage = false,
+                isRefreshing = false,
+                footer = ListFooter.Retry,
+              )
             )
           } else {
             CommonUiState.Error(pagingState.error.toUiMessage())
@@ -100,13 +122,25 @@ class BeersListViewModel(
       FetchBeersError.Network -> "No internet connection"
       FetchBeersError.NotFound -> "Beers not found"
       FetchBeersError.Forbidden -> "Access denied"
+      FetchBeersError.RateLimited -> "Too many requests. Please wait a moment."
       is FetchBeersError.Unknown -> cause.message ?: "Failed to load beers"
     }
 
   init {
     observeBeers()
     observePaging()
+    observeEvents()
     loadFirstPageIfCacheIsEmpty()
+  }
+
+  private fun observeEvents() {
+    pager.events
+      .onEach { event ->
+        when (event) {
+          is PagingEvent.LoadMoreFailed -> _events.trySend(BeersListEvent.ShowLoadMoreError)
+        }
+      }
+      .launchIn(viewModelScope)
   }
 
   private fun loadFirstPageIfCacheIsEmpty() {
@@ -125,21 +159,16 @@ class BeersListViewModel(
           // We rely on PagingState to tell us if we are loading
         } else {
           val currentState = _beerListViewState.value
-          // Preserve isLoadingNextPage flag when updating the list
-          val isLoadingNextPage =
-            if (currentState is CommonUiState.Success) {
-              currentState.data.isLoadingNextPage
-            } else {
-              false
-            }
+          // A fresh beers emission rebuilds the model, so carry over the transient paging flags the
+          // reducer owns (loading/refreshing/footer) instead of resetting them under the new list.
+          val current = (currentState as? CommonUiState.Success)?.data
           _beerListViewState.value =
             CommonUiState.Success(
               BeersListUiModel(
                 beers = beers,
-                isLoadingNextPage = isLoadingNextPage,
-                isRefreshing =
-                  if (currentState is CommonUiState.Success) currentState.data.isRefreshing
-                  else false,
+                isLoadingNextPage = current?.isLoadingNextPage ?: false,
+                isRefreshing = current?.isRefreshing ?: false,
+                footer = current?.footer ?: ListFooter.Hidden,
                 totalCount = lastTotalCount,
               )
             )
@@ -163,15 +192,35 @@ class BeersListViewModel(
     viewModelScope.launch(coroutineDispatcher.io) { pager.loadNextPage() }
   }
 
+  /** Footer retry tap: reloads the failed next page. Retry is free - the key never advanced. */
+  fun onRetryLoadMore() {
+    viewModelScope.launch(coroutineDispatcher.io) { pager.loadNextPage() }
+  }
+
   fun refresh() {
     viewModelScope.launch(coroutineDispatcher.io) { pager.loadFirstPage() }
   }
+}
+
+/** The list's bottom item: nothing, a retry row after a failed "load more", or the end caption. */
+sealed interface ListFooter {
+  data object Hidden : ListFooter
+
+  data object Retry : ListFooter
+
+  data object EndReached : ListFooter
+}
+
+/** One-shot effects the screen consumes exactly once. */
+sealed interface BeersListEvent {
+  data object ShowLoadMoreError : BeersListEvent
 }
 
 data class BeersListUiModel(
   val beers: List<Beer> = emptyList(),
   val isLoadingNextPage: Boolean = false,
   val isRefreshing: Boolean = false,
+  val footer: ListFooter = ListFooter.Hidden,
   // Server-reported catalog size (X-Total-Count); null until the server reports it. Renders "N of
   // M".
   val totalCount: Int? = null,

--- a/feature/beerslist/src/main/res/values-es/strings.xml
+++ b/feature/beerslist/src/main/res/values-es/strings.xml
@@ -2,4 +2,7 @@
 <resources>
     <string name="billion_beers_list">"Lista de mil millones de cervezas"</string>
     <string name="beers_count_of_total">%1$d de %2$d</string>
+    <string name="beers_load_more_failed">No se pudieron cargar más cervezas</string>
+    <string name="beers_load_more_retry">Reintentar</string>
+    <string name="beers_end_of_list">Eso es todo: %1$d cervezas</string>
 </resources>

--- a/feature/beerslist/src/main/res/values-fr/strings.xml
+++ b/feature/beerslist/src/main/res/values-fr/strings.xml
@@ -2,4 +2,7 @@
 <resources>
     <string name="billion_beers_list">"Liste de milliards de bières"</string>
     <string name="beers_count_of_total">%1$d sur %2$d</string>
+    <string name="beers_load_more_failed">Impossible de charger plus de bières</string>
+    <string name="beers_load_more_retry">Réessayer</string>
+    <string name="beers_end_of_list">C\'est tout : %1$d bières</string>
 </resources>

--- a/feature/beerslist/src/main/res/values/strings.xml
+++ b/feature/beerslist/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
 <resources>
     <string name="billion_beers_list">"Billion Beers List"</string>
     <string name="beers_count_of_total">%1$d of %2$d</string>
+    <string name="beers_load_more_failed">Couldn\'t load more beers</string>
+    <string name="beers_load_more_retry">Retry</string>
+    <string name="beers_end_of_list">That\'s all %1$d beers</string>
 </resources>

--- a/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
+++ b/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
@@ -1,11 +1,13 @@
 package com.simtop.feature.beerslist
 
 import app.cash.turbine.test
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.fakes.FakeBeersPagerFactory
 import com.simtop.beerdomain.fakes.FakeBeersRepository
 import com.simtop.core.core.CommonUiState
 import com.simtop.core.core.CoroutineDispatcherProvider
+import com.simtop.core.core.PagingEvent
 import com.simtop.core.core.PagingState
 import io.mockk.every
 import io.mockk.mockk
@@ -89,6 +91,45 @@ class BeersListViewModelTest {
         val finalState = awaitItem()
         expectThat(finalState).isA<CommonUiState.Success<BeersListUiModel>>()
         expectThat((finalState as CommonUiState.Success).data.isLoadingNextPage).isFalse()
+      }
+    }
+
+  @Test
+  fun `a failed load-more surfaces a retry footer and a one-shot error event`() =
+    runTest(testDispatcher) {
+      fakeBeersRepository.setBeers(listOf(Beer.empty.copy(id = "1")))
+      val viewModel = buildViewModel()
+      val pager = fakeBeersPagerFactory.pager
+
+      viewModel.events.test {
+        viewModel.beerListViewState.test {
+          expectThat(awaitItem()).isA<CommonUiState.Success<BeersListUiModel>>()
+
+          // The pager reports a non-first-page failure and emits its one-shot event.
+          pager.setPagingState(PagingState.Error(FetchBeersError.RateLimited, isFirstPage = false))
+          pager.emitEvent(PagingEvent.LoadMoreFailed(FetchBeersError.RateLimited))
+
+          val state = awaitItem()
+          expectThat((state as CommonUiState.Success).data.footer).isEqualTo(ListFooter.Retry)
+        }
+        expectThat(awaitItem()).isEqualTo(BeersListEvent.ShowLoadMoreError)
+      }
+    }
+
+  @Test
+  fun `end of pagination surfaces the end-of-list footer`() =
+    runTest(testDispatcher) {
+      fakeBeersRepository.setBeers(listOf(Beer.empty.copy(id = "1")))
+      val viewModel = buildViewModel()
+      val pager = fakeBeersPagerFactory.pager
+
+      viewModel.beerListViewState.test {
+        expectThat(awaitItem()).isA<CommonUiState.Success<BeersListUiModel>>()
+
+        pager.setPagingState(PagingState.EndOfPagination)
+
+        val state = awaitItem()
+        expectThat((state as CommonUiState.Success).data.footer).isEqualTo(ListFooter.EndReached)
       }
     }
 

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_END_OF_LIST]_beerslistscreenpreview_success_end_of_list.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_END_OF_LIST]_beerslistscreenpreview_success_end_of_list.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a627514088787928ed38531b56cf4e5b2b883b2f3ce2dbe023b78c056cad3136
+size 21387

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_LOAD_MORE_FAILED]_beerslistscreenpreview_success_load_more_failed.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_LOAD_MORE_FAILED]_beerslistscreenpreview_success_load_more_failed.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b891112110d459b0cfa870703ae77c0b1f6cfec606eeea04e76d7a0bb9068157
+size 23180


### PR DESCRIPTION
Paging 2.0 sub-PR 1c: the list now says what happened at the bottom.

Before this, a failed "load more" silently swallowed the error (the code literally said
"we might want to show a snackbar") and reaching the end looked identical to more-to-come.
1c closes both, and adds the missing rate-limit case.

**One-shot events (core-common).** The mediator exposes a conflated `events` channel
alongside `pagingState`. A *subsequent*-page failure keeps the list (its `Error` state
drives the footer) and additionally fires `PagingEvent.LoadMoreFailed`. It has to be a
channel, not the StateFlow: a StateFlow replays its current `Error` to every new collector,
so a config-change re-collect would re-fire the toast. First-page failures stay the
full-screen `Error` path and emit nothing. `FakePager` gains `emitEvent`.

**Footer (feature/beerslist).** `BeersListUiModel` gains a `ListFooter` (Hidden / Retry /
EndReached) reduced from `PagingState`: a load-more failure shows a retry row (tap re-runs
the free retry), end-of-pagination shows an end caption ("That's all N beers" — N is
`beers.size`, which equals the total once the whole catalog is in, so the footer needs no
nullable total). `isLoadingNextPage` keeps driving the existing spinner and the load-more
guard, so the footer is purely additive — every existing screenshot is byte-identical and
only the two new footer states get baselines.

**Toast + rate limit.** The view model relays `LoadMoreFailed` to a one-shot toast
("Couldn't load more beers"); the footer owns recovery. Adds `FetchBeersError.RateLimited`
(HTTP 429, named constant — no `HttpURLConnection` value for it) with a friendly full-screen
message for a first-page 429.

**Auto-load vs. retry.** `InfiniteListHandler` only gates on `isLoadingNextPage`, so after a
failure — user parked at the bottom — it could auto-re-fire and bypass the Retry button
(and, on a 429, loop). The handler is now suspended while the retry footer is shown; tapping
Retry clears it and re-arms auto-load. (The handler's own `isLoadingNextPage` staleness is
pre-existing and out of scope; this gate sidesteps it locally.)

**Tests.** Mediator: a non-first-page failure emits `LoadMoreFailed`, a first-page failure
emits nothing. Factory: HTTP 429 → `RateLimited`. View model: retry footer + one-shot event
on load-more failure, end footer on end-of-pagination. Plus the two new Paparazzi baselines.

Third slice of Phase 1; 1d (contract + warm-fixture tests) closes it out.
