### PR TITLE
fix: the two remaining paging quirks — exact end-of-pagination and localized error messages

### DIFF
--- a/core-common/src/main/kotlin/com/simtop/core/core/CommonUiState.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/CommonUiState.kt
@@ -5,7 +5,13 @@ sealed class CommonUiState<out T> {
 
   data class Success<T>(val data: T) : CommonUiState<T>()
 
-  data class Error(val message: String? = null) : CommonUiState<Nothing>()
+  /**
+   * [message] is a literal runtime string (e.g. an exception message); [messageRes] is an Android
+   * string resource id, used for known error kinds so they localize. When both are null the screen
+   * falls back to its generic error copy.
+   */
+  data class Error(val message: String? = null, val messageRes: Int? = null) :
+    CommonUiState<Nothing>()
 
   object Empty : CommonUiState<Nothing>()
 }

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagedListReducer.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagedListReducer.kt
@@ -40,7 +40,7 @@ data class PagedListUiModel<T>(
  * whose states it reduces (a new search term means a new reducer).
  */
 class PagedListReducer<T, E : Any>(
-  private val errorMessage: (E) -> String,
+  private val errorState: (E) -> CommonUiState.Error,
   private val endedEmpty: () -> CommonUiState<PagedListUiModel<T>> = { CommonUiState.Empty },
 ) {
 
@@ -63,7 +63,7 @@ class PagedListReducer<T, E : Any>(
         if (items.isEmpty()) endedEmpty() else success(items, footer = PagedListFooter.EndReached)
       is PagingState.Error ->
         when {
-          items.isEmpty() -> CommonUiState.Error(errorMessage(state.error))
+          items.isEmpty() -> errorState(state.error)
           // A failed refresh keeps the list with no footer: the load-more retry row would carry
           // the wrong copy and target the wrong load - repeating the refresh is the retry.
           state.isFirstPage -> success(items)

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
@@ -257,9 +257,13 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
       }
 
       // After a first-page store the storage - not the fetched page - is the authority on
-      // position: a merging storage may still hold pages beyond the one just fetched.
+      // position: a merging storage may still hold pages beyond the one just fetched. Except when
+      // the fetch itself says the first page is also the last (nextKey == null): the total-count
+      // math is authoritative about the end, and a row-count estimate from storage (e.g. a
+      // sub-page dataset rounding to "page 1 is next") must not resurrect pagination past it.
       currentKey =
-        if (isFirstPage) nextKeyFromStorage?.invoke() ?: result.nextKey else result.nextKey
+        if (isFirstPage && result.nextKey != null) nextKeyFromStorage?.invoke() ?: result.nextKey
+        else result.nextKey
       if (currentKey == null) {
         endPagination()
       } else {

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagedListReducerTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagedListReducerTest.kt
@@ -7,7 +7,11 @@ class PagedListReducerTest {
 
   private fun reducer(
     endedEmpty: () -> CommonUiState<PagedListUiModel<String>> = { CommonUiState.Empty }
-  ) = PagedListReducer<String, String>(errorMessage = { "error: $it" }, endedEmpty = endedEmpty)
+  ) =
+    PagedListReducer<String, String>(
+      errorState = { CommonUiState.Error("error: $it") },
+      endedEmpty = endedEmpty,
+    )
 
   private val items = listOf("a", "b")
 

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
@@ -427,6 +427,30 @@ class PagingMediatorTest {
     assertEquals(listOf("item 1", "item 2", "item 3"), storage.stored.value)
   }
 
+  // A dataset smaller than one page: the fetch's total-count math says the first page is also the
+  // last (nextKey == null). The storage's row-count estimate rounds to "page 1 is next" and must
+  // not override that - it used to, costing a redundant refetch of page 1 on the next scroll.
+  @Test
+  fun `a first page that is also the last ends pagination despite nextKeyFromStorage`() = runTest {
+    val fetchedKeys = mutableListOf<Int>()
+    val mediator =
+      PagingMediator<Int, String, String>(
+        initialKey = 1,
+        fetchRemote = { key ->
+          fetchedKeys += key
+          PageResult(listOf("only item"), nextKey = null)
+        },
+        classifyError = { "unused" },
+        nextKeyFromStorage = { 1 }, // stale estimate: fewer rows than a page rounds back to 1
+      )
+
+    mediator.loadFirstPage()
+    assertEquals(PagingState.EndOfPagination, mediator.pagingState.value)
+
+    mediator.loadNextPage() // must be a no-op, not a refetch of page 1
+    assertEquals(listOf(1), fetchedKeys)
+  }
+
   @Test
   fun `nextKeyFromStorage failure emits Error and the next loadNextPage retries it`() = runTest {
     val fetchedKeys = mutableListOf<Int>()

--- a/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchScreen.kt
+++ b/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchScreen.kt
@@ -47,6 +47,7 @@ import com.simtop.core.core.PagedListFooter
 import com.simtop.core.core.PagedListUiModel
 import com.simtop.presentation_utils.R as PresentationUtilsR
 import com.simtop.presentation_utils.core.InfiniteListHandler
+import com.simtop.presentation_utils.core.resolvedMessage
 import com.simtop.presentation_utils.custom_views.ComposeBeersListItem
 import com.simtop.presentation_utils.custom_views.ComposeErrorView
 import com.simtop.presentation_utils.custom_views.pagedListFooter
@@ -132,7 +133,7 @@ fun BeersSearchContent(
             CircularProgressIndicator()
           }
         is CommonUiState.Error ->
-          ComposeErrorView(message = state.message.orEmpty(), onRetry = onRetrySearch)
+          ComposeErrorView(message = state.resolvedMessage().orEmpty(), onRetry = onRetrySearch)
         is CommonUiState.Success ->
           if (state.data.items.isEmpty()) {
             CenteredHint(stringResource(R.string.search_no_results, query))

--- a/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchViewModel.kt
+++ b/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchViewModel.kt
@@ -15,7 +15,7 @@ import com.simtop.core.core.PagedListReducer
 import com.simtop.core.core.PagedListUiModel
 import com.simtop.core.core.Pager
 import com.simtop.core.core.PagingEvent
-import com.simtop.presentation_utils.core.toUiMessage
+import com.simtop.presentation_utils.core.toErrorState
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
@@ -113,7 +113,7 @@ class BeersSearchViewModel(
         // prompt.
         val reducer =
           PagedListReducer<Beer, FetchBeersError>(
-            errorMessage = { it.toUiMessage() },
+            errorState = { it.toErrorState() },
             endedEmpty = { CommonUiState.Success(PagedListUiModel()) },
           )
 

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -74,6 +74,7 @@ import com.simtop.presentation_utils.R as PresentationUtilsR
 import com.simtop.presentation_utils.core.DynamicFeatureLoader
 import com.simtop.presentation_utils.core.InfiniteListHandler
 import com.simtop.presentation_utils.core.LocalDebugDrawerToggle
+import com.simtop.presentation_utils.core.resolvedMessage
 import com.simtop.presentation_utils.custom_views.ComposeBeersListItem
 import com.simtop.presentation_utils.custom_views.ComposeErrorView
 import com.simtop.presentation_utils.custom_views.pagedListFooter
@@ -211,12 +212,13 @@ fun BeersListContent(
         }
 
         is CommonUiState.Error -> {
+          val errorMessage = state.resolvedMessage()
           ComposeErrorView(
-            message = state.message ?: stringResource(PresentationUtilsR.string.empty_state),
+            message = errorMessage ?: stringResource(PresentationUtilsR.string.empty_state),
             onRetry = onRetry,
             modifier = Modifier.padding(top = paddingValues.calculateTopPadding()),
           )
-          state.message?.let { message -> LaunchedEffect(message) { showToast(context, message) } }
+          errorMessage?.let { message -> LaunchedEffect(message) { showToast(context, message) } }
         }
 
         CommonUiState.Loading -> {

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
@@ -12,7 +12,7 @@ import com.simtop.core.core.PagedListReducer
 import com.simtop.core.core.PagedListUiModel
 import com.simtop.core.core.PagingEvent
 import com.simtop.core.core.PagingState
-import com.simtop.presentation_utils.core.toUiMessage
+import com.simtop.presentation_utils.core.toErrorState
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
@@ -41,7 +41,7 @@ class BeersListViewModel(
   // the app-scoped repository stays a stateless data accessor.
   private val pager = beersPagerFactory.create()
 
-  private val reducer = PagedListReducer<Beer, FetchBeersError>(errorMessage = { it.toUiMessage() })
+  private val reducer = PagedListReducer<Beer, FetchBeersError>(errorState = { it.toErrorState() })
 
   // Eagerly: the screen state has always been hot (it previously accumulated in a MutableStateFlow
   // from init), and the refresh-failure check below reads the current value between subscribers.

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/core/FetchBeersErrorMessages.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/core/FetchBeersErrorMessages.kt
@@ -1,17 +1,29 @@
 package com.simtop.presentation_utils.core
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import com.simtop.beerdomain.domain.errors.FetchBeersError
+import com.simtop.core.core.CommonUiState
+import com.simtop.presentation_utils.R
 
 /**
- * The one user-facing message per [FetchBeersError], shared by every paged beers screen (the
- * catalog and search used to keep diverging private copies). Plain strings for now - threading
- * resource ids through `CommonUiState.Error` is the known localization gap.
+ * The one user-facing error state per [FetchBeersError], shared by every paged beers screen (the
+ * catalog and search used to keep diverging private copies). Known kinds carry a string resource so
+ * they localize; only an [FetchBeersError.Unknown] with a cause message falls back to that literal
+ * runtime string.
  */
-fun FetchBeersError.toUiMessage(): String =
+fun FetchBeersError.toErrorState(): CommonUiState.Error =
   when (this) {
-    FetchBeersError.Network -> "No internet connection"
-    FetchBeersError.NotFound -> "No beers found"
-    FetchBeersError.Forbidden -> "Access denied"
-    FetchBeersError.RateLimited -> "Too many requests. Please wait a moment."
-    is FetchBeersError.Unknown -> cause.message ?: "Failed to load beers"
+    FetchBeersError.Network -> CommonUiState.Error(messageRes = R.string.error_no_internet)
+    FetchBeersError.NotFound -> CommonUiState.Error(messageRes = R.string.error_no_beers_found)
+    FetchBeersError.Forbidden -> CommonUiState.Error(messageRes = R.string.error_access_denied)
+    FetchBeersError.RateLimited -> CommonUiState.Error(messageRes = R.string.error_rate_limited)
+    is FetchBeersError.Unknown ->
+      cause.message?.let { CommonUiState.Error(message = it) }
+        ?: CommonUiState.Error(messageRes = R.string.error_failed_to_load_beers)
   }
+
+/** Resolves an error to displayable text: the literal message, else the localized resource. */
+@Composable
+fun CommonUiState.Error.resolvedMessage(): String? =
+  message ?: messageRes?.let { stringResource(it) }

--- a/presentation_utils/src/main/res/values-es/strings.xml
+++ b/presentation_utils/src/main/res/values-es/strings.xml
@@ -24,4 +24,9 @@
     <string name="beer_detail_food_pairing">Maridaje</string>
     <string name="beer_detail_abv_label">ABV</string>
     <string name="beer_detail_ibu_label">IBU</string>
+    <string name="error_no_internet">Sin conexión a internet</string>
+    <string name="error_no_beers_found">No se encontraron cervezas</string>
+    <string name="error_access_denied">Acceso denegado</string>
+    <string name="error_rate_limited">Demasiadas solicitudes. Espera un momento.</string>
+    <string name="error_failed_to_load_beers">No se pudieron cargar las cervezas</string>
 </resources>

--- a/presentation_utils/src/main/res/values-fr/strings.xml
+++ b/presentation_utils/src/main/res/values-fr/strings.xml
@@ -24,4 +24,9 @@
     <string name="beer_detail_food_pairing">Accords mets et bières</string>
     <string name="beer_detail_abv_label">ABV</string>
     <string name="beer_detail_ibu_label">IBU</string>
+    <string name="error_no_internet">Pas de connexion Internet</string>
+    <string name="error_no_beers_found">Aucune bière trouvée</string>
+    <string name="error_access_denied">Accès refusé</string>
+    <string name="error_rate_limited">Trop de requêtes. Veuillez patienter un instant.</string>
+    <string name="error_failed_to_load_beers">Impossible de charger les bières</string>
 </resources>

--- a/presentation_utils/src/main/res/values/strings.xml
+++ b/presentation_utils/src/main/res/values/strings.xml
@@ -24,4 +24,9 @@
     <string name="beer_detail_food_pairing">Food Pairing</string>
     <string name="beer_detail_abv_label">ABV</string>
     <string name="beer_detail_ibu_label">IBU</string>
+    <string name="error_no_internet">No internet connection</string>
+    <string name="error_no_beers_found">No beers found</string>
+    <string name="error_access_denied">Access denied</string>
+    <string name="error_rate_limited">Too many requests. Please wait a moment.</string>
+    <string name="error_failed_to_load_beers">Failed to load beers</string>
 </resources>


### PR DESCRIPTION
Stacked on #76 (merge order: #74 → #75 → #76 → this). Two small, independent fixes, one commit each.

**Exact end-of-pagination for sub-page datasets.** After a first-page store, the mediator consults `nextKeyFromStorage` because a merging storage may hold pages beyond the one just fetched — but when the fetch itself reports `nextKey == null`, the total-count math is authoritative that nothing more exists. The storage's row-count estimate (`count / pageSize + 1`) rounds a sub-page dataset back to "page 1 is next", which resurrected pagination and cost a redundant refetch of page 1 on the next scroll. The mediator now only consults storage when the fetch says a next page exists. Regression test included.

**Localized error messages.** The shared `FetchBeersError` mapping produced hardcoded English strings in an app that ships es/fr. `CommonUiState.Error` gains an optional `messageRes` alongside `message` (source-compatible; the only other consumer, beerdetail, ignores Error entirely), the mapping becomes `toErrorState()` handing known kinds a string resource, and screens resolve through a shared `resolvedMessage()` composable — an `Unknown` error's cause message still passes through as a literal string. New strings translated in en/es/fr.

Verified: full `make test`, `make screenshot-verify`, `make konsist` green (goldens unaffected — previews pass literal messages, which resolve unchanged); and on an emulator, a fresh offline launch renders the full-screen "No internet connection" through the new resource path.