### PR TITLE
feat: query-parameterised pager for search (Paging 2.0 2a)

### DIFF
--- a/app/src/test/java/com/simtop/billionbeers/data/BeersRemoteSourceTest.kt
+++ b/app/src/test/java/com/simtop/billionbeers/data/BeersRemoteSourceTest.kt
@@ -47,4 +47,24 @@ class BeersRemoteSourceTest : TestMockWebService() {
 
     runBlocking { remoteSource.getListOfBeers(1) }
   }
+
+  @Test
+  fun `a search sends the q query parameter`() {
+    mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_OK, mapOf("X-Total-Count" to "159"))
+
+    runBlocking { remoteSource.getListOfBeers(1, search = "ipa") }
+
+    val path = mockServer.takeRequest().path.orEmpty()
+    path.contains("q=ipa") shouldBeEqualTo true
+  }
+
+  @Test
+  fun `a catalog fetch omits the q query parameter`() {
+    mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_OK)
+
+    runBlocking { remoteSource.getListOfBeers(1) }
+
+    val path = mockServer.takeRequest().path.orEmpty()
+    path.contains("q=") shouldBeEqualTo false
+  }
 }

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
@@ -3,8 +3,10 @@ package com.simtop.beer_data.repositories
 import com.simtop.beer_network.network.BeersService
 import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeersQuery
 import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.core.core.InMemoryPagingStorage
 import com.simtop.core.core.LanguageProvider
 import com.simtop.core.core.PageResult
 import com.simtop.core.core.Pager
@@ -52,6 +54,24 @@ class BeersPagerFactoryImpl(
       },
     )
   }
+
+  override fun create(query: BeersQuery): Pager<Beer, FetchBeersError> =
+    // Search is its own surface: results live only in memory (they die with the screen and a new
+    // query instantly invalidates them) and never touch the beers table, so the catalog's
+    // SELECT * view is untouched. No nextKeyFromStorage - there's no warm cache to resume from.
+    PagingMediator(
+      initialKey = FIRST_PAGE,
+      fetchRemote = { page ->
+        val beerPage = repository.getBeersPageFromApi(page, query.search)
+        val total = beerPage.totalCount
+        val nextKey =
+          if (total != null && page * BeersService.DEFAULT_ITEMS_PER_PAGE >= total) null
+          else page + 1
+        PageResult(items = beerPage.items, nextKey = nextKey, totalCount = total)
+      },
+      classifyError = { it.toFetchBeersError() },
+      storage = InMemoryPagingStorage(),
+    )
 
   private fun Throwable.toFetchBeersError(): FetchBeersError =
     when (this) {

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
@@ -24,8 +24,8 @@ class BeersRepositoryImpl(
   private val beersMapper: BeersMapper,
 ) : BeersRepository {
 
-  override suspend fun getBeersPageFromApi(page: Int): BeerPage {
-    val remotePage = beersRemoteSource.getListOfBeers(page)
+  override suspend fun getBeersPageFromApi(page: Int, search: String?): BeerPage {
+    val remotePage = beersRemoteSource.getListOfBeers(page, search)
     return BeerPage(
       items = remotePage.items.map { beersMapper.fromBeersApiResponseItemToBeer(it) },
       totalCount = remotePage.totalCount,

--- a/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersRemoteSource.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersRemoteSource.kt
@@ -12,6 +12,7 @@ class FakeBeersRemoteSource : BeersRemoteSource {
   private var exceptionToThrow: Exception = Exception("Fake Remote Error")
 
   val requestedPages = mutableListOf<Int>()
+  val requestedSearches = mutableListOf<String?>()
 
   fun setBeersResponse(beers: List<BeersApiResponseItem>, totalCount: Int? = null) {
     beersResponse = beers
@@ -26,8 +27,9 @@ class FakeBeersRemoteSource : BeersRemoteSource {
     exceptionToThrow = exception
   }
 
-  override suspend fun getListOfBeers(page: Int): BeersPage {
+  override suspend fun getListOfBeers(page: Int, search: String?): BeersPage {
     requestedPages += page
+    requestedSearches += search
     if (shouldThrowError) {
       throw exceptionToThrow
     }

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -6,6 +6,7 @@ import com.simtop.beer_data.mappers.BeersMapper
 import com.simtop.beer_network.models.BeersApiResponseItem
 import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeersQuery
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.LanguageProvider
 import com.simtop.core.core.NoOpLogger
@@ -191,6 +192,20 @@ class BeersPagerFactoryImplTest {
 
       expectThat(pager.pagingState.value)
         .isEqualTo(PagingState.Error(FetchBeersError.RateLimited, isFirstPage = true))
+    }
+
+  @Test
+  fun `a search pager fetches with the query term and keeps results in memory`() =
+    runTest(testDispatcher) {
+      beersRemoteSource.setBeersResponse(listOf(apiItem(id = "1")), totalCount = 1)
+      val pager = factory.create(BeersQuery(search = "ipa"))
+
+      pager.loadFirstPage()
+
+      expectThat(pager.data.first().map { it.id }).isEqualTo(listOf("1"))
+      expectThat(beersRemoteSource.requestedSearches.toList()).isEqualTo(listOf("ipa"))
+      // Pure in-memory surface: a search must never write into the catalog's beers table.
+      expectThat(repository.countDBEntries()).isEqualTo(0)
     }
 
   @Test

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
@@ -62,6 +62,16 @@ class BeersRepositoryTest {
     }
 
   @Test
+  fun `getBeersPageFromApi forwards the search term to the remote source`() =
+    runTest(testDispatcher) {
+      beersRemoteSource.setBeersResponse(emptyList(), totalCount = 0)
+
+      beersRepository.getBeersPageFromApi(1, search = "stout")
+
+      expectThat(beersRemoteSource.requestedSearches.toList()).isEqualTo(listOf("stout"))
+    }
+
+  @Test
   fun `updateAvailability should call local source`() =
     runTest(testDispatcher) {
       // Arrange

--- a/beer_network/src/main/java/com/simtop/beer_network/network/BeersService.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/network/BeersService.kt
@@ -12,6 +12,8 @@ interface BeersService {
     @Query("_page") page: Int,
     @Query("_limit") perPage: Int = DEFAULT_ITEMS_PER_PAGE,
     @Query("translations.language.code") languageCode: String = DEFAULT_LANGUAGE_CODE,
+    // Free-text search; null (catalog) omits the param entirely so the full list is returned.
+    @Query("q") search: String? = null,
   ): Response<List<BeersApiResponseItem>>
 
   companion object {

--- a/beer_network/src/main/java/com/simtop/beer_network/remotesources/BeersRemoteSource.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/remotesources/BeersRemoteSource.kt
@@ -6,7 +6,8 @@ import com.simtop.core.core.LanguageProvider
 import dev.zacsweers.metro.Inject
 
 interface BeersRemoteSource {
-  suspend fun getListOfBeers(page: Int): BeersPage
+  /** [search] null fetches the full catalog; non-null adds `q=` for the search surface. */
+  suspend fun getListOfBeers(page: Int, search: String? = null): BeersPage
 }
 
 class BeersRemoteSourceImpl
@@ -14,9 +15,13 @@ class BeersRemoteSourceImpl
 constructor(private val service: BeersService, private val languageProvider: LanguageProvider) :
   BeersRemoteSource {
 
-  override suspend fun getListOfBeers(page: Int): BeersPage {
+  override suspend fun getListOfBeers(page: Int, search: String?): BeersPage {
     val response =
-      service.getListOfBeers(page = page, languageCode = languageProvider.currentLanguageCode())
+      service.getListOfBeers(
+        page = page,
+        languageCode = languageProvider.currentLanguageCode(),
+        search = search,
+      )
     // Malformed or absent header → null; the pager falls back to the empty-page probe.
     val totalCount = response.headers()[HEADER_TOTAL_COUNT]?.toIntOrNull()
     return BeersPage(items = response.body().orEmpty(), totalCount = totalCount)

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/BeersQuery.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/BeersQuery.kt
@@ -1,0 +1,12 @@
+package com.simtop.beerdomain.domain.models
+
+/**
+ * The identity of a paged beers surface: what to fetch, as a value. A pager is created *for* a
+ * query, and a changed query means a *new* pager, not a mutation - which keeps invalidation out of
+ * the mediator (see `BeersPagerFactory`).
+ *
+ * Phase 2 wires only [search] (`q=`); language stays on the `LanguageProvider` the way the catalog
+ * does it, so it isn't part of the query. Style/brewery/abv/sort filters are Phase 3 - additive and
+ * non-breaking when they arrive.
+ */
+data class BeersQuery(val search: String)

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersPagerFactory.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersPagerFactory.kt
@@ -2,20 +2,25 @@ package com.simtop.beerdomain.domain.repositories
 
 import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeersQuery
 import com.simtop.core.core.Pager
 
 /**
- * Creates a fully wired beers pager. Each screen calls [create] once and owns the returned
+ * Creates a fully wired beers pager. Each screen calls a `create` once and owns the returned
  * instance, so paging *position* (current page, end-of-list) is scoped to that screen instead of
  * living on an app-scoped singleton (docs/adr/0002-hand-rolled-paging.md).
  *
- * The paged *data* is not screen-scoped: every pager from this factory reads and writes the one
- * beers table, which is only sound while the full catalog list is the app's single paged surface. A
- * future differently-filtered surface (favorites, search) needs its own factory whose storage
- * queries are scoped by that surface's parameters - not a second pager over this table.
+ * Two surfaces exist, and they deliberately do **not** share storage:
+ * - [create] (no args) is the **catalog**: the Room-backed single source of truth, whose pager
+ *   reads and writes the one beers table and resumes from the `paging_state` bookmark.
+ * - [create] with a [BeersQuery] is a **search** surface: a per-query in-memory pager whose results
+ *   die with the screen and never touch the beers table (so the catalog's `SELECT * FROM beers`
+ *   view can't be polluted by search hits). A changed query means a new pager, not a mutation.
  *
  * The factory itself is stateless, so it can safely be an app-scoped binding.
  */
 interface BeersPagerFactory {
   fun create(): Pager<Beer, FetchBeersError>
+
+  fun create(query: BeersQuery): Pager<Beer, FetchBeersError>
 }

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -45,6 +45,9 @@ interface BeersRepository {
 
   suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit>
 
-  /** Fetches one page from the API, carrying the server total for end-detection and "N of M" UI. */
-  suspend fun getBeersPageFromApi(page: Int): BeerPage
+  /**
+   * Fetches one page from the API, carrying the server total for end-detection and "N of M" UI.
+   * [search] null fetches the full catalog; non-null fetches the `q=` search surface.
+   */
+  suspend fun getBeersPageFromApi(page: Int, search: String? = null): BeerPage
 }

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersPagerFactory.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersPagerFactory.kt
@@ -2,6 +2,7 @@ package com.simtop.beerdomain.fakes
 
 import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeersQuery
 import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.core.core.Pager
 import com.simtop.core.core.PagingEvent
@@ -57,5 +58,13 @@ class FakeBeersPagerFactory(repository: FakeBeersRepository) : BeersPagerFactory
 
   val pager: FakePager<Beer, FetchBeersError> = FakePager(repository.observeBeers())
 
+  /** Every query a search pager was created for, so tests can assert debounce/cancel behaviour. */
+  val createdQueries = mutableListOf<BeersQuery>()
+
   override fun create(): Pager<Beer, FetchBeersError> = pager
+
+  override fun create(query: BeersQuery): Pager<Beer, FetchBeersError> {
+    createdQueries += query
+    return pager
+  }
 }

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
@@ -93,7 +93,11 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
 
   var apiPage: BeerPage = BeerPage(emptyList(), null)
 
-  override suspend fun getBeersPageFromApi(page: Int): BeerPage {
+  /** Records every (page, search) the pager fetched, so tests can assert what was requested. */
+  val apiRequests = mutableListOf<Pair<Int, String?>>()
+
+  override suspend fun getBeersPageFromApi(page: Int, search: String?): BeerPage {
+    apiRequests += page to search
     return apiPage
   }
 }


### PR DESCRIPTION
Paging 2.0 sub-PR 2a: the data-layer foundation for search — a query-parameterised pager.

First slice of Phase 2 (Search). No UI yet; this makes the pager fetch a filtered surface.

**Query plumbing.** A `q=` search term threads through `BeersService` ->
`BeersRemoteSource.getListOfBeers(page, search)` -> `BeersRepository.getBeersPageFromApi(page,
search)`. `search == null` is the catalog (the param is omitted entirely); non-null is the
search surface.

**`create(query)`.** `BeersPagerFactory` gains `create(query: BeersQuery)` alongside the
existing catalog `create()`. It builds a per-query pager over `InMemoryPagingStorage`: search
results live only in memory (they die with the screen and a new query invalidates them
instantly) and **never touch the beers table**. That's deliberate — the catalog pager observes
`SELECT * FROM beers`, so writing search hits there would show un-paged beers in the catalog and
blow "N of 206" past 206. It also isn't needed: search -> detail passes the full `Beer` through
navigation (like the catalog), so detail needs no DB row. The catalog `create()` path is
untouched.

`BeersQuery` models only `search` for now; style / brewery / abv / sort are Phase 3 (additive,
non-breaking). Language stays on `LanguageProvider`, as the catalog does it.

**Tests.** The search pager forwards the term to the remote source and keeps results in memory
(zero DB writes); a MockWebServer test confirms `q=ipa` is sent for a search and no `q=` for the
catalog. All Phase-1 catalog tests stay green.

Next: 2b (`feature/beersearch` module + the debounced, cancel-stale-pager view model), then 2c
(search screen UI + nav + screenshots).
