### PR TITLE
test: PagingStorage contract + warm-start coverage (Paging 2.0 1d)

### DIFF
--- a/core-common/src/test/kotlin/com/simtop/core/core/PagingStorageContractTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagingStorageContractTest.kt
@@ -1,0 +1,107 @@
+package com.simtop.core.core
+
+import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * The behaviour every [PagingStorage] must satisfy, regardless of where it stores pages. Concrete
+ * implementations subclass this and run the whole suite, so a new paged surface (search, favorites)
+ * gets the invariants for free and can't silently break them - the PR-#57 class of bug lived
+ * exactly in a storage that looked fine in isolation.
+ *
+ * Two families exist by design and can't share one assertion for a refresh: a network-only storage
+ * *replaces* its contents on [PagingStorage.storeFirstPage] (the fetched page is the whole truth),
+ * while a DB-backed SSOT *merges* (upsert, never delete, so a locally-owned column survives). That
+ * single difference is declared via [storeFirstPageReplaces]; everything else is shared.
+ */
+@ExperimentalCoroutinesApi
+abstract class PagingStorageContractTest {
+
+  /** A fresh, empty storage for each test. */
+  abstract fun createStorage(): PagingStorage<Int, String>
+
+  /** True if [PagingStorage.storeFirstPage] replaces existing contents; false if it merges them. */
+  abstract val storeFirstPageReplaces: Boolean
+
+  private fun page(vararg items: String) = PageResult<Int, String>(items.toList(), nextKey = null)
+
+  @Test
+  fun `storeFirstPage surfaces its items in data`() = runTest {
+    val storage = createStorage()
+
+    storage.storeFirstPage(page("a", "b"))
+
+    storage.data.test { assertEquals(listOf("a", "b"), awaitItem()) }
+  }
+
+  @Test
+  fun `append adds a subsequent page after the first, in order`() = runTest {
+    val storage = createStorage()
+    storage.storeFirstPage(page("a", "b"))
+
+    storage.append(page("c", "d"))
+
+    storage.data.test { assertEquals(listOf("a", "b", "c", "d"), awaitItem()) }
+  }
+
+  @Test
+  fun `append never drops earlier pages`() = runTest {
+    val storage = createStorage()
+    storage.storeFirstPage(page("a"))
+    storage.append(page("b"))
+
+    storage.append(page("c"))
+
+    storage.data.test { assertEquals(listOf("a", "b", "c"), awaitItem()) }
+  }
+
+  @Test
+  fun `storeFirstPage over existing data replaces or merges as declared`() = runTest {
+    val storage = createStorage()
+    storage.storeFirstPage(page("a", "b"))
+
+    // A refresh delivering a disjoint page - replace keeps only the new one, merge keeps both.
+    storage.storeFirstPage(page("c"))
+
+    val expected = if (storeFirstPageReplaces) listOf("c") else listOf("a", "b", "c")
+    storage.data.test { assertEquals(expected, awaitItem()) }
+  }
+}
+
+/** Network-only storage: [PagingStorage.storeFirstPage] replaces. */
+@ExperimentalCoroutinesApi
+class InMemoryPagingStorageContractTest : PagingStorageContractTest() {
+  override fun createStorage() = InMemoryPagingStorage<Int, String>()
+
+  override val storeFirstPageReplaces = true
+}
+
+/**
+ * A minimal upsert-by-value storage standing in for a DB-backed SSOT: every write merges instead of
+ * replacing, mirroring the beers cache's "refresh never deletes" policy. The real Room storage's
+ * merge is covered end-to-end by BeersPagerFactoryImplTest (composition) and the instrumented DAO
+ * test; this proves the *contract itself* holds for the merging family.
+ */
+@ExperimentalCoroutinesApi
+class MergingPagingStorageContractTest : PagingStorageContractTest() {
+  override fun createStorage() =
+    object : PagingStorage<Int, String> {
+      private val items = MutableStateFlow<List<String>>(emptyList())
+      override val data = items
+
+      private fun upsert(page: List<String>) = items.update { current ->
+        current + page.filterNot(current::contains)
+      }
+
+      override suspend fun storeFirstPage(page: PageResult<Int, String>) = upsert(page.items)
+
+      override suspend fun append(page: PageResult<Int, String>) = upsert(page.items)
+    }
+
+  override val storeFirstPageReplaces = false
+}

--- a/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
+++ b/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
@@ -168,6 +168,23 @@ class BeersListViewModelTest {
       expectThat(fakeBeersPagerFactory.pager.loadFirstPageCallCount).isEqualTo(0)
     }
 
+  // Warm start: a previous process left beers cached, so the screen shows them straight away
+  // (Success, not the Loading skeleton) with no network first-page load.
+  @Test
+  fun `a warm cache surfaces the cached beers as Success without loading the first page`() =
+    runTest(testDispatcher) {
+      fakeBeersRepository.setBeers(listOf(Beer.empty.copy(id = "1"), Beer.empty.copy(id = "2")))
+      val viewModel = buildViewModel()
+
+      viewModel.beerListViewState.test {
+        val state = awaitItem()
+        expectThat(state).isA<CommonUiState.Success<BeersListUiModel>>()
+        expectThat((state as CommonUiState.Success).data.beers.map { it.id })
+          .isEqualTo(listOf("1", "2"))
+      }
+      expectThat(fakeBeersPagerFactory.pager.loadFirstPageCallCount).isEqualTo(0)
+    }
+
   // Regression test: PagingState.Loading over an already-shown list is a refresh in progress, so
   // the pull-to-refresh indicator must stay visible until the load resolves.
   @Test


### PR DESCRIPTION
Paging 2.0 sub-PR 1d: close out Phase 1 with the cross-cutting test pieces.

Most of Workstream D's checklist was already satisfied by the per-feature tests that landed
in 1a–1c (single-request guard in BeersRepositoryTest, end-detection and resume in
PagingMediatorTest / BeersPagerFactoryImplTest, the instrumented migration + DAO tests in
1b). This adds the two genuinely-missing pieces and nothing redundant.

**PagingStorageContractTest.** An abstract spec of the invariants every `PagingStorage`
must hold no matter where it stores pages — `storeFirstPage` surfaces its items, `append`
grows the list in order and never drops earlier pages — with the one refresh difference
declared per implementation (`storeFirstPageReplaces`): a network-only storage replaces, a
DB-backed SSOT merges. Run against `InMemoryPagingStorage` (replace) and a merging stand-in
(merge), so both families are pinned and a future paged surface (search, favorites) inherits
the contract. The real Room storage's merge stays covered end-to-end by the factory
composition and instrumented DAO tests, so this doesn't duplicate them.

**Warm-start view-model test.** Complements the existing "no first-page load on a warm
cache" check by asserting the screen actually shows the cached list straight away (Success,
not the Loading skeleton) — the user-visible payoff of the paging_state resume work carrying
a cold start.

Deliberately out of scope: an `InfiniteListHandler` staleness fix (already neutralised
locally in 1c; a proper fix + test is a cleaner standalone chore) and a warm-fixture
refactor (the existing tests had no real duplication to remove).

Final slice of Phase 1 — the hand-rolled pager now knows where the list ends, resumes
exactly across process death, and reports what failed.
