### PR TITLE
feat: debounced cancel-stale search view model + beersearch module (Paging 2.0 2b)

### DIFF
--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersPagerFactory.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersPagerFactory.kt
@@ -15,11 +15,19 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
- * A [Pager] whose [data] is whatever flow the test wires in and whose [pagingState]/[events] are
- * set directly with [setPagingState]/[emitEvent] - load calls are only recorded, never fetch
- * anything.
+ * A [Pager] whose [pagingState]/[events] are set directly with [setPagingState]/[emitEvent] and
+ * whose [data] is either an external flow wired in (catalog, backed by the repository) or, when
+ * none is given, an internal source driven with [setData] (search). Load calls are only recorded.
  */
-class FakePager<Value : Any, E : Any>(override val data: Flow<List<Value>>) : Pager<Value, E> {
+class FakePager<Value : Any, E : Any>(dataFlow: Flow<List<Value>>? = null) : Pager<Value, E> {
+
+  private val _data = MutableStateFlow<List<Value>>(emptyList())
+  override val data: Flow<List<Value>> = dataFlow ?: _data
+
+  /** Pushes items when this pager owns its data source (no external flow was supplied). */
+  fun setData(items: List<Value>) {
+    _data.value = items
+  }
 
   private val _pagingState = MutableStateFlow<PagingState<E>>(PagingState.Idle)
   override val pagingState: StateFlow<PagingState<E>> = _pagingState.asStateFlow()
@@ -51,20 +59,25 @@ class FakePager<Value : Any, E : Any>(override val data: Flow<List<Value>>) : Pa
 }
 
 /**
- * Hands out a single [FakePager] backed by [repository]'s beers flow, so tests drive the list with
- * [FakeBeersRepository.setBeers] and paging states with [FakePager.setPagingState].
+ * The catalog [create] hands out a single [pager] backed by [repository]'s beers flow (drive it
+ * with [FakeBeersRepository.setBeers] + [FakePager.setPagingState]). Each search [create] mints a
+ * *fresh* pager with its own data source, recorded in [searchPagers]/[createdQueries], so a test
+ * can drive different terms independently and prove a stale one can't overwrite a newer one.
  */
 class FakeBeersPagerFactory(repository: FakeBeersRepository) : BeersPagerFactory {
 
   val pager: FakePager<Beer, FetchBeersError> = FakePager(repository.observeBeers())
 
-  /** Every query a search pager was created for, so tests can assert debounce/cancel behaviour. */
+  /** Every query a search pager was created for, in order. */
   val createdQueries = mutableListOf<BeersQuery>()
+
+  /** The per-query search pagers handed out, in order - one per [create] with a query. */
+  val searchPagers = mutableListOf<FakePager<Beer, FetchBeersError>>()
 
   override fun create(): Pager<Beer, FetchBeersError> = pager
 
   override fun create(query: BeersQuery): Pager<Beer, FetchBeersError> {
     createdQueries += query
-    return pager
+    return FakePager<Beer, FetchBeersError>().also { searchPagers += it }
   }
 }

--- a/feature/beersearch/build.gradle.kts
+++ b/feature/beersearch/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins { id("billionbeers.android.feature") }
+
+android { namespace = "com.simtop.feature.beersearch" }
+
+dependencies {
+  implementation(project(":navigation"))
+  implementation(project(":core:designsystem"))
+  implementation(libs.androidx.material3.android)
+  implementation(libs.androidx.ui.tooling.preview.android)
+
+  testImplementation(project(":beerdomain:fakes"))
+  testImplementation(libs.striktCore)
+}

--- a/feature/beersearch/src/main/AndroidManifest.xml
+++ b/feature/beersearch/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchViewModel.kt
+++ b/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchViewModel.kt
@@ -1,0 +1,194 @@
+package com.simtop.feature.beersearch
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.simtop.beerdomain.domain.errors.FetchBeersError
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
+import com.simtop.core.core.CommonUiState
+import com.simtop.core.core.CoroutineDispatcherProvider
+import com.simtop.core.core.Pager
+import com.simtop.core.core.PagingEvent
+import com.simtop.core.core.PagingState
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.launch
+
+/**
+ * Search-as-you-type over the beers API. Each debounced term gets a *fresh* pager
+ * ([BeersPagerFactory.create] with a [BeersQuery]); [transformLatest] cancels the previous term's
+ * collection (and its in-flight first-page load) the moment a newer term arrives, so a slow stale
+ * response can never overwrite results for what the user is now typing - the crux of a correct
+ * as-you-type search.
+ *
+ * Results are in-memory only (the pager's storage is), so they die with the screen and a new query
+ * invalidates instantly. The catalog's Room cache is never touched.
+ */
+@ContributesIntoMap(AppScope::class)
+@ViewModelKey(BeersSearchViewModel::class)
+@Inject
+class BeersSearchViewModel(
+  private val coroutineDispatcher: CoroutineDispatcherProvider,
+  private val beersPagerFactory: BeersPagerFactory,
+) : ViewModel() {
+
+  private val queryText = MutableStateFlow("")
+
+  // The pager backing whatever term is on screen now, so scroll/retry act on it. Written on Main
+  // (short-query reset) and IO (each term's searchFlow), read on IO (scroll/retry) - volatile for
+  // visibility. Atomicity isn't needed: a scroll lands long after the pager is set.
+  @Volatile private var currentPager: Pager<Beer, FetchBeersError>? = null
+
+  private val _events = Channel<BeersSearchEvent>(Channel.BUFFERED)
+  val events: Flow<BeersSearchEvent> = _events.receiveAsFlow()
+
+  @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
+  val viewState: StateFlow<CommonUiState<BeersSearchUiModel>> =
+    queryText
+      .map { it.trim() }
+      .debounce(DEBOUNCE_MILLIS)
+      .distinctUntilChanged()
+      .transformLatest { term ->
+        if (term.length < MIN_QUERY_LENGTH) {
+          currentPager = null
+          emit(CommonUiState.Empty) // pre-search prompt
+        } else {
+          emitAll(searchFlow(term))
+        }
+      }
+      .stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MILLIS),
+        CommonUiState.Empty,
+      )
+
+  private fun searchFlow(term: String): Flow<CommonUiState<BeersSearchUiModel>> =
+    channelFlow {
+        val pager = beersPagerFactory.create(BeersQuery(term))
+        currentPager = pager
+        var lastTotalCount: Int? = null
+
+        launch { pager.loadFirstPage() }
+        launch {
+          pager.events.collect { event ->
+            when (event) {
+              is PagingEvent.LoadMoreFailed -> _events.trySend(BeersSearchEvent.ShowLoadMoreError)
+            }
+          }
+        }
+        combine(pager.data, pager.pagingState) { beers, state ->
+            if (state is PagingState.Success) state.totalCount?.let { lastTotalCount = it }
+            reduce(beers, state, lastTotalCount)
+          }
+          .collect { send(it) }
+      }
+      .flowOn(coroutineDispatcher.io)
+
+  private fun reduce(
+    beers: List<Beer>,
+    state: PagingState<FetchBeersError>,
+    totalCount: Int?,
+  ): CommonUiState<BeersSearchUiModel> =
+    when (state) {
+      is PagingState.Error ->
+        if (state.isFirstPage) {
+          CommonUiState.Error(state.error.toUiMessage())
+        } else {
+          success(beers, totalCount, SearchFooter.Retry)
+        }
+      is PagingState.Loading,
+      PagingState.Idle -> if (beers.isEmpty()) CommonUiState.Loading else success(beers, totalCount)
+      is PagingState.LoadingNextPage -> success(beers, totalCount, isLoadingNextPage = true)
+      is PagingState.Success -> success(beers, totalCount)
+      PagingState.EndOfPagination ->
+        success(
+          beers,
+          totalCount,
+          if (beers.isEmpty()) SearchFooter.Hidden else SearchFooter.EndReached,
+        )
+    }
+
+  private fun success(
+    beers: List<Beer>,
+    totalCount: Int?,
+    footer: SearchFooter = SearchFooter.Hidden,
+    isLoadingNextPage: Boolean = false,
+  ) =
+    CommonUiState.Success(
+      BeersSearchUiModel(
+        beers = beers,
+        resultCount = totalCount,
+        isLoadingNextPage = isLoadingNextPage,
+        footer = if (beers.isEmpty()) SearchFooter.Hidden else footer,
+      )
+    )
+
+  private fun FetchBeersError.toUiMessage(): String =
+    when (this) {
+      FetchBeersError.Network -> "No internet connection"
+      FetchBeersError.NotFound -> "No beers found"
+      FetchBeersError.Forbidden -> "Access denied"
+      FetchBeersError.RateLimited -> "Too many requests. Please wait a moment."
+      is FetchBeersError.Unknown -> cause.message ?: "Search failed"
+    }
+
+  fun onQueryChange(text: String) {
+    queryText.value = text
+  }
+
+  fun onScrollToBottom() {
+    viewModelScope.launch(coroutineDispatcher.io) { currentPager?.loadNextPage() }
+  }
+
+  fun onRetryLoadMore() {
+    viewModelScope.launch(coroutineDispatcher.io) { currentPager?.loadNextPage() }
+  }
+
+  private companion object {
+    const val DEBOUNCE_MILLIS = 700L
+    const val MIN_QUERY_LENGTH = 2
+    const val SUBSCRIPTION_TIMEOUT_MILLIS = 5_000L
+  }
+}
+
+/** The bottom-of-list affordance for search results: nothing, a retry row, or the end caption. */
+sealed interface SearchFooter {
+  data object Hidden : SearchFooter
+
+  data object Retry : SearchFooter
+
+  data object EndReached : SearchFooter
+}
+
+/** One-shot effects the search screen consumes once. */
+sealed interface BeersSearchEvent {
+  data object ShowLoadMoreError : BeersSearchEvent
+}
+
+data class BeersSearchUiModel(
+  val beers: List<Beer>,
+  // X-Total-Count for "N results"; null until the server reports it.
+  val resultCount: Int?,
+  val isLoadingNextPage: Boolean = false,
+  val footer: SearchFooter = SearchFooter.Hidden,
+)

--- a/feature/beersearch/src/test/java/com/simtop/feature/beersearch/BeersSearchViewModelTest.kt
+++ b/feature/beersearch/src/test/java/com/simtop/feature/beersearch/BeersSearchViewModelTest.kt
@@ -1,0 +1,212 @@
+package com.simtop.feature.beersearch
+
+import app.cash.turbine.test
+import com.simtop.beerdomain.domain.errors.FetchBeersError
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.beerdomain.fakes.FakeBeersPagerFactory
+import com.simtop.beerdomain.fakes.FakeBeersRepository
+import com.simtop.core.core.CommonUiState
+import com.simtop.core.core.CoroutineDispatcherProvider
+import com.simtop.core.core.PagingState
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isA
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
+
+@ExperimentalCoroutinesApi
+class BeersSearchViewModelTest {
+
+  private val coroutineDispatcherProvider = mockk<CoroutineDispatcherProvider>()
+  private val fakeRepository = FakeBeersRepository()
+  private val fakeFactory = FakeBeersPagerFactory(fakeRepository)
+
+  private lateinit var testDispatcher: TestDispatcher
+
+  private val pastDebounce = 701L // just over the 700ms debounce
+
+  @BeforeEach
+  fun setUp() {
+    testDispatcher = UnconfinedTestDispatcher()
+    Dispatchers.setMain(testDispatcher)
+    every { coroutineDispatcherProvider.io } returns testDispatcher
+    every { coroutineDispatcherProvider.main } returns testDispatcher
+  }
+
+  @AfterEach fun tearDown() = Dispatchers.resetMain()
+
+  private fun buildViewModel() = BeersSearchViewModel(coroutineDispatcherProvider, fakeFactory)
+
+  @Test
+  fun `rapid typing debounces into a single query`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        expectThat(awaitItem()).isEqualTo(CommonUiState.Empty) // pre-search prompt
+
+        viewModel.onQueryChange("i")
+        viewModel.onQueryChange("ip")
+        viewModel.onQueryChange("ipa")
+        advanceTimeBy(pastDebounce)
+        runCurrent()
+
+        expectThat(fakeFactory.createdQueries.toList()).isEqualTo(listOf(BeersQuery("ipa")))
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+  @Test
+  fun `a query under two characters creates no pager`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        expectThat(awaitItem()).isEqualTo(CommonUiState.Empty)
+
+        viewModel.onQueryChange("i")
+        advanceTimeBy(pastDebounce)
+        runCurrent()
+
+        expectThat(fakeFactory.createdQueries).isEmpty()
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+  @Test
+  fun `results are exposed with the server total as the result count`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        expectThat(awaitItem()).isEqualTo(CommonUiState.Empty)
+
+        viewModel.onQueryChange("ipa")
+        advanceTimeBy(pastDebounce)
+        runCurrent()
+        val pager = fakeFactory.searchPagers.last()
+        pager.setData(listOf(Beer.empty.copy(id = "1")))
+        pager.setPagingState(PagingState.Success(totalCount = 159))
+        runCurrent()
+
+        val state = expectMostRecentItem()
+        expectThat(state).isA<CommonUiState.Success<BeersSearchUiModel>>()
+        val model = (state as CommonUiState.Success).data
+        expectThat(model.beers.map { it.id }).isEqualTo(listOf("1"))
+        expectThat(model.resultCount).isEqualTo(159)
+      }
+    }
+
+  // A valid query that matches nothing: empty first page -> EndOfPagination over an empty list.
+  // Surfaces as Success with zero results (count 0), which 2c's "No results" empty state reads.
+  @Test
+  fun `a query with no matches exposes zero results`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        expectThat(awaitItem()).isEqualTo(CommonUiState.Empty)
+
+        viewModel.onQueryChange("zzz")
+        advanceTimeBy(pastDebounce)
+        runCurrent()
+        val pager = fakeFactory.searchPagers.last()
+        pager.setData(emptyList())
+        pager.setPagingState(PagingState.EndOfPagination)
+        runCurrent()
+
+        val state = expectMostRecentItem()
+        expectThat(state).isA<CommonUiState.Success<BeersSearchUiModel>>()
+        expectThat((state as CommonUiState.Success).data.beers).isEmpty()
+      }
+    }
+
+  @Test
+  fun `a first-page rate limit shows the error state`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        expectThat(awaitItem()).isEqualTo(CommonUiState.Empty)
+
+        viewModel.onQueryChange("ipa")
+        advanceTimeBy(pastDebounce)
+        runCurrent()
+        fakeFactory.searchPagers
+          .last()
+          .setPagingState(PagingState.Error(FetchBeersError.RateLimited, isFirstPage = true))
+        runCurrent()
+
+        expectThat(expectMostRecentItem()).isA<CommonUiState.Error>()
+      }
+    }
+
+  // The crux: a newer term must win. A stale pager emitting late (its collection cancelled by the
+  // newer term) can't overwrite the results the user is now looking at.
+  @Test
+  fun `a newer term supersedes a stale one`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        expectThat(awaitItem()).isEqualTo(CommonUiState.Empty)
+
+        viewModel.onQueryChange("ipa")
+        advanceTimeBy(pastDebounce)
+        runCurrent()
+        val stalePager = fakeFactory.searchPagers.last()
+
+        viewModel.onQueryChange("stout")
+        advanceTimeBy(pastDebounce)
+        runCurrent()
+        val freshPager = fakeFactory.searchPagers.last()
+        freshPager.setData(listOf(Beer.empty.copy(id = "stout-1")))
+        freshPager.setPagingState(PagingState.Success(totalCount = 10))
+        runCurrent()
+
+        // The stale "ipa" pager fires late - it must be ignored.
+        stalePager.setData(listOf(Beer.empty.copy(id = "ipa-late")))
+        stalePager.setPagingState(PagingState.Success(totalCount = 159))
+        runCurrent()
+
+        val state = expectMostRecentItem()
+        expectThat((state as CommonUiState.Success).data.beers.map { it.id })
+          .isEqualTo(listOf("stout-1"))
+      }
+    }
+
+  @Test
+  fun `onScrollToBottom loads the next page of the current results`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        expectThat(awaitItem()).isEqualTo(CommonUiState.Empty)
+
+        viewModel.onQueryChange("ipa")
+        advanceTimeBy(pastDebounce)
+        runCurrent()
+        val pager = fakeFactory.searchPagers.last()
+
+        viewModel.onScrollToBottom()
+        runCurrent()
+
+        expectThat(pager.loadNextPageCallCount).isEqualTo(1)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+}


### PR DESCRIPTION
Paging 2.0 sub-PR 2b: the debounced, cancel-stale search view model.

New `feature/beersearch` module (a static feature) holding `BeersSearchViewModel` — the
correctness core of search-as-you-type. No screen yet; 2c wires the UI and navigation.

**Debounce + fresh pager per term.** Typing flows through `debounce(~700ms)` + a 2-char
minimum; each surviving term gets its own pager via `create(BeersQuery(term))` (the
in-memory search surface from 2a). Results carry a count (`X-Total-Count`) and a footer
(retry / end), with a one-shot toast on load-more failure.

**Cancel-stale is the crux.** The term flow drives `transformLatest`, so a newer term
cancels the previous term's collection *and its in-flight first-page load*. A slow response
for "ip" can't overwrite results for "ipa" — proven by a test that fires a stale pager late
and asserts the newer term's results still stand.

**In-memory only.** The pager's storage is in-memory, so results die with the screen and a
new query invalidates instantly; the catalog's Room cache is never touched.

**Tests (runTest virtual time + Turbine):** rapid typing coalesces to one query, sub-2-char
creates no pager, results expose the server total, a valid query with no matches surfaces
zero results (the contract 2c's empty state reads), a first-page 429 shows the error state,
`onScrollToBottom` pages the current results, and — the crux — a newer term supersedes a
stale one. `FakePager` gained a settable data source so each term drives an independent pager.

`currentPager` (touched by scroll/retry from another thread) is `@Volatile`.

Next: 2c — search screen UI, nav entry (search icon → Search destination), and screenshots.
