### PR TITLE
feat: restore search results across process death

### DIFF
--- a/core-common/src/main/kotlin/com/simtop/core/core/CommonUiState.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/CommonUiState.kt
@@ -5,7 +5,13 @@ sealed class CommonUiState<out T> {
 
   data class Success<T>(val data: T) : CommonUiState<T>()
 
-  data class Error(val message: String? = null) : CommonUiState<Nothing>()
+  /**
+   * [message] is a literal runtime string (e.g. an exception message); [messageRes] is an Android
+   * string resource id, used for known error kinds so they localize. When both are null the screen
+   * falls back to its generic error copy.
+   */
+  data class Error(val message: String? = null, val messageRes: Int? = null) :
+    CommonUiState<Nothing>()
 
   object Empty : CommonUiState<Nothing>()
 }

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagedListReducer.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagedListReducer.kt
@@ -40,7 +40,7 @@ data class PagedListUiModel<T>(
  * whose states it reduces (a new search term means a new reducer).
  */
 class PagedListReducer<T, E : Any>(
-  private val errorMessage: (E) -> String,
+  private val errorState: (E) -> CommonUiState.Error,
   private val endedEmpty: () -> CommonUiState<PagedListUiModel<T>> = { CommonUiState.Empty },
 ) {
 
@@ -63,7 +63,7 @@ class PagedListReducer<T, E : Any>(
         if (items.isEmpty()) endedEmpty() else success(items, footer = PagedListFooter.EndReached)
       is PagingState.Error ->
         when {
-          items.isEmpty() -> CommonUiState.Error(errorMessage(state.error))
+          items.isEmpty() -> errorState(state.error)
           // A failed refresh keeps the list with no footer: the load-more retry row would carry
           // the wrong copy and target the wrong load - repeating the refresh is the retry.
           state.isFirstPage -> success(items)

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
@@ -257,9 +257,13 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
       }
 
       // After a first-page store the storage - not the fetched page - is the authority on
-      // position: a merging storage may still hold pages beyond the one just fetched.
+      // position: a merging storage may still hold pages beyond the one just fetched. Except when
+      // the fetch itself says the first page is also the last (nextKey == null): the total-count
+      // math is authoritative about the end, and a row-count estimate from storage (e.g. a
+      // sub-page dataset rounding to "page 1 is next") must not resurrect pagination past it.
       currentKey =
-        if (isFirstPage) nextKeyFromStorage?.invoke() ?: result.nextKey else result.nextKey
+        if (isFirstPage && result.nextKey != null) nextKeyFromStorage?.invoke() ?: result.nextKey
+        else result.nextKey
       if (currentKey == null) {
         endPagination()
       } else {

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagedListReducerTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagedListReducerTest.kt
@@ -7,7 +7,11 @@ class PagedListReducerTest {
 
   private fun reducer(
     endedEmpty: () -> CommonUiState<PagedListUiModel<String>> = { CommonUiState.Empty }
-  ) = PagedListReducer<String, String>(errorMessage = { "error: $it" }, endedEmpty = endedEmpty)
+  ) =
+    PagedListReducer<String, String>(
+      errorState = { CommonUiState.Error("error: $it") },
+      endedEmpty = endedEmpty,
+    )
 
   private val items = listOf("a", "b")
 

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
@@ -427,6 +427,30 @@ class PagingMediatorTest {
     assertEquals(listOf("item 1", "item 2", "item 3"), storage.stored.value)
   }
 
+  // A dataset smaller than one page: the fetch's total-count math says the first page is also the
+  // last (nextKey == null). The storage's row-count estimate rounds to "page 1 is next" and must
+  // not override that - it used to, costing a redundant refetch of page 1 on the next scroll.
+  @Test
+  fun `a first page that is also the last ends pagination despite nextKeyFromStorage`() = runTest {
+    val fetchedKeys = mutableListOf<Int>()
+    val mediator =
+      PagingMediator<Int, String, String>(
+        initialKey = 1,
+        fetchRemote = { key ->
+          fetchedKeys += key
+          PageResult(listOf("only item"), nextKey = null)
+        },
+        classifyError = { "unused" },
+        nextKeyFromStorage = { 1 }, // stale estimate: fewer rows than a page rounds back to 1
+      )
+
+    mediator.loadFirstPage()
+    assertEquals(PagingState.EndOfPagination, mediator.pagingState.value)
+
+    mediator.loadNextPage() // must be a no-op, not a refetch of page 1
+    assertEquals(listOf(1), fetchedKeys)
+  }
+
   @Test
   fun `nextKeyFromStorage failure emits Error and the next loadNextPage retries it`() = runTest {
     val fetchedKeys = mutableListOf<Int>()

--- a/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchScreen.kt
+++ b/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchScreen.kt
@@ -24,10 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -62,7 +59,8 @@ fun BeersSearchScreen(
   viewModel: BeersSearchViewModel = metroViewModel(),
 ) {
   val viewState by viewModel.viewState.collectAsState()
-  var query by rememberSaveable { mutableStateOf("") }
+  // VM-owned (SavedStateHandle-backed) so process death restores the search, not just the text.
+  val query by viewModel.query.collectAsState()
   val context = LocalContext.current
   val lifecycleOwner = LocalLifecycleOwner.current
   val loadMoreFailedMessage = stringResource(PresentationUtilsR.string.paged_list_load_more_failed)
@@ -80,10 +78,7 @@ fun BeersSearchScreen(
   BeersSearchContent(
     viewState = viewState,
     query = query,
-    onQueryChange = {
-      query = it
-      viewModel.onQueryChange(it)
-    },
+    onQueryChange = viewModel::onQueryChange,
     onBeerClick = onBeerClick,
     onBack = onBack,
     onScrollToBottom = { viewModel.onScrollToBottom() },

--- a/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchScreen.kt
+++ b/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchScreen.kt
@@ -47,6 +47,7 @@ import com.simtop.core.core.PagedListFooter
 import com.simtop.core.core.PagedListUiModel
 import com.simtop.presentation_utils.R as PresentationUtilsR
 import com.simtop.presentation_utils.core.InfiniteListHandler
+import com.simtop.presentation_utils.core.resolvedMessage
 import com.simtop.presentation_utils.custom_views.ComposeBeersListItem
 import com.simtop.presentation_utils.custom_views.ComposeErrorView
 import com.simtop.presentation_utils.custom_views.pagedListFooter
@@ -132,7 +133,7 @@ fun BeersSearchContent(
             CircularProgressIndicator()
           }
         is CommonUiState.Error ->
-          ComposeErrorView(message = state.message.orEmpty(), onRetry = onRetrySearch)
+          ComposeErrorView(message = state.resolvedMessage().orEmpty(), onRetry = onRetrySearch)
         is CommonUiState.Success ->
           if (state.data.items.isEmpty()) {
             CenteredHint(stringResource(R.string.search_no_results, query))

--- a/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchViewModel.kt
+++ b/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchViewModel.kt
@@ -15,7 +15,7 @@ import com.simtop.core.core.PagedListReducer
 import com.simtop.core.core.PagedListUiModel
 import com.simtop.core.core.Pager
 import com.simtop.core.core.PagingEvent
-import com.simtop.presentation_utils.core.toUiMessage
+import com.simtop.presentation_utils.core.toErrorState
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -113,7 +113,7 @@ class BeersSearchViewModel(
         // prompt.
         val reducer =
           PagedListReducer<Beer, FetchBeersError>(
-            errorMessage = { it.toUiMessage() },
+            errorState = { it.toErrorState() },
             endedEmpty = { CommonUiState.Success(PagedListUiModel()) },
           )
 

--- a/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchViewModel.kt
+++ b/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchViewModel.kt
@@ -1,7 +1,10 @@
 package com.simtop.feature.beersearch
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.models.BeersQuery
@@ -14,14 +17,16 @@ import com.simtop.core.core.Pager
 import com.simtop.core.core.PagingEvent
 import com.simtop.presentation_utils.core.toUiMessage
 import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
 import dev.zacsweers.metro.ContributesIntoMap
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ViewModelAssistedFactoryKey
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.channelFlow
@@ -45,16 +50,31 @@ import kotlinx.coroutines.launch
  *
  * Results are in-memory only (the pager's storage is), so they die with the screen and a new query
  * invalidates instantly. The catalog's Room cache is never touched.
+ *
+ * The query lives here in the [SavedStateHandle], not in the screen: process death then restores
+ * the *results* (the restored query re-runs the search), not just the text in the field.
  */
-@ContributesIntoMap(AppScope::class)
-@ViewModelKey(BeersSearchViewModel::class)
-@Inject
+@AssistedInject
 class BeersSearchViewModel(
   private val coroutineDispatcher: CoroutineDispatcherProvider,
   private val beersPagerFactory: BeersPagerFactory,
+  @Assisted private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
-  private val queryText = MutableStateFlow("")
+  @AssistedFactory
+  @ViewModelAssistedFactoryKey(BeersSearchViewModel::class)
+  @ContributesIntoMap(AppScope::class)
+  fun interface Factory : ViewModelAssistedFactory {
+    override fun create(extras: CreationExtras): BeersSearchViewModel =
+      create(extras.createSavedStateHandle())
+
+    fun create(@Assisted savedStateHandle: SavedStateHandle): BeersSearchViewModel
+  }
+
+  private val queryText = savedStateHandle.getStateFlow(KEY_QUERY, "")
+
+  /** The current query text, owned here so the screen and the search can never disagree. */
+  val query: StateFlow<String> = queryText
 
   // The pager backing whatever term is on screen now, so scroll/retry act on it. Written on Main
   // (short-query reset) and IO (each term's searchFlow), read on IO (scroll/retry) - volatile for
@@ -110,7 +130,7 @@ class BeersSearchViewModel(
       .flowOn(coroutineDispatcher.io)
 
   fun onQueryChange(text: String) {
-    queryText.value = text
+    savedStateHandle[KEY_QUERY] = text
   }
 
   fun onScrollToBottom() {
@@ -130,6 +150,7 @@ class BeersSearchViewModel(
   }
 
   private companion object {
+    const val KEY_QUERY = "search_query"
     const val DEBOUNCE_MILLIS = 700L
     const val MIN_QUERY_LENGTH = 2
     const val SUBSCRIPTION_TIMEOUT_MILLIS = 5_000L

--- a/feature/beersearch/src/test/java/com/simtop/feature/beersearch/BeersSearchViewModelTest.kt
+++ b/feature/beersearch/src/test/java/com/simtop/feature/beersearch/BeersSearchViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.simtop.feature.beersearch
 
+import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
@@ -50,7 +51,8 @@ class BeersSearchViewModelTest {
 
   @AfterEach fun tearDown() = Dispatchers.resetMain()
 
-  private fun buildViewModel() = BeersSearchViewModel(coroutineDispatcherProvider, fakeFactory)
+  private fun buildViewModel(savedStateHandle: SavedStateHandle = SavedStateHandle()) =
+    BeersSearchViewModel(coroutineDispatcherProvider, fakeFactory, savedStateHandle)
 
   @Test
   fun `rapid typing debounces into a single query`() =
@@ -187,6 +189,23 @@ class BeersSearchViewModelTest {
         val state = expectMostRecentItem()
         expectThat((state as CommonUiState.Success).data.items.map { it.id })
           .isEqualTo(listOf("stout-1"))
+      }
+    }
+
+  // Process death: the query survives in the SavedStateHandle, so a recreated ViewModel re-runs
+  // the search on its own - the user gets their results back, not just the text in the field.
+  @Test
+  fun `a query restored from the saved state re-runs the search`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel(SavedStateHandle(mapOf("search_query" to "ipa")))
+
+      viewModel.viewState.test {
+        advanceTimeBy(pastDebounce)
+        runCurrent()
+
+        expectThat(fakeFactory.createdQueries.toList()).isEqualTo(listOf(BeersQuery("ipa")))
+        expectThat(viewModel.query.value).isEqualTo("ipa")
+        cancelAndIgnoreRemainingEvents()
       }
     }
 

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -74,6 +74,7 @@ import com.simtop.presentation_utils.R as PresentationUtilsR
 import com.simtop.presentation_utils.core.DynamicFeatureLoader
 import com.simtop.presentation_utils.core.InfiniteListHandler
 import com.simtop.presentation_utils.core.LocalDebugDrawerToggle
+import com.simtop.presentation_utils.core.resolvedMessage
 import com.simtop.presentation_utils.custom_views.ComposeBeersListItem
 import com.simtop.presentation_utils.custom_views.ComposeErrorView
 import com.simtop.presentation_utils.custom_views.pagedListFooter
@@ -211,12 +212,13 @@ fun BeersListContent(
         }
 
         is CommonUiState.Error -> {
+          val errorMessage = state.resolvedMessage()
           ComposeErrorView(
-            message = state.message ?: stringResource(PresentationUtilsR.string.empty_state),
+            message = errorMessage ?: stringResource(PresentationUtilsR.string.empty_state),
             onRetry = onRetry,
             modifier = Modifier.padding(top = paddingValues.calculateTopPadding()),
           )
-          state.message?.let { message -> LaunchedEffect(message) { showToast(context, message) } }
+          errorMessage?.let { message -> LaunchedEffect(message) { showToast(context, message) } }
         }
 
         CommonUiState.Loading -> {

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
@@ -12,7 +12,7 @@ import com.simtop.core.core.PagedListReducer
 import com.simtop.core.core.PagedListUiModel
 import com.simtop.core.core.PagingEvent
 import com.simtop.core.core.PagingState
-import com.simtop.presentation_utils.core.toUiMessage
+import com.simtop.presentation_utils.core.toErrorState
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
@@ -41,7 +41,7 @@ class BeersListViewModel(
   // the app-scoped repository stays a stateless data accessor.
   private val pager = beersPagerFactory.create()
 
-  private val reducer = PagedListReducer<Beer, FetchBeersError>(errorMessage = { it.toUiMessage() })
+  private val reducer = PagedListReducer<Beer, FetchBeersError>(errorState = { it.toErrorState() })
 
   // Eagerly: the screen state has always been hot (it previously accumulated in a MutableStateFlow
   // from init), and the refresh-failure check below reads the current value between subscribers.

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/core/FetchBeersErrorMessages.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/core/FetchBeersErrorMessages.kt
@@ -1,17 +1,29 @@
 package com.simtop.presentation_utils.core
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import com.simtop.beerdomain.domain.errors.FetchBeersError
+import com.simtop.core.core.CommonUiState
+import com.simtop.presentation_utils.R
 
 /**
- * The one user-facing message per [FetchBeersError], shared by every paged beers screen (the
- * catalog and search used to keep diverging private copies). Plain strings for now - threading
- * resource ids through `CommonUiState.Error` is the known localization gap.
+ * The one user-facing error state per [FetchBeersError], shared by every paged beers screen (the
+ * catalog and search used to keep diverging private copies). Known kinds carry a string resource so
+ * they localize; only an [FetchBeersError.Unknown] with a cause message falls back to that literal
+ * runtime string.
  */
-fun FetchBeersError.toUiMessage(): String =
+fun FetchBeersError.toErrorState(): CommonUiState.Error =
   when (this) {
-    FetchBeersError.Network -> "No internet connection"
-    FetchBeersError.NotFound -> "No beers found"
-    FetchBeersError.Forbidden -> "Access denied"
-    FetchBeersError.RateLimited -> "Too many requests. Please wait a moment."
-    is FetchBeersError.Unknown -> cause.message ?: "Failed to load beers"
+    FetchBeersError.Network -> CommonUiState.Error(messageRes = R.string.error_no_internet)
+    FetchBeersError.NotFound -> CommonUiState.Error(messageRes = R.string.error_no_beers_found)
+    FetchBeersError.Forbidden -> CommonUiState.Error(messageRes = R.string.error_access_denied)
+    FetchBeersError.RateLimited -> CommonUiState.Error(messageRes = R.string.error_rate_limited)
+    is FetchBeersError.Unknown ->
+      cause.message?.let { CommonUiState.Error(message = it) }
+        ?: CommonUiState.Error(messageRes = R.string.error_failed_to_load_beers)
   }
+
+/** Resolves an error to displayable text: the literal message, else the localized resource. */
+@Composable
+fun CommonUiState.Error.resolvedMessage(): String? =
+  message ?: messageRes?.let { stringResource(it) }

--- a/presentation_utils/src/main/res/values-es/strings.xml
+++ b/presentation_utils/src/main/res/values-es/strings.xml
@@ -24,4 +24,9 @@
     <string name="beer_detail_food_pairing">Maridaje</string>
     <string name="beer_detail_abv_label">ABV</string>
     <string name="beer_detail_ibu_label">IBU</string>
+    <string name="error_no_internet">Sin conexión a internet</string>
+    <string name="error_no_beers_found">No se encontraron cervezas</string>
+    <string name="error_access_denied">Acceso denegado</string>
+    <string name="error_rate_limited">Demasiadas solicitudes. Espera un momento.</string>
+    <string name="error_failed_to_load_beers">No se pudieron cargar las cervezas</string>
 </resources>

--- a/presentation_utils/src/main/res/values-fr/strings.xml
+++ b/presentation_utils/src/main/res/values-fr/strings.xml
@@ -24,4 +24,9 @@
     <string name="beer_detail_food_pairing">Accords mets et bières</string>
     <string name="beer_detail_abv_label">ABV</string>
     <string name="beer_detail_ibu_label">IBU</string>
+    <string name="error_no_internet">Pas de connexion Internet</string>
+    <string name="error_no_beers_found">Aucune bière trouvée</string>
+    <string name="error_access_denied">Accès refusé</string>
+    <string name="error_rate_limited">Trop de requêtes. Veuillez patienter un instant.</string>
+    <string name="error_failed_to_load_beers">Impossible de charger les bières</string>
 </resources>

--- a/presentation_utils/src/main/res/values/strings.xml
+++ b/presentation_utils/src/main/res/values/strings.xml
@@ -24,4 +24,9 @@
     <string name="beer_detail_food_pairing">Food Pairing</string>
     <string name="beer_detail_abv_label">ABV</string>
     <string name="beer_detail_ibu_label">IBU</string>
+    <string name="error_no_internet">No internet connection</string>
+    <string name="error_no_beers_found">No beers found</string>
+    <string name="error_access_denied">Access denied</string>
+    <string name="error_rate_limited">Too many requests. Please wait a moment.</string>
+    <string name="error_failed_to_load_beers">Failed to load beers</string>
 </resources>


### PR DESCRIPTION
Stacked on #75 (merge order: #74 → #75 → this).

Previously the search query lived in the screen's `rememberSaveable` while the view model started blank, so after process death the restored UI showed the old text over the pre-search prompt — the results were gone until the user edited the query.

The query now lives in the view model behind a `SavedStateHandle`: `getStateFlow` feeds the existing debounce/`transformLatest` chain, so a recreated view model re-runs the search by itself, and the screen reads the query from the VM (`onQueryChange` writes through the handle), leaving one source of truth. To receive the `SavedStateHandle`, the VM switches from map-injected `@ViewModelKey` to metrox's `ViewModelAssistedFactory` (`@ViewModelAssistedFactoryKey` + `extras.createSavedStateHandle()`) — the screen still uses plain `metroViewModel()`, since assisted factories are tried first with `CreationExtras`.

Verified three ways: a new unit test builds the VM with a pre-seeded `SavedStateHandle` and asserts the search re-runs; full `make test` / `make screenshot-verify` / `make konsist` green; and end-to-end on an emulator — searched "ipa" (159 results), confirmed the process dead via `pidof` after `am kill`, relaunched, and the results list came back, not just the text.