### PR TITLE
fix: count-based load-more trigger in InfiniteListHandler (drop stale flag)

### DIFF
--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -217,15 +217,10 @@ fun BeersListContent(
             val listState = rememberLazyListState()
 
             // Suspend auto-load while the retry footer is up: the user is parked at the bottom
-            // after
-            // a failure, so an unconditional scroll trigger would bypass the Retry button and, on a
-            // 429, auto-loop. Tapping Retry clears the footer and re-arms the handler.
+            // after a failure, so scrolling away and back would re-trigger a load instead of
+            // waiting for an explicit Retry tap. Tapping Retry clears the footer and re-arms it.
             if (state.data.footer !is ListFooter.Retry) {
-              InfiniteListHandler(
-                listState = listState,
-                isLoadingNextPage = state.data.isLoadingNextPage,
-                onLoadMore = onScrollToBottom,
-              )
+              InfiniteListHandler(listState = listState, onLoadMore = onScrollToBottom)
             }
 
             val layoutDirection = LocalLayoutDirection.current

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/core/InfiniteListHandler.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/core/InfiniteListHandler.kt
@@ -3,30 +3,52 @@ package com.simtop.presentation_utils.core
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 
-@Composable
-fun InfiniteListHandler(
-  listState: LazyListState,
-  isLoadingNextPage: Boolean,
-  buffer: Int = 1,
-  onLoadMore: () -> Unit,
-) {
-  val loadMore = remember {
-    derivedStateOf {
-      val layoutInfo = listState.layoutInfo
-      val totalItemsNumber = layoutInfo.totalItemsCount
-      val lastVisibleItemIndex = (layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0) + 1
+/**
+ * A scroll position sampled from a [LazyListState]: how many items exist and the last one shown.
+ */
+internal data class ListPosition(val totalItems: Int, val lastVisibleIndex: Int)
 
-      !isLoadingNextPage && lastVisibleItemIndex > (totalItemsNumber - buffer)
+/**
+ * Emits one "load more" signal each time the list first reaches near its bottom for a *new* length.
+ *
+ * The latch key is the item count, not a boolean: firing once per distinct at-bottom count means a
+ * load already in flight (count unchanged) or a load that failed (count unchanged) produces no
+ * further signal on its own - no double-fetch, no auto-retry loop - while a page that grew the list
+ * re-arms the next fetch. The old implementation gated on an `isLoadingNextPage` flag captured in
+ * an unkeyed `remember`, so the flag was stale and effectively dead; this needs no such flag - the
+ * pager's own mutex collapses any overlap.
+ */
+internal fun Flow<ListPosition>.loadMoreSignals(buffer: Int): Flow<Unit> =
+  map { position ->
+      val lastVisiblePlusOne = position.lastVisibleIndex + 1
+      position.totalItems.takeIf { lastVisiblePlusOne > it - buffer }
     }
-  }
+    .distinctUntilChanged()
+    .filterNotNull()
+    .map {}
 
-  LaunchedEffect(loadMore) {
-    snapshotFlow { loadMore.value }.distinctUntilChanged().filter { it }.collect { onLoadMore() }
+/**
+ * Calls [onLoadMore] when the user scrolls near the end of [listState] (within [buffer] items),
+ * once per distinct list length - see [loadMoreSignals] for why the dedup is count-based. Correct
+ * on its own: a caller need not suppress it during a load or an error to avoid a re-fetch loop.
+ */
+@Composable
+fun InfiniteListHandler(listState: LazyListState, buffer: Int = 1, onLoadMore: () -> Unit) {
+  LaunchedEffect(listState, buffer) {
+    snapshotFlow {
+        val layoutInfo = listState.layoutInfo
+        ListPosition(
+          totalItems = layoutInfo.totalItemsCount,
+          lastVisibleIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0,
+        )
+      }
+      .loadMoreSignals(buffer)
+      .collect { onLoadMore() }
   }
 }

--- a/presentation_utils/src/test/java/com/simtop/presentation_utils/core/InfiniteListHandlerTest.kt
+++ b/presentation_utils/src/test/java/com/simtop/presentation_utils/core/InfiniteListHandlerTest.kt
@@ -1,0 +1,71 @@
+package com.simtop.presentation_utils.core
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+@ExperimentalCoroutinesApi
+class InfiniteListHandlerTest {
+
+  private suspend fun signalsFor(vararg positions: ListPosition, buffer: Int = 1): Int =
+    flowOf(*positions).loadMoreSignals(buffer).toList().size
+
+  @Test
+  fun `reaching the bottom fires exactly one signal`() = runTest {
+    val count =
+      signalsFor(
+        ListPosition(totalItems = 25, lastVisibleIndex = 5), // mid-list: not near bottom
+        ListPosition(totalItems = 25, lastVisibleIndex = 24), // last item visible: near bottom
+      )
+
+    count shouldBeEqualTo 1
+  }
+
+  // The key regression guard: the same at-bottom count arriving twice (a load in flight, or a load
+  // that just failed - neither grows the list) must NOT re-fire. This is what the stale-flag
+  // implementation got wrong.
+  @Test
+  fun `the same at-bottom count does not re-fire`() = runTest {
+    val count =
+      signalsFor(
+        ListPosition(totalItems = 25, lastVisibleIndex = 24),
+        ListPosition(totalItems = 25, lastVisibleIndex = 24),
+      )
+
+    count shouldBeEqualTo 1
+  }
+
+  @Test
+  fun `a longer list re-arms the next signal`() = runTest {
+    val count =
+      signalsFor(
+        ListPosition(totalItems = 25, lastVisibleIndex = 24), // bottom of page 1 -> fire
+        ListPosition(totalItems = 50, lastVisibleIndex = 24), // page 2 loaded, no longer at bottom
+        ListPosition(totalItems = 50, lastVisibleIndex = 49), // bottom of page 2 -> fire again
+      )
+
+    count shouldBeEqualTo 2
+  }
+
+  @Test
+  fun `staying away from the bottom never fires`() = runTest {
+    val count =
+      signalsFor(
+        ListPosition(totalItems = 50, lastVisibleIndex = 5),
+        ListPosition(totalItems = 50, lastVisibleIndex = 10),
+      )
+
+    count shouldBeEqualTo 0
+  }
+
+  @Test
+  fun `buffer widens the near-bottom trigger`() = runTest {
+    // With buffer 5, item 20 of 25 already counts as "near bottom" (20 + 1 > 25 - 5).
+    val count = signalsFor(ListPosition(totalItems = 25, lastVisibleIndex = 20), buffer = 5)
+
+    count shouldBeEqualTo 1
+  }
+}


### PR DESCRIPTION
Harden the shared infinite-scroll handler so its correctness doesn't depend on the caller.

`InfiniteListHandler` gated its load-more trigger on an `isLoadingNextPage` flag read inside
a `remember { derivedStateOf { … } }` with **no keys** — so the flag was captured once and
never updated, i.e. the guard was effectively dead. It happened to be harmless in the beers
list (the 1c retry footer already unmounts the handler on a load-more failure, and
`distinctUntilChanged` masked the rest), but any future paged screen reusing it without that
gate could re-fire on a stuck state.

**Fix: a count-based latch instead of a boolean.** The trigger now emits one "load more"
signal per *distinct at-bottom list length*. A load already in flight or one that just failed
leaves the count unchanged, so nothing fires again on its own — no double-fetch, no auto-retry
loop — while a page that grew the list re-arms the next fetch. No `isLoadingNextPage` needed
(the pager's own mutex collapses any overlap), so the parameter is dropped and the one caller
updated.

The trigger condition (near-bottom threshold + the count dedup) is extracted into a pure
`Flow<ListPosition> -> Flow<Unit>` operator and unit-tested: reaching the bottom fires once,
the **same at-bottom count arriving twice fires nothing** (the case the old logic got wrong),
a longer list re-arms, staying away never fires, and `buffer` widens the trigger.

Behavioral note: firing per distinct at-bottom count (vs. the old "once while at bottom")
means that if a whole page ever fit on screen at once it would auto-page to fill the
viewport — a non-issue at page size 25 on a phone, and self-limiting at end-of-list.

Verified on the emulator: scrolling the beers list still pages 25 → 50 → 75 of 206.
