### PR TITLE
fix: paging edge cases in the mediator, load-more trigger and catalog reducer

### DIFF
--- a/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
@@ -140,7 +140,9 @@ class InMemoryPagingStorage<Key : Any, Value : Any> : PagingStorage<Key, Value> 
  * [PagingStorage] for single-source-of-truth caching).
  *
  * Retry is free by construction: the page key only advances after a successful fetch-and-store, so
- * after a [PagingState.Error] any entry point simply re-requests the failed page.
+ * after a [PagingState.Error] any entry point simply re-requests the failed page. That includes a
+ * failed first page or refresh retried through [loadNextPage]: the retry re-runs it *as* a first
+ * page (stored via [PagingStorage.storeFirstPage]), never as an append of page one.
  *
  * [loadFirstPage] is also refresh: it resets the key and hands the new first page to
  * [PagingStorage.storeFirstPage] - only *after* a successful fetch, so a failed refresh never
@@ -199,6 +201,11 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
   private var isKeyInitialized = false
   private var isLastPage = false
 
+  // Set while the page to retry is a *first* page (a failed initial load or refresh). Without it,
+  // a loadNextPage after a failed loadFirstPage would refetch the first page but store it through
+  // append - duplicating it in a replacing storage and mispositioning a merging one.
+  private var retryFirstPage = false
+
   override suspend fun loadFirstPage() {
     mutex.withLock {
       currentKey = initialKey
@@ -225,7 +232,7 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
           }
         isKeyInitialized = true
       }
-      currentKey?.let { key -> loadPage(key, isFirstPage = false) }
+      currentKey?.let { key -> loadPage(key, isFirstPage = retryFirstPage) }
     } finally {
       mutex.unlock()
     }
@@ -240,6 +247,7 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
       val items = result.items
       if (isFirstPage) storage.storeFirstPage(result)
       else if (items.isNotEmpty()) storage.append(result)
+      retryFirstPage = false
 
       // Empty-page probe: the fallback end signal when the server reports no total (nextKey stays
       // non-null) - preserves the pre-2.0 behaviour for a header-less backend.
@@ -260,6 +268,7 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
     } catch (e: CancellationException) {
       throw e
     } catch (e: Exception) {
+      retryFirstPage = isFirstPage
       val error = classifyError(e)
       // A subsequent-page failure keeps the list, so it also fires a one-shot event for a transient
       // notice; a first-page failure is the full-screen Error condition and needs no event.

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
@@ -289,6 +289,46 @@ class PagingMediatorTest {
     )
   }
 
+  // Regression guard: a failed first page retried through loadNextPage must re-run as a *first*
+  // page. Storing it via append would duplicate page 1 in a replacing storage and leave the pager
+  // positioned as if page 1 were the next page in a merging one.
+  @Test
+  fun `after a failed first load loadNextPage retries it as a first page not an append`() =
+    runTest {
+      val harness = Harness()
+      harness.failOnKey(1)
+      harness.mediator.loadFirstPage() // fails
+      harness.succeedOnKey(1)
+      harness.storage.events.clear()
+
+      harness.mediator.loadNextPage() // retry entry point after the failure
+
+      assertEquals(listOf("fetch 1", "storeFirstPage"), harness.storage.events)
+      assertEquals(listOf("item 1"), harness.storage.stored.value)
+
+      harness.mediator.loadNextPage() // and pagination resumes normally afterwards
+      assertEquals(listOf(1, 1, 2), harness.fetchedKeys)
+    }
+
+  @Test
+  fun `after a failed refresh loadNextPage re-runs the refresh instead of appending page 1`() =
+    runTest {
+      val harness = Harness()
+      harness.mediator.loadFirstPage()
+      harness.mediator.loadNextPage() // pages 1 and 2 on screen
+      harness.failOnKey(1)
+      harness.mediator.loadFirstPage() // refresh fails
+      harness.succeedOnKey(1)
+      harness.storage.events.clear()
+
+      harness.mediator.loadNextPage()
+
+      assertEquals(listOf("fetch 1", "storeFirstPage"), harness.storage.events)
+      // The replacing storage holds exactly the refreshed first page - "item 1" was not appended
+      // after the stale list.
+      assertEquals(listOf("item 1"), harness.storage.stored.value)
+    }
+
   @Test
   fun `storage write failure emits Error and does not advance the key`() = runTest {
     val harness = Harness()

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -99,13 +99,16 @@ fun BeersListScreen(
   val context = LocalContext.current
   val lifecycleOwner = LocalLifecycleOwner.current
   val loadMoreFailedMessage = stringResource(R.string.beers_load_more_failed)
+  val refreshFailedMessage = stringResource(R.string.beers_refresh_failed)
 
-  // One-shot toast when a "load more" fails; the footer owns the retry affordance.
+  // One-shot toasts: a failed "load more" (the footer owns the retry affordance) and a failed
+  // refresh (the list stays; pulling again is the retry).
   LaunchedEffect(viewModel, lifecycleOwner) {
     lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
       viewModel.events.collect { event ->
         when (event) {
           BeersListEvent.ShowLoadMoreError -> showToast(context, loadMoreFailedMessage)
+          BeersListEvent.ShowRefreshError -> showToast(context, refreshFailedMessage)
         }
       }
     }

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
@@ -100,19 +100,35 @@ class BeersListViewModel(
               )
             )
           } else {
-            currentState
+            // Pagination ended with nothing on screen: the catalog is genuinely empty. Without
+            // this, observeBeers (which ignores empty emissions) never resolves the state and the
+            // skeleton spins forever.
+            CommonUiState.Empty
           }
         is PagingState.Error ->
           if (currentUiModel != null) {
-            // A load-more failure keeps the list and offers a retry row; the transient toast is
-            // driven separately off the pager's one-shot events.
-            CommonUiState.Success(
-              currentUiModel.copy(
-                isLoadingNextPage = false,
-                isRefreshing = false,
-                footer = ListFooter.Retry,
+            if (pagingState.isFirstPage) {
+              // A failed refresh: keep the list and stop the indicator. Feedback is the one-shot
+              // refresh-error toast - the load-more footer would show the wrong copy, and pulling
+              // again is the natural retry.
+              CommonUiState.Success(
+                currentUiModel.copy(
+                  isLoadingNextPage = false,
+                  isRefreshing = false,
+                  footer = ListFooter.Hidden,
+                )
               )
-            )
+            } else {
+              // A load-more failure keeps the list and offers a retry row; the transient toast is
+              // driven separately off the pager's one-shot events.
+              CommonUiState.Success(
+                currentUiModel.copy(
+                  isLoadingNextPage = false,
+                  isRefreshing = false,
+                  footer = ListFooter.Retry,
+                )
+              )
+            }
           } else {
             CommonUiState.Error(pagingState.error.toUiMessage())
           }
@@ -186,6 +202,15 @@ class BeersListViewModel(
         if (pagingState is PagingState.Success) {
           pagingState.totalCount?.let { lastTotalCount = it }
         }
+        // A first-page failure with a list already on screen is a failed refresh: the reducer
+        // keeps the list, so the user's only feedback is this one-shot toast.
+        if (
+          pagingState is PagingState.Error &&
+            pagingState.isFirstPage &&
+            _beerListViewState.value is CommonUiState.Success
+        ) {
+          _events.trySend(BeersListEvent.ShowRefreshError)
+        }
         pagingHandler.handlePagingState(pagingState)
       }
       .launchIn(viewModelScope)
@@ -217,6 +242,8 @@ sealed interface ListFooter {
 /** One-shot effects the screen consumes exactly once. */
 sealed interface BeersListEvent {
   data object ShowLoadMoreError : BeersListEvent
+
+  data object ShowRefreshError : BeersListEvent
 }
 
 data class BeersListUiModel(

--- a/feature/beerslist/src/main/res/values-es/strings.xml
+++ b/feature/beerslist/src/main/res/values-es/strings.xml
@@ -3,6 +3,7 @@
     <string name="billion_beers_list">"Lista de mil millones de cervezas"</string>
     <string name="beers_count_of_total">%1$d de %2$d</string>
     <string name="beers_load_more_failed">No se pudieron cargar más cervezas</string>
+    <string name="beers_refresh_failed">No se pudo actualizar</string>
     <string name="beers_load_more_retry">Reintentar</string>
     <string name="beers_end_of_list">Eso es todo: %1$d cervezas</string>
     <string name="beers_search">Buscar</string>

--- a/feature/beerslist/src/main/res/values-fr/strings.xml
+++ b/feature/beerslist/src/main/res/values-fr/strings.xml
@@ -3,6 +3,7 @@
     <string name="billion_beers_list">"Liste de milliards de bières"</string>
     <string name="beers_count_of_total">%1$d sur %2$d</string>
     <string name="beers_load_more_failed">Impossible de charger plus de bières</string>
+    <string name="beers_refresh_failed">Impossible d\'actualiser</string>
     <string name="beers_load_more_retry">Réessayer</string>
     <string name="beers_end_of_list">C\'est tout : %1$d bières</string>
     <string name="beers_search">Rechercher</string>

--- a/feature/beerslist/src/main/res/values/strings.xml
+++ b/feature/beerslist/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="billion_beers_list">"Billion Beers List"</string>
     <string name="beers_count_of_total">%1$d of %2$d</string>
     <string name="beers_load_more_failed">Couldn\'t load more beers</string>
+    <string name="beers_refresh_failed">Couldn\'t refresh</string>
     <string name="beers_load_more_retry">Retry</string>
     <string name="beers_end_of_list">That\'s all %1$d beers</string>
     <string name="beers_search">Search</string>

--- a/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
+++ b/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
@@ -212,6 +212,52 @@ class BeersListViewModelTest {
       }
     }
 
+  // Regression test: an empty catalog (first fetch returns no items) must resolve to Empty. The
+  // beers flow never emits a non-empty list, so only the paging state can end the skeleton.
+  @Test
+  fun `an empty catalog resolves to Empty instead of staying on the skeleton`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+      val pager = fakeBeersPagerFactory.pager
+
+      viewModel.beerListViewState.test {
+        expectThat(awaitItem()).isA<CommonUiState.Loading>()
+
+        pager.setPagingState(PagingState.EndOfPagination)
+
+        expectThat(awaitItem()).isEqualTo(CommonUiState.Empty)
+      }
+    }
+
+  // A failed refresh keeps the list on screen: no load-more retry footer (its copy would be wrong
+  // and its tap targets the wrong load) - the one-shot toast is the feedback, pulling again the
+  // retry.
+  @Test
+  fun `a failed refresh keeps the list, hides the footer and emits a one-shot refresh error`() =
+    runTest(testDispatcher) {
+      fakeBeersRepository.setBeers(listOf(Beer.empty.copy(id = "1")))
+      val viewModel = buildViewModel()
+      val pager = fakeBeersPagerFactory.pager
+
+      viewModel.events.test {
+        viewModel.beerListViewState.test {
+          expectThat(awaitItem()).isA<CommonUiState.Success<BeersListUiModel>>()
+
+          viewModel.refresh()
+          pager.setPagingState(PagingState.Loading)
+          expectThat((awaitItem() as CommonUiState.Success).data.isRefreshing).isTrue()
+
+          pager.setPagingState(PagingState.Error(FetchBeersError.Network, isFirstPage = true))
+
+          val state = awaitItem()
+          expectThat(state).isA<CommonUiState.Success<BeersListUiModel>>()
+          expectThat((state as CommonUiState.Success).data.isRefreshing).isFalse()
+          expectThat(state.data.footer).isEqualTo(ListFooter.Hidden)
+        }
+        expectThat(awaitItem()).isEqualTo(BeersListEvent.ShowRefreshError)
+      }
+    }
+
   @Test
   fun `refresh delegates to the pager's first page load`() =
     runTest(testDispatcher) {

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/core/InfiniteListHandler.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/core/InfiniteListHandler.kt
@@ -27,7 +27,9 @@ internal data class ListPosition(val totalItems: Int, val lastVisibleIndex: Int)
 internal fun Flow<ListPosition>.loadMoreSignals(buffer: Int): Flow<Unit> =
   map { position ->
       val lastVisiblePlusOne = position.lastVisibleIndex + 1
-      position.totalItems.takeIf { lastVisiblePlusOne > it - buffer }
+      // `it > 0` guards the pre-layout snapshot: layoutInfo reports 0 items before the first
+      // measure pass, which would otherwise count as "near bottom" and fire a load on entry.
+      position.totalItems.takeIf { it > 0 && lastVisiblePlusOne > it - buffer }
     }
     .distinctUntilChanged()
     .filterNotNull()

--- a/presentation_utils/src/test/java/com/simtop/presentation_utils/core/InfiniteListHandlerTest.kt
+++ b/presentation_utils/src/test/java/com/simtop/presentation_utils/core/InfiniteListHandlerTest.kt
@@ -61,6 +61,26 @@ class InfiniteListHandlerTest {
     count shouldBeEqualTo 0
   }
 
+  // Before the list's first layout pass, layoutInfo reports 0 items - that snapshot must not
+  // count as "near bottom", or every screen entry would fire an unscrolled load-more.
+  @Test
+  fun `an empty list never fires`() = runTest {
+    val count = signalsFor(ListPosition(totalItems = 0, lastVisibleIndex = 0))
+
+    count shouldBeEqualTo 0
+  }
+
+  @Test
+  fun `the pre-layout empty snapshot does not eat the real at-bottom signal`() = runTest {
+    val count =
+      signalsFor(
+        ListPosition(totalItems = 0, lastVisibleIndex = 0), // before first layout
+        ListPosition(totalItems = 25, lastVisibleIndex = 24), // laid out, user at bottom
+      )
+
+    count shouldBeEqualTo 1
+  }
+
   @Test
   fun `buffer widens the near-bottom trigger`() = runTest {
     // With buffer 5, item 20 of 25 already counts as "near bottom" (20 + 1 > 25 - 5).


### PR DESCRIPTION
Four edge-case bugs found while reviewing the paging stack for reuse, each with a regression test.

**`InfiniteListHandler` fired a load-more on an empty list.** With `totalItems = 0` the near-bottom check is `1 > -1`, and `0.takeIf { true }` survives `filterNotNull`, so the pre-layout snapshot (layoutInfo reports 0 items before the first measure pass) fired an unscrolled load on every screen entry: a warm-cache catalog fetched its next page immediately, and every search term fetched page 2 right after page 1. Guarded with `totalItems > 0`.

**`PagingMediator` retried a failed first page as an append.** After a failed `loadFirstPage` (initial load or refresh), a subsequent `loadNextPage` refetched page 1 but stored it via `storage.append()` — duplicating page 1 in a replacing storage and mispositioning a merging one. A new `retryFirstPage` flag routes the retry back through `storeFirstPage`.

**An empty catalog left the skeleton spinning forever.** `EndOfPagination` with nothing on screen returned the current state (`Loading`), and `observeBeers` ignores empty emissions, so nothing ever resolved. It now yields `Empty`.

**A failed pull-to-refresh gave no feedback.** `Error(isFirstPage = true)` with a list on screen showed the load-more retry footer at the bottom (wrong copy, and its tap targeted the wrong load — see bug 2). The list now stays with the footer hidden and a one-shot `ShowRefreshError` toast (en/es/fr); pulling again is the retry.

Verified: full `make test` and `make screenshot-verify` green.