### PR TITLE
feat: style and brewery query plumbing for the browse surfaces (Paging 2.0 3a)

### DIFF
--- a/app/src/main/java/com/simtop/billionbeers/di/BaseAppGraph.kt
+++ b/app/src/main/java/com/simtop/billionbeers/di/BaseAppGraph.kt
@@ -1,6 +1,7 @@
 package com.simtop.billionbeers.di
 
 import com.google.android.play.core.splitinstall.SplitInstallManager
+import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.CoroutineDispatcherProvider
 import com.simtop.core.core.FeatureFlagProvider
@@ -11,6 +12,7 @@ import dev.zacsweers.metrox.viewmodel.MetroViewModelMultibindings
 
 interface BaseAppGraph : DynamicDependencies, MetroViewModelMultibindings {
   override val beersRepository: BeersRepository
+  override val beersPagerFactory: BeersPagerFactory
   override val coroutineDispatcher: CoroutineDispatcherProvider
   val splitInstallManager: SplitInstallManager
   val metroViewModelFactory: MetroViewModelFactory

--- a/app/src/main/java/com/simtop/billionbeers/di/DynamicDependencies.kt
+++ b/app/src/main/java/com/simtop/billionbeers/di/DynamicDependencies.kt
@@ -1,10 +1,13 @@
 package com.simtop.billionbeers.di
 
+import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.CoroutineDispatcherProvider
 
 interface DynamicDependencies {
   val beersRepository: BeersRepository
+
+  val beersPagerFactory: BeersPagerFactory
 
   val coroutineDispatcher: CoroutineDispatcherProvider
 }

--- a/app/src/test/java/com/simtop/billionbeers/data/BeersRemoteSourceTest.kt
+++ b/app/src/test/java/com/simtop/billionbeers/data/BeersRemoteSourceTest.kt
@@ -1,6 +1,8 @@
 package com.simtop.billionbeers.data
 
+import com.simtop.beer_network.fixtures.FAKE_BREWERIES_JSON
 import com.simtop.beer_network.fixtures.FAKE_JSON
+import com.simtop.beer_network.fixtures.FAKE_TYPOLOGIES_JSON
 import com.simtop.beer_network.remotesources.BeersRemoteSourceImpl
 import com.simtop.billionbeers.TestMockWebService
 import com.simtop.core.core.LanguageProvider
@@ -66,5 +68,60 @@ class BeersRemoteSourceTest : TestMockWebService() {
 
     val path = mockServer.takeRequest().path.orEmpty()
     path.contains("q=") shouldBeEqualTo false
+  }
+
+  @Test
+  fun `a style filter sends the typology id query parameter`() {
+    mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_OK, mapOf("X-Total-Count" to "9"))
+
+    runBlocking { remoteSource.getListOfBeers(1, typologyId = "t1") }
+
+    val path = mockServer.takeRequest().path.orEmpty()
+    path.contains("typology.id=t1") shouldBeEqualTo true
+  }
+
+  @Test
+  fun `a brewery filter sends the brewery id query parameter`() {
+    mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_OK, mapOf("X-Total-Count" to "5"))
+
+    runBlocking { remoteSource.getListOfBeers(1, breweryId = "b1") }
+
+    val path = mockServer.takeRequest().path.orEmpty()
+    path.contains("brewery.id=b1") shouldBeEqualTo true
+  }
+
+  @Test
+  fun `a catalog fetch omits the filter query parameters`() {
+    mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_OK)
+
+    runBlocking { remoteSource.getListOfBeers(1) }
+
+    val path = mockServer.takeRequest().path.orEmpty()
+    path.contains("typology.id=") shouldBeEqualTo false
+    path.contains("brewery.id=") shouldBeEqualTo false
+  }
+
+  @Test
+  fun `typologies parse ignoring the unrendered translations`() {
+    mockHttpResponse(FAKE_TYPOLOGIES_JSON, HttpURLConnection.HTTP_OK)
+
+    val typologies = runBlocking { remoteSource.getTypologies() }
+
+    typologies.map { it.id } shouldBeEqualTo listOf("t1", "t2")
+    typologies.map { it.name } shouldBeEqualTo listOf("IPA (Indian Pale Ale)", "Stout")
+  }
+
+  @Test
+  fun `breweries parse the embedded country and image`() {
+    mockHttpResponse(FAKE_BREWERIES_JSON, HttpURLConnection.HTTP_OK)
+
+    val breweries = runBlocking { remoteSource.getBreweries() }
+
+    breweries.size shouldBeEqualTo 1
+    breweries[0].id shouldBeEqualTo "b1"
+    breweries[0].name shouldBeEqualTo "Supreme Suds Collective"
+    breweries[0].foundedYear shouldBeEqualTo 1972
+    breweries[0].country?.code shouldBeEqualTo "KP"
+    breweries[0].image?.url shouldBeEqualTo "https://brewbuddy.dev/images/b1.jpg"
   }
 }

--- a/app/src/test/resources/json/fake_breweries_response.json
+++ b/app/src/test/resources/json/fake_breweries_response.json
@@ -1,0 +1,25 @@
+[
+  {
+    "id": "b1",
+    "name": "Supreme Suds Collective",
+    "country_id": "c1",
+    "image_id": "i1",
+    "founded_year": 1972,
+    "country": {
+      "id": "c1",
+      "code": "KP",
+      "translations": [
+        {
+          "id": "ctr1",
+          "language_id": "l1",
+          "country_id": "c1",
+          "name": "North Korea"
+        }
+      ]
+    },
+    "image": {
+      "id": "i1",
+      "url": "https://brewbuddy.dev/images/b1.jpg"
+    }
+  }
+]

--- a/app/src/test/resources/json/fake_typologies_response.json
+++ b/app/src/test/resources/json/fake_typologies_response.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "t1",
+    "name": "IPA (Indian Pale Ale)",
+    "translations": [
+      {
+        "id": "tr1",
+        "language_id": "l1",
+        "typology_id": "t1",
+        "description": "Hop-forward and bitter."
+      }
+    ]
+  },
+  {
+    "id": "t2",
+    "name": "Stout"
+  }
+]

--- a/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
@@ -3,8 +3,12 @@ package com.simtop.beer_data.mappers
 import com.simtop.beer_database.models.BeerDbModel
 import com.simtop.beer_database.utils.Converters
 import com.simtop.beer_network.models.BeersApiResponseItem
+import com.simtop.beer_network.models.BreweryApiResponseItem
+import com.simtop.beer_network.models.TypologyApiResponseItem
 import com.simtop.beer_network.network.BeersService
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeerStyle
+import com.simtop.beerdomain.domain.models.Brewery
 import com.simtop.core.core.LanguageProvider
 import com.simtop.core.core.Logger
 import dev.zacsweers.metro.Inject
@@ -39,6 +43,26 @@ constructor(private val languageProvider: LanguageProvider, private val logger: 
 
   private fun logMissingField(field: String, response: BeersApiResponseItem?) {
     logger.warn(TAG, "missing $field for beer id=${response?.id}, defaulting")
+  }
+
+  fun fromTypologyToBeerStyle(response: TypologyApiResponseItem): BeerStyle {
+    if (response.id == null || response.name == null) {
+      logger.warn(TAG, "missing id or name for typology id=${response.id}, defaulting")
+    }
+    return BeerStyle(id = response.id ?: "", name = response.name ?: "")
+  }
+
+  fun fromBreweryApiResponseItemToBrewery(response: BreweryApiResponseItem): Brewery {
+    if (response.id == null || response.name == null) {
+      logger.warn(TAG, "missing id or name for brewery id=${response.id}, defaulting")
+    }
+    return Brewery(
+      id = response.id ?: "",
+      name = response.name ?: "",
+      countryCode = response.country?.code ?: "",
+      foundedYear = response.foundedYear,
+      imageUrl = response.image?.url ?: "",
+    )
   }
 
   fun fromBeerToBeerDbModel(beer: Beer) =

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
@@ -13,10 +13,7 @@ import com.simtop.core.core.Pager
 import com.simtop.core.core.PagingMediator
 import com.simtop.core.core.PagingStorage
 import dev.zacsweers.metro.Inject
-import java.io.IOException
-import java.net.HttpURLConnection
 import kotlinx.coroutines.flow.Flow
-import retrofit2.HttpException
 
 @Inject
 class BeersPagerFactoryImpl(
@@ -30,7 +27,7 @@ class BeersPagerFactoryImpl(
     val surface = CATALOG_SURFACE_PREFIX + languageProvider.currentLanguageCode()
     return PagingMediator(
       initialKey = FIRST_PAGE,
-      fetchRemote = fetchPage(search = null),
+      fetchRemote = fetchPage(BeersQuery()),
       classifyError = { it.toFetchBeersError() },
       storage = BeersPagingStorage(repository, surface),
       // Exact resume: the paging_state bookmark records the first uncached page, written in the
@@ -47,12 +44,13 @@ class BeersPagerFactoryImpl(
   }
 
   override fun create(query: BeersQuery): Pager<Beer, FetchBeersError> =
-    // Search is its own surface: results live only in memory (they die with the screen and a new
-    // query instantly invalidates them) and never touch the beers table, so the catalog's
-    // SELECT * view is untouched. No nextKeyFromStorage - there's no warm cache to resume from.
+    // A query surface (search, beers-by-style, beers-by-brewery) is its own pager: results live
+    // only in memory (they die with the screen and a new query instantly invalidates them) and
+    // never touch the beers table, so the catalog's SELECT * view is untouched. No
+    // nextKeyFromStorage - there's no warm cache to resume from.
     PagingMediator(
       initialKey = FIRST_PAGE,
-      fetchRemote = fetchPage(query.search),
+      fetchRemote = fetchPage(query),
       classifyError = { it.toFetchBeersError() },
       storage = InMemoryPagingStorage(),
     )
@@ -61,32 +59,17 @@ class BeersPagerFactoryImpl(
    * One page fetch plus the shared nextKey math: with a known total the end is exact (no wasted
    * empty fetch); without it, keep advancing and let the mediator's empty-page probe find the end.
    */
-  private fun fetchPage(search: String?): suspend (Int) -> PageResult<Int, Beer> = { page ->
-    val beerPage = repository.getBeersPageFromApi(page, search)
+  private fun fetchPage(query: BeersQuery): suspend (Int) -> PageResult<Int, Beer> = { page ->
+    val beerPage = repository.getBeersPageFromApi(page, query)
     val total = beerPage.totalCount
     val nextKey =
       if (total != null && page * BeersService.DEFAULT_ITEMS_PER_PAGE >= total) null else page + 1
     PageResult(items = beerPage.items, nextKey = nextKey, totalCount = total)
   }
 
-  private fun Throwable.toFetchBeersError(): FetchBeersError =
-    when (this) {
-      is HttpException ->
-        when (code()) {
-          HttpURLConnection.HTTP_NOT_FOUND -> FetchBeersError.NotFound
-          HttpURLConnection.HTTP_FORBIDDEN -> FetchBeersError.Forbidden
-          HTTP_TOO_MANY_REQUESTS -> FetchBeersError.RateLimited
-          else -> FetchBeersError.Unknown(this)
-        }
-      is IOException -> FetchBeersError.Network
-      else -> FetchBeersError.Unknown(this)
-    }
-
   private companion object {
     const val FIRST_PAGE = 1
     const val CATALOG_SURFACE_PREFIX = "catalog:"
-    // No HttpURLConnection constant exists for 429.
-    const val HTTP_TOO_MANY_REQUESTS = 429
   }
 }
 

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
@@ -3,9 +3,13 @@ package com.simtop.beer_data.repositories
 import com.simtop.beer_data.mappers.BeersMapper
 import com.simtop.beer_database.localsources.BeersLocalSource
 import com.simtop.beer_network.remotesources.BeersRemoteSource
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.models.BeerPage
+import com.simtop.beerdomain.domain.models.BeerStyle
+import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.beerdomain.domain.models.Brewery
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.Either
 import dev.zacsweers.metro.AppScope
@@ -24,13 +28,36 @@ class BeersRepositoryImpl(
   private val beersMapper: BeersMapper,
 ) : BeersRepository {
 
-  override suspend fun getBeersPageFromApi(page: Int, search: String?): BeerPage {
-    val remotePage = beersRemoteSource.getListOfBeers(page, search)
+  override suspend fun getBeersPageFromApi(page: Int, query: BeersQuery): BeerPage {
+    val remotePage =
+      beersRemoteSource.getListOfBeers(page, query.search, query.styleId, query.breweryId)
     return BeerPage(
       items = remotePage.items.map { beersMapper.fromBeersApiResponseItemToBeer(it) },
       totalCount = remotePage.totalCount,
     )
   }
+
+  override suspend fun getBeerStyles(): Either<FetchBeersError, List<BeerStyle>> = fetchClassified {
+    beersRemoteSource.getTypologies().map { beersMapper.fromTypologyToBeerStyle(it) }
+  }
+
+  override suspend fun getBreweries(): Either<FetchBeersError, List<Brewery>> = fetchClassified {
+    beersRemoteSource.getBreweries().map { beersMapper.fromBreweryApiResponseItemToBrewery(it) }
+  }
+
+  /**
+   * Unpaged fetches have no pager to classify their errors, so the repository does it - with the
+   * same shared mapping the pager paths use.
+   */
+  @Suppress("TooGenericExceptionCaught")
+  private inline fun <T> fetchClassified(fetch: () -> T): Either<FetchBeersError, T> =
+    try {
+      Either.Right(fetch())
+    } catch (e: CancellationException) {
+      throw e
+    } catch (e: Exception) {
+      Either.Left(e.toFetchBeersError())
+    }
 
   @Suppress("TooGenericExceptionCaught")
   override suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit> {

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/FetchBeersErrors.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/FetchBeersErrors.kt
@@ -1,0 +1,23 @@
+package com.simtop.beer_data.repositories
+
+import com.simtop.beerdomain.domain.errors.FetchBeersError
+import java.io.IOException
+import java.net.HttpURLConnection
+import retrofit2.HttpException
+
+// No HttpURLConnection constant exists for 429.
+private const val HTTP_TOO_MANY_REQUESTS = 429
+
+/** The one HTTP/IO → [FetchBeersError] mapping, shared by every beers fetch path. */
+internal fun Throwable.toFetchBeersError(): FetchBeersError =
+  when (this) {
+    is HttpException ->
+      when (code()) {
+        HttpURLConnection.HTTP_NOT_FOUND -> FetchBeersError.NotFound
+        HttpURLConnection.HTTP_FORBIDDEN -> FetchBeersError.Forbidden
+        HTTP_TOO_MANY_REQUESTS -> FetchBeersError.RateLimited
+        else -> FetchBeersError.Unknown(this)
+      }
+    is IOException -> FetchBeersError.Network
+    else -> FetchBeersError.Unknown(this)
+  }

--- a/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersRemoteSource.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersRemoteSource.kt
@@ -2,6 +2,8 @@ package com.simtop.beer_data.fakes
 
 import com.simtop.beer_network.models.BeersApiResponseItem
 import com.simtop.beer_network.models.BeersPage
+import com.simtop.beer_network.models.BreweryApiResponseItem
+import com.simtop.beer_network.models.TypologyApiResponseItem
 import com.simtop.beer_network.remotesources.BeersRemoteSource
 
 class FakeBeersRemoteSource : BeersRemoteSource {
@@ -13,6 +15,11 @@ class FakeBeersRemoteSource : BeersRemoteSource {
 
   val requestedPages = mutableListOf<Int>()
   val requestedSearches = mutableListOf<String?>()
+  val requestedTypologyIds = mutableListOf<String?>()
+  val requestedBreweryIds = mutableListOf<String?>()
+
+  var typologiesResponse: List<TypologyApiResponseItem> = emptyList()
+  var breweriesResponse: List<BreweryApiResponseItem> = emptyList()
 
   fun setBeersResponse(beers: List<BeersApiResponseItem>, totalCount: Int? = null) {
     beersResponse = beers
@@ -27,12 +34,29 @@ class FakeBeersRemoteSource : BeersRemoteSource {
     exceptionToThrow = exception
   }
 
-  override suspend fun getListOfBeers(page: Int, search: String?): BeersPage {
+  override suspend fun getListOfBeers(
+    page: Int,
+    search: String?,
+    typologyId: String?,
+    breweryId: String?,
+  ): BeersPage {
     requestedPages += page
     requestedSearches += search
+    requestedTypologyIds += typologyId
+    requestedBreweryIds += breweryId
     if (shouldThrowError) {
       throw exceptionToThrow
     }
     return BeersPage(items = beersResponse, totalCount = totalCount)
+  }
+
+  override suspend fun getTypologies(): List<TypologyApiResponseItem> {
+    if (shouldThrowError) throw exceptionToThrow
+    return typologiesResponse
+  }
+
+  override suspend fun getBreweries(): List<BreweryApiResponseItem> {
+    if (shouldThrowError) throw exceptionToThrow
+    return breweriesResponse
   }
 }

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -209,6 +209,33 @@ class BeersPagerFactoryImplTest {
     }
 
   @Test
+  fun `a style-filtered pager fetches with the typology id and keeps results in memory`() =
+    runTest(testDispatcher) {
+      beersRemoteSource.setBeersResponse(listOf(apiItem(id = "1")), totalCount = 1)
+      val pager = factory.create(BeersQuery(styleId = "style-1"))
+
+      pager.loadFirstPage()
+
+      expectThat(pager.data.first().map { it.id }).isEqualTo(listOf("1"))
+      expectThat(beersRemoteSource.requestedTypologyIds.toList()).isEqualTo(listOf("style-1"))
+      // One page load = exactly one /beers request (the browse analogue of the N+1 guard).
+      expectThat(beersRemoteSource.requestedPages.toList()).isEqualTo(listOf(1))
+      expectThat(repository.countDBEntries()).isEqualTo(0)
+    }
+
+  @Test
+  fun `a brewery-filtered pager fetches with the brewery id`() =
+    runTest(testDispatcher) {
+      beersRemoteSource.setBeersResponse(listOf(apiItem(id = "1")), totalCount = 1)
+      val pager = factory.create(BeersQuery(breweryId = "brew-1"))
+
+      pager.loadFirstPage()
+
+      expectThat(beersRemoteSource.requestedBreweryIds.toList()).isEqualTo(listOf("brew-1"))
+      expectThat(repository.countDBEntries()).isEqualTo(0)
+    }
+
+  @Test
   fun `pager data emits beers from the local source`() =
     runTest(testDispatcher) {
       beersRemoteSource.setBeersResponse(listOf(apiItem(id = "1")))

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
@@ -6,10 +6,19 @@ import com.simtop.beer_data.fakes.FakeBeersRemoteSource
 import com.simtop.beer_data.mappers.BeersMapper
 import com.simtop.beer_database.models.BeerDbModel
 import com.simtop.beer_network.models.BeersApiResponseItem
+import com.simtop.beer_network.models.BreweryApiResponseItem
+import com.simtop.beer_network.models.EmbeddedCountry
 import com.simtop.beer_network.models.EmbeddedImage
+import com.simtop.beer_network.models.TypologyApiResponseItem
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeerStyle
+import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.core.core.Either
 import com.simtop.core.core.LanguageProvider
 import com.simtop.core.core.NoOpLogger
+import java.io.IOException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -66,9 +75,74 @@ class BeersRepositoryTest {
     runTest(testDispatcher) {
       beersRemoteSource.setBeersResponse(emptyList(), totalCount = 0)
 
-      beersRepository.getBeersPageFromApi(1, search = "stout")
+      beersRepository.getBeersPageFromApi(1, BeersQuery(search = "stout"))
 
       expectThat(beersRemoteSource.requestedSearches.toList()).isEqualTo(listOf("stout"))
+    }
+
+  @Test
+  fun `getBeersPageFromApi forwards the style and brewery filters to the remote source`() =
+    runTest(testDispatcher) {
+      beersRemoteSource.setBeersResponse(emptyList(), totalCount = 0)
+
+      beersRepository.getBeersPageFromApi(1, BeersQuery(styleId = "style-1"))
+      beersRepository.getBeersPageFromApi(1, BeersQuery(breweryId = "brew-1"))
+
+      expectThat(beersRemoteSource.requestedTypologyIds.toList()).isEqualTo(listOf("style-1", null))
+      expectThat(beersRemoteSource.requestedBreweryIds.toList()).isEqualTo(listOf(null, "brew-1"))
+    }
+
+  @Test
+  fun `getBeerStyles maps typologies to domain styles`() =
+    runTest(testDispatcher) {
+      beersRemoteSource.typologiesResponse =
+        listOf(TypologyApiResponseItem(id = "t1", name = "IPA (Indian Pale Ale)"))
+
+      val result = beersRepository.getBeerStyles()
+
+      expectThat(result)
+        .isEqualTo(Either.Right(listOf(BeerStyle(id = "t1", name = "IPA (Indian Pale Ale)"))))
+    }
+
+  @Test
+  fun `getBreweries maps embedded country and image to a domain brewery`() =
+    runTest(testDispatcher) {
+      beersRemoteSource.breweriesResponse =
+        listOf(
+          BreweryApiResponseItem(
+            id = "b1",
+            name = "Supreme Suds Collective",
+            foundedYear = 1972,
+            country = EmbeddedCountry(code = "KP"),
+            image = EmbeddedImage("https://embedded.url/brewery.jpg"),
+          )
+        )
+
+      val result = beersRepository.getBreweries()
+
+      expectThat(result)
+        .isEqualTo(
+          Either.Right(
+            listOf(
+              Brewery(
+                id = "b1",
+                name = "Supreme Suds Collective",
+                countryCode = "KP",
+                foundedYear = 1972,
+                imageUrl = "https://embedded.url/brewery.jpg",
+              )
+            )
+          )
+        )
+    }
+
+  @Test
+  fun `unpaged fetch failures come back as classified errors, not thrown`() =
+    runTest(testDispatcher) {
+      beersRemoteSource.setShouldThrowError(true, IOException("no network"))
+
+      expectThat(beersRepository.getBeerStyles()).isEqualTo(Either.Left(FetchBeersError.Network))
+      expectThat(beersRepository.getBreweries()).isEqualTo(Either.Left(FetchBeersError.Network))
     }
 
   @Test

--- a/beer_network/fixtures/src/main/java/com/simtop/beer_network/fixtures/NetworkFixtures.kt
+++ b/beer_network/fixtures/src/main/java/com/simtop/beer_network/fixtures/NetworkFixtures.kt
@@ -6,6 +6,10 @@ import com.simtop.beer_network.models.Translation
 
 const val FAKE_JSON = "fake_json_response.json"
 
+const val FAKE_TYPOLOGIES_JSON = "fake_typologies_response.json"
+
+const val FAKE_BREWERIES_JSON = "fake_breweries_response.json"
+
 val fakeBeersApiResponseItem =
   BeersApiResponseItem(
     id = "1",

--- a/beer_network/src/main/java/com/simtop/beer_network/models/BreweryApiResponseItem.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/models/BreweryApiResponseItem.kt
@@ -1,0 +1,16 @@
+package com.simtop.beer_network.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** One `/breweries` row; the embedded `country` and `image` objects replace by-id lookups. */
+@Serializable
+data class BreweryApiResponseItem(
+  val id: String? = null,
+  val name: String? = null,
+  @SerialName("founded_year") val foundedYear: Int? = null,
+  val country: EmbeddedCountry? = null,
+  val image: EmbeddedImage? = null,
+)
+
+@Serializable data class EmbeddedCountry(val code: String? = null)

--- a/beer_network/src/main/java/com/simtop/beer_network/models/TypologyApiResponseItem.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/models/TypologyApiResponseItem.kt
@@ -1,0 +1,10 @@
+package com.simtop.beer_network.models
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One `/typologies` row. `name` is language-neutral ("Ale", "IPA (Indian Pale Ale)"); the
+ * per-language `translations` carry only descriptions, which nothing renders, so they're not
+ * modeled.
+ */
+@Serializable data class TypologyApiResponseItem(val id: String? = null, val name: String? = null)

--- a/beer_network/src/main/java/com/simtop/beer_network/network/BeersService.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/network/BeersService.kt
@@ -1,6 +1,8 @@
 package com.simtop.beer_network.network
 
 import com.simtop.beer_network.models.BeersApiResponseItem
+import com.simtop.beer_network.models.BreweryApiResponseItem
+import com.simtop.beer_network.models.TypologyApiResponseItem
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -12,9 +14,18 @@ interface BeersService {
     @Query("_page") page: Int,
     @Query("_limit") perPage: Int = DEFAULT_ITEMS_PER_PAGE,
     @Query("translations.language.code") languageCode: String = DEFAULT_LANGUAGE_CODE,
-    // Free-text search; null (catalog) omits the param entirely so the full list is returned.
+    // Filters; null omits the param entirely, so the catalog's unfiltered fetch stays byte-
+    // identical on the wire. The server ANDs whichever are present.
     @Query("q") search: String? = null,
+    @Query("typology.id") typologyId: String? = null,
+    @Query("brewery.id") breweryId: String? = null,
   ): Response<List<BeersApiResponseItem>>
+
+  // 17 rows - deliberately unpaged, so no Response<> wrapper: there's no header worth reading.
+  @GET("typologies") suspend fun getTypologies(): List<TypologyApiResponseItem>
+
+  // 38 rows - same reasoning.
+  @GET("breweries") suspend fun getBreweries(): List<BreweryApiResponseItem>
 
   companion object {
     const val DEFAULT_ITEMS_PER_PAGE = 25

--- a/beer_network/src/main/java/com/simtop/beer_network/remotesources/BeersRemoteSource.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/remotesources/BeersRemoteSource.kt
@@ -1,13 +1,29 @@
 package com.simtop.beer_network.remotesources
 
 import com.simtop.beer_network.models.BeersPage
+import com.simtop.beer_network.models.BreweryApiResponseItem
+import com.simtop.beer_network.models.TypologyApiResponseItem
 import com.simtop.beer_network.network.BeersService
 import com.simtop.core.core.LanguageProvider
 import dev.zacsweers.metro.Inject
 
 interface BeersRemoteSource {
-  /** [search] null fetches the full catalog; non-null adds `q=` for the search surface. */
-  suspend fun getListOfBeers(page: Int, search: String? = null): BeersPage
+  /**
+   * One page of beers. All filters null fetches the full catalog; [search] adds `q=`, [typologyId]
+   * `typology.id=`, [breweryId] `brewery.id=` - the server ANDs whichever are present.
+   */
+  suspend fun getListOfBeers(
+    page: Int,
+    search: String? = null,
+    typologyId: String? = null,
+    breweryId: String? = null,
+  ): BeersPage
+
+  /** All beer styles - 17 rows, unpaged. */
+  suspend fun getTypologies(): List<TypologyApiResponseItem>
+
+  /** All breweries - 38 rows, unpaged. */
+  suspend fun getBreweries(): List<BreweryApiResponseItem>
 }
 
 class BeersRemoteSourceImpl
@@ -15,17 +31,28 @@ class BeersRemoteSourceImpl
 constructor(private val service: BeersService, private val languageProvider: LanguageProvider) :
   BeersRemoteSource {
 
-  override suspend fun getListOfBeers(page: Int, search: String?): BeersPage {
+  override suspend fun getListOfBeers(
+    page: Int,
+    search: String?,
+    typologyId: String?,
+    breweryId: String?,
+  ): BeersPage {
     val response =
       service.getListOfBeers(
         page = page,
         languageCode = languageProvider.currentLanguageCode(),
         search = search,
+        typologyId = typologyId,
+        breweryId = breweryId,
       )
     // Malformed or absent header → null; the pager falls back to the empty-page probe.
     val totalCount = response.headers()[HEADER_TOTAL_COUNT]?.toIntOrNull()
     return BeersPage(items = response.body().orEmpty(), totalCount = totalCount)
   }
+
+  override suspend fun getTypologies(): List<TypologyApiResponseItem> = service.getTypologies()
+
+  override suspend fun getBreweries(): List<BreweryApiResponseItem> = service.getBreweries()
 
   private companion object {
     const val HEADER_TOTAL_COUNT = "X-Total-Count"

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/BeerStyle.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/BeerStyle.kt
@@ -1,0 +1,8 @@
+package com.simtop.beerdomain.domain.models
+
+/**
+ * A beer style (the API calls it a typology): "Ale", "IPA (Indian Pale Ale)", ... The API's `name`
+ * is language-neutral; only per-language *descriptions* exist and the browse list doesn't render
+ * them, so they're deliberately not modeled.
+ */
+data class BeerStyle(val id: String, val name: String)

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/BeersQuery.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/BeersQuery.kt
@@ -5,8 +5,12 @@ package com.simtop.beerdomain.domain.models
  * query, and a changed query means a *new* pager, not a mutation - which keeps invalidation out of
  * the mediator (see `BeersPagerFactory`).
  *
- * Phase 2 wires only [search] (`q=`); language stays on the `LanguageProvider` the way the catalog
- * does it, so it isn't part of the query. Style/brewery/abv/sort filters are Phase 3 - additive and
- * non-breaking when they arrive.
+ * [search] maps to `q=`, [styleId] to `typology.id=`, [breweryId] to `brewery.id=`. The API ANDs
+ * whatever is present, so combinations are legal even though each screen sets exactly one. Language
+ * stays on the `LanguageProvider` the way the catalog does it, so it isn't part of the query.
  */
-data class BeersQuery(val search: String)
+data class BeersQuery(
+  val search: String? = null,
+  val styleId: String? = null,
+  val breweryId: String? = null,
+)

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/Brewery.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/Brewery.kt
@@ -1,0 +1,13 @@
+package com.simtop.beerdomain.domain.models
+
+/**
+ * A brewery as the browse list renders it. [countryCode] is the ISO code ("KP"); localized country
+ * names exist server-side but a list row doesn't need them.
+ */
+data class Brewery(
+  val id: String,
+  val name: String,
+  val countryCode: String,
+  val foundedYear: Int?,
+  val imageUrl: String,
+)

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersPagerFactory.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersPagerFactory.kt
@@ -13,9 +13,10 @@ import com.simtop.core.core.Pager
  * Two surfaces exist, and they deliberately do **not** share storage:
  * - [create] (no args) is the **catalog**: the Room-backed single source of truth, whose pager
  *   reads and writes the one beers table and resumes from the `paging_state` bookmark.
- * - [create] with a [BeersQuery] is a **search** surface: a per-query in-memory pager whose results
- *   die with the screen and never touch the beers table (so the catalog's `SELECT * FROM beers`
- *   view can't be polluted by search hits). A changed query means a new pager, not a mutation.
+ * - [create] with a [BeersQuery] is a **query** surface (search, beers-by-style, beers-by-brewery):
+ *   a per-query in-memory pager whose results die with the screen and never touch the beers table
+ *   (so the catalog's `SELECT * FROM beers` view can't be polluted by filtered hits). A changed
+ *   query means a new pager, not a mutation.
  *
  * The factory itself is stateless, so it can safely be an app-scoped binding.
  */

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -1,8 +1,12 @@
 package com.simtop.beerdomain.domain.repositories
 
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.models.BeerPage
+import com.simtop.beerdomain.domain.models.BeerStyle
+import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.beerdomain.domain.models.Brewery
 import com.simtop.core.core.Either
 import kotlinx.coroutines.flow.Flow
 
@@ -46,8 +50,15 @@ interface BeersRepository {
   suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit>
 
   /**
-   * Fetches one page from the API, carrying the server total for end-detection and "N of M" UI.
-   * [search] null fetches the full catalog; non-null fetches the `q=` search surface.
+   * Fetches one page from the API, carrying the server total for end-detection and "N of M" UI. The
+   * default (all-null) [query] fetches the full catalog; setting search/style/brewery fetches that
+   * filtered surface.
    */
-  suspend fun getBeersPageFromApi(page: Int, search: String? = null): BeerPage
+  suspend fun getBeersPageFromApi(page: Int, query: BeersQuery = BeersQuery()): BeerPage
+
+  /** All 17 beer styles, unpaged - a list this small never needs a pager. */
+  suspend fun getBeerStyles(): Either<FetchBeersError, List<BeerStyle>>
+
+  /** All 38 breweries, unpaged - same reasoning as [getBeerStyles]. */
+  suspend fun getBreweries(): Either<FetchBeersError, List<Brewery>>
 }

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
@@ -1,8 +1,12 @@
 package com.simtop.beerdomain.fakes
 
+import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.errors.UpdateAvailabilityError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.models.BeerPage
+import com.simtop.beerdomain.domain.models.BeerStyle
+import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.beerdomain.domain.models.Brewery
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.Either
 import kotlinx.coroutines.flow.Flow
@@ -93,11 +97,19 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
 
   var apiPage: BeerPage = BeerPage(emptyList(), null)
 
-  /** Records every (page, search) the pager fetched, so tests can assert what was requested. */
-  val apiRequests = mutableListOf<Pair<Int, String?>>()
+  /** Records every (page, query) the pager fetched, so tests can assert what was requested. */
+  val apiRequests = mutableListOf<Pair<Int, BeersQuery>>()
 
-  override suspend fun getBeersPageFromApi(page: Int, search: String?): BeerPage {
-    apiRequests += page to search
+  override suspend fun getBeersPageFromApi(page: Int, query: BeersQuery): BeerPage {
+    apiRequests += page to query
     return apiPage
   }
+
+  var beerStyles: Either<FetchBeersError, List<BeerStyle>> = Either.Right(emptyList())
+
+  var breweries: Either<FetchBeersError, List<Brewery>> = Either.Right(emptyList())
+
+  override suspend fun getBeerStyles(): Either<FetchBeersError, List<BeerStyle>> = beerStyles
+
+  override suspend fun getBreweries(): Either<FetchBeersError, List<Brewery>> = breweries
 }


### PR DESCRIPTION
First of three Phase 3 (Browse) PRs: the data layer for browse-by-style and browse-by-brewery, with zero `core-common` changes — the plan's plug-and-play criterion for a new filtered surface.

- `BeersQuery` widens additively: `search` / `styleId` / `breweryId`, all optional. A query surface is still one immutable value = one in-memory pager; the catalog `create()` path is behaviorally unchanged (all-null query serializes to the identical request).
- `BeersService` gains `typology.id` / `brewery.id` filter params (null omits them, so the catalog request stays byte-identical on the wire) plus unpaged `GET /typologies` (17 rows) and `GET /breweries` (38 rows) — deliberately no pager and no `Response<>` wrapper for lists this small.
- `BeersRepository.getBeersPageFromApi(page, query)` replaces the search-only overload; new `getBeerStyles()` / `getBreweries()` return `Either<FetchBeersError, …>` since there's no pager to classify errors for them. The HTTP→`FetchBeersError` mapping moved out of the factory into a shared `toFetchBeersError()` used by both paths.
- New domain models `BeerStyle(id, name)` (typology names are language-neutral; localized descriptions exist but nothing renders them) and `Brewery(id, name, countryCode, foundedYear, imageUrl)` from the embedded country/image objects.
- `DynamicDependencies` now exposes `BeersPagerFactory` so the upcoming dynamic beerbrowse module (3b) can mint filtered pagers.
- Filter endpoints re-verified live 2026-07-19: `typology.id=` returns exact `X-Total-Count` (9 for the first style); typologies/breweries shapes match the new models.

Tests: MockWebServer coverage for the filter params on the wire (and their absence on catalog fetches) and both new endpoints' parsing; repository tests for filter forwarding, style/brewery mapping, and classified (not thrown) unpaged-fetch failures; factory tests proving filtered pagers stay in-memory and one page load = exactly one `/beers` request. Full `make test`, `make lint`, `make konsist` green.