### PR TITLE
feat: beerbrowse dynamic feature module with styles and breweries (Paging 2.0 3b)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ baselineProfile {
 
 android {
   namespace = "com.simtop.billionbeers"
-  dynamicFeatures += setOf(":feature:beerdetail")
+  dynamicFeatures += setOf(":feature:beerdetail", ":feature:beerbrowse")
 
   packaging {
     resources {

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
@@ -109,7 +109,20 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
 
   var breweries: Either<FetchBeersError, List<Brewery>> = Either.Right(emptyList())
 
-  override suspend fun getBeerStyles(): Either<FetchBeersError, List<BeerStyle>> = beerStyles
+  /** Fetch counts, so tests can assert lazy/once semantics of the unpaged browse loads. */
+  var beerStylesCallCount = 0
+    private set
 
-  override suspend fun getBreweries(): Either<FetchBeersError, List<Brewery>> = breweries
+  var breweriesCallCount = 0
+    private set
+
+  override suspend fun getBeerStyles(): Either<FetchBeersError, List<BeerStyle>> {
+    beerStylesCallCount++
+    return beerStyles
+  }
+
+  override suspend fun getBreweries(): Either<FetchBeersError, List<Brewery>> {
+    breweriesCallCount++
+    return breweries
+  }
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.dynamic.feature.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.dynamic.feature.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     "implementation"(libs.lifecycleRuntimeKtx)
     "implementation"(libs.navigationFragmentKtx)
     "implementation"(libs.navigationUi)
-    "implementation"(libs.navigationDynamicFeaturesFragment)
 
     "testImplementation"(libs.mockk)
     "testImplementation"(libs.coreTesting)

--- a/feature/beerbrowse/build.gradle.kts
+++ b/feature/beerbrowse/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+  id("billionbeers.android.dynamic.feature")
+  id("billionbeers.android.screenshot")
+}
+
+android { namespace = "com.simtop.feature.beerbrowse" }
+
+dependencies {
+  implementation(project(":beerdomain:api"))
+  implementation(project(":presentation_utils"))
+  implementation(project(":core"))
+  implementation(project(":core:designsystem"))
+  implementation(project(":navigation"))
+  implementation(libs.androidx.navigation3.runtime)
+  implementation(libs.androidx.material3.android)
+  implementation(libs.androidx.compose.material.icons.core)
+  implementation(libs.kotlinx.serialization.json)
+
+  testImplementation(project(":beerdomain:fakes"))
+  testImplementation(libs.striktCore)
+}

--- a/feature/beerbrowse/src/main/AndroidManifest.xml
+++ b/feature/beerbrowse/src/main/AndroidManifest.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:dist="http://schemas.android.com/apk/distribution">
+
+    <dist:module
+        dist:instant="false"
+        dist:title="@string/title_dynamicfeature">
+        <dist:delivery>
+            <dist:on-demand/>
+        </dist:delivery>
+        <dist:fusing dist:include="true" />
+    </dist:module>
+</manifest>

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BeerBrowseProviderImpl.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BeerBrowseProviderImpl.kt
@@ -1,0 +1,16 @@
+package com.simtop.feature.beerbrowse.presentation
+
+import androidx.annotation.Keep
+import androidx.compose.runtime.Composable
+import androidx.navigation3.runtime.NavKey
+import com.simtop.navigation.BeerBrowse
+import com.simtop.navigation.DynamicFeatureContentProvider
+
+@Suppress("MISSING_DEPENDENCY_SUPERCLASS_IN_TYPE_ARGUMENT")
+@Keep
+class BeerBrowseProviderImpl : DynamicFeatureContentProvider<BeerBrowse> {
+  @Composable
+  override fun Content(key: BeerBrowse, onBack: () -> Unit, onNavigate: (NavKey) -> Unit) {
+    BeerBrowseScreenImpl(onBack = onBack, onNavigate = onNavigate)
+  }
+}

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BeerBrowseScreenImpl.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BeerBrowseScreenImpl.kt
@@ -1,0 +1,121 @@
+package com.simtop.feature.beerbrowse.presentation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
+import androidx.compose.runtime.saveable.listSaver
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.navigation3.runtime.NavKey
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.billionbeers.BillionBeersApplication
+import com.simtop.billionbeers.di.DynamicDependencies
+import com.simtop.feature.beerbrowse.presentation.di.FeatureBrowseComponent
+import com.simtop.navigation.BeerDetail
+import com.simtop.navigation.FeatureConstants
+import com.simtop.presentation_utils.core.DynamicFeatureLoader
+import dev.zacsweers.metro.createGraphFactory
+import dev.zacsweers.metrox.viewmodel.LocalMetroViewModelFactory
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * One browse drill-in: the beers of a single style or brewery. Exactly one id is set; [name] is the
+ * results screen title. Kept as plain saveable state *inside* the module - only [BeerDetail]
+ * crosses the module boundary onto the app back stack.
+ */
+internal data class BrowseSelection(
+  val styleId: String? = null,
+  val breweryId: String? = null,
+  val name: String,
+) {
+  fun toQuery() = BeersQuery(styleId = styleId, breweryId = breweryId)
+
+  val key: String
+    get() = styleId ?: breweryId.orEmpty()
+}
+
+private val BrowseSelectionSaver =
+  listSaver<BrowseSelection?, String>(
+    save = { selection ->
+      selection?.let { listOf(it.styleId.orEmpty(), it.breweryId.orEmpty(), it.name) }
+        ?: emptyList()
+    },
+    restore = { saved ->
+      if (saved.isEmpty()) null
+      else
+        BrowseSelection(
+          styleId = saved[0].ifEmpty { null },
+          breweryId = saved[1].ifEmpty { null },
+          name = saved[2],
+        )
+    },
+  )
+
+// Same recipe as the catalog's saver: Beer is @Serializable, so a JSON round-trip survives
+// process death while the beerdetail install is in flight.
+private val BeerSaver: Saver<Beer?, String> =
+  Saver(
+    save = { beer -> beer?.let { Json.encodeToString(it) }.orEmpty() },
+    restore = { json -> json.takeIf { it.isNotEmpty() }?.let { Json.decodeFromString<Beer>(it) } },
+  )
+
+@Composable
+fun BeerBrowseScreenImpl(onBack: () -> Unit, onNavigate: (NavKey) -> Unit) {
+  val context = LocalContext.current
+
+  val factory = remember {
+    val appGraph =
+      (context.applicationContext as BillionBeersApplication).appGraph as DynamicDependencies
+    val component = createGraphFactory<FeatureBrowseComponent.Factory>().create(appGraph)
+    component.metroViewModelFactory
+  }
+
+  CompositionLocalProvider(LocalMetroViewModelFactory provides factory) {
+    var selection by
+      rememberSaveable(stateSaver = BrowseSelectionSaver) {
+        mutableStateOf<BrowseSelection?>(null)
+      }
+    // A tapped beer pending the beerdetail install - the same gate the catalog list uses, saved
+    // across process death so the in-flight navigation resumes instead of silently dropping.
+    var installingBeer by rememberSaveable(stateSaver = BeerSaver) { mutableStateOf<Beer?>(null) }
+
+    when (val current = selection) {
+      null ->
+        BrowseHomeScreen(
+          onBack = onBack,
+          onStyleClick = { style ->
+            selection = BrowseSelection(styleId = style.id, name = style.name)
+          },
+          onBreweryClick = { brewery ->
+            selection = BrowseSelection(breweryId = brewery.id, name = brewery.name)
+          },
+        )
+      else ->
+        BrowseBeersScreen(
+          selection = current,
+          onBack = { selection = null },
+          onBeerClick = { beer -> installingBeer = beer },
+        )
+    }
+
+    installingBeer?.let { beer ->
+      DynamicFeatureLoader(
+        featureName = FeatureConstants.BEER_DETAIL_MODULE,
+        onCancelled = { installingBeer = null },
+      ) {
+        LaunchedEffect(beer) {
+          onNavigate(BeerDetail(beer))
+          installingBeer = null
+        }
+      }
+    }
+  }
+}

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersScreen.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersScreen.kt
@@ -1,0 +1,218 @@
+package com.simtop.feature.beerbrowse.presentation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
+import com.simtop.billionbeers.core.designsystem.component.showToast
+import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
+import com.simtop.core.core.CommonUiState
+import com.simtop.core.core.PagedListFooter
+import com.simtop.core.core.PagedListUiModel
+import com.simtop.presentation_utils.R
+import com.simtop.presentation_utils.core.InfiniteListHandler
+import com.simtop.presentation_utils.core.resolvedMessage
+import com.simtop.presentation_utils.custom_views.ComposeBeersListItem
+import com.simtop.presentation_utils.custom_views.ComposeErrorView
+import com.simtop.presentation_utils.custom_views.pagedListFooter
+import dev.zacsweers.metrox.viewmodel.assistedMetroViewModel
+
+@Composable
+internal fun BrowseBeersScreen(
+  selection: BrowseSelection,
+  onBack: () -> Unit,
+  onBeerClick: (Beer) -> Unit,
+) {
+  // Keyed by the selection: picking a different style/brewery mints a fresh ViewModel (and with
+  // it a fresh pager) instead of mutating the old one - the query-surface invalidation rule.
+  val viewModel =
+    assistedMetroViewModel<BrowseBeersViewModel, BrowseBeersViewModel.Factory>(
+      key = selection.key
+    ) {
+      create(selection.toQuery())
+    }
+  val viewState by viewModel.viewState.collectAsState()
+  val context = LocalContext.current
+  val lifecycleOwner = LocalLifecycleOwner.current
+  val loadMoreFailedMessage = stringResource(R.string.paged_list_load_more_failed)
+
+  LaunchedEffect(viewModel, lifecycleOwner) {
+    lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+      viewModel.events.collect { event ->
+        when (event) {
+          BrowseBeersEvent.ShowLoadMoreError -> showToast(context, loadMoreFailedMessage)
+        }
+      }
+    }
+  }
+
+  BrowseBeersContent(
+    title = selection.name,
+    viewState = viewState,
+    onBack = onBack,
+    onBeerClick = onBeerClick,
+    onScrollToBottom = { viewModel.onScrollToBottom() },
+    onRetryLoadMore = { viewModel.onRetryLoadMore() },
+    onRetryFirstPage = { viewModel.onRetryFirstPage() },
+  )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun BrowseBeersContent(
+  title: String,
+  viewState: CommonUiState<PagedListUiModel<Beer>>,
+  onBack: () -> Unit,
+  onBeerClick: (Beer) -> Unit,
+  onScrollToBottom: () -> Unit,
+  onRetryLoadMore: () -> Unit,
+  onRetryFirstPage: () -> Unit,
+) {
+  Scaffold(
+    topBar = {
+      TopAppBar(
+        navigationIcon = {
+          IconButton(onClick = onBack) {
+            Icon(
+              Icons.AutoMirrored.Filled.ArrowBack,
+              contentDescription = stringResource(R.string.browse_back),
+            )
+          }
+        },
+        title = { Text(title) },
+      )
+    }
+  ) { padding ->
+    Box(modifier = Modifier.fillMaxSize().padding(top = padding.calculateTopPadding())) {
+      when (val state = viewState) {
+        CommonUiState.Empty,
+        CommonUiState.Loading ->
+          Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator()
+          }
+        is CommonUiState.Error ->
+          ComposeErrorView(message = state.resolvedMessage().orEmpty(), onRetry = onRetryFirstPage)
+        is CommonUiState.Success ->
+          if (state.data.items.isEmpty()) {
+            CenteredHint(stringResource(R.string.browse_no_beers))
+          } else {
+            BrowseBeersResults(
+              model = state.data,
+              onBeerClick = onBeerClick,
+              onScrollToBottom = onScrollToBottom,
+              onRetryLoadMore = onRetryLoadMore,
+            )
+          }
+      }
+    }
+  }
+}
+
+@Composable
+private fun BrowseBeersResults(
+  model: PagedListUiModel<Beer>,
+  onBeerClick: (Beer) -> Unit,
+  onScrollToBottom: () -> Unit,
+  onRetryLoadMore: () -> Unit,
+) {
+  Column {
+    model.totalCount?.let { count ->
+      Text(
+        text = stringResource(R.string.browse_beers_count, count),
+        style = MaterialTheme.typography.labelLarge,
+        modifier =
+          Modifier.fillMaxWidth()
+            .padding(
+              horizontal = BillionBeersTheme.spacing.medium,
+              vertical = BillionBeersTheme.spacing.small,
+            ),
+      )
+    }
+
+    val listState = rememberLazyListState()
+    if (model.footer !is PagedListFooter.Retry) {
+      InfiniteListHandler(listState = listState, onLoadMore = onScrollToBottom)
+    }
+
+    val endOfListText = stringResource(R.string.browse_beers_end_of_list, model.items.size)
+    LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+      items(model.items.size) { index ->
+        ComposeBeersListItem(beer = model.items[index], onClick = onBeerClick)
+      }
+      pagedListFooter(
+        model = model,
+        endOfListText = endOfListText,
+        onRetryLoadMore = onRetryLoadMore,
+      )
+    }
+  }
+}
+
+class BrowseBeersPreviewParameterProvider :
+  PreviewParameterProvider<BrowseBeersPreviewParameterProvider.Case> {
+
+  data class Case(val title: String, val state: CommonUiState<PagedListUiModel<Beer>>)
+
+  private val sampleBeers =
+    listOf(
+      Beer.empty.copy(name = "Punk IPA", tagline = "Post Modern Classic.", abv = 5.6, ibu = 41.5),
+      Beer.empty.copy(name = "Hazy Jane", tagline = "New England IPA.", abv = 5.0, ibu = 25.0),
+    )
+
+  override val values =
+    sequenceOf(
+      Case(
+        "IPA (Indian Pale Ale)",
+        CommonUiState.Success(PagedListUiModel(items = sampleBeers, totalCount = 9)),
+      ),
+      Case("Stout", CommonUiState.Success(PagedListUiModel(totalCount = 0))),
+      Case("Lager", CommonUiState.Error(messageRes = R.string.error_rate_limited)),
+    )
+}
+
+@PreviewLightDark
+@Composable
+fun BrowseBeersScreenPreview(
+  @PreviewParameter(BrowseBeersPreviewParameterProvider::class)
+  case: BrowseBeersPreviewParameterProvider.Case
+) {
+  BillionBeersTheme {
+    BrowseBeersContent(
+      title = case.title,
+      viewState = case.state,
+      onBack = {},
+      onBeerClick = {},
+      onScrollToBottom = {},
+      onRetryLoadMore = {},
+      onRetryFirstPage = {},
+    )
+  }
+}

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersViewModel.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersViewModel.kt
@@ -1,0 +1,107 @@
+package com.simtop.feature.beerbrowse.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.simtop.beerdomain.domain.errors.FetchBeersError
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
+import com.simtop.core.core.CommonUiState
+import com.simtop.core.core.CoroutineDispatcherProvider
+import com.simtop.core.core.PagedListReducer
+import com.simtop.core.core.PagedListUiModel
+import com.simtop.core.core.PagingEvent
+import com.simtop.feature.beerbrowse.presentation.di.FeatureBrowseScope
+import com.simtop.presentation_utils.core.toErrorState
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactory
+import dev.zacsweers.metrox.viewmodel.ManualViewModelAssistedFactoryKey
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * The beers matching one browse selection (a style or a brewery), paged with the same machinery as
+ * the catalog and search: a per-query in-memory pager from [BeersPagerFactory] reduced by the
+ * shared [PagedListReducer]. One ViewModel per selection ([query] is assisted), so switching
+ * selections is a new pager, not a mutation - the same invalidation rule every query surface
+ * follows.
+ */
+class BrowseBeersViewModel
+@AssistedInject
+constructor(
+  private val coroutineDispatcher: CoroutineDispatcherProvider,
+  beersPagerFactory: BeersPagerFactory,
+  @Assisted query: BeersQuery,
+) : ViewModel() {
+
+  @AssistedFactory
+  @ManualViewModelAssistedFactoryKey(Factory::class)
+  @ContributesIntoMap(FeatureBrowseScope::class)
+  interface Factory : ManualViewModelAssistedFactory {
+    fun create(@Assisted query: BeersQuery): BrowseBeersViewModel
+  }
+
+  private val pager = beersPagerFactory.create(query)
+
+  // Ended empty is a Success with no items (the "no beers here" hint), not the generic Empty.
+  private val reducer =
+    PagedListReducer<Beer, FetchBeersError>(
+      errorState = { it.toErrorState() },
+      endedEmpty = { CommonUiState.Success(PagedListUiModel()) },
+    )
+
+  private val _events = Channel<BrowseBeersEvent>(Channel.BUFFERED)
+  val events: Flow<BrowseBeersEvent> = _events.receiveAsFlow()
+
+  val viewState: StateFlow<CommonUiState<PagedListUiModel<Beer>>> =
+    combine(pager.data, pager.pagingState, reducer::reduce)
+      .flowOn(coroutineDispatcher.io)
+      .stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(SUBSCRIPTION_TIMEOUT_MILLIS),
+        CommonUiState.Loading,
+      )
+
+  init {
+    viewModelScope.launch(coroutineDispatcher.io) { pager.loadFirstPage() }
+    viewModelScope.launch {
+      pager.events.collect { event ->
+        when (event) {
+          is PagingEvent.LoadMoreFailed -> _events.trySend(BrowseBeersEvent.ShowLoadMoreError)
+        }
+      }
+    }
+  }
+
+  fun onScrollToBottom() {
+    viewModelScope.launch(coroutineDispatcher.io) { pager.loadNextPage() }
+  }
+
+  fun onRetryLoadMore() {
+    viewModelScope.launch(coroutineDispatcher.io) { pager.loadNextPage() }
+  }
+
+  /** Full-screen error retry: re-runs the first page of this selection. */
+  fun onRetryFirstPage() {
+    viewModelScope.launch(coroutineDispatcher.io) { pager.loadFirstPage() }
+  }
+
+  private companion object {
+    const val SUBSCRIPTION_TIMEOUT_MILLIS = 5_000L
+  }
+}
+
+/** One-shot effects the browse beers screen consumes once. */
+sealed interface BrowseBeersEvent {
+  data object ShowLoadMoreError : BrowseBeersEvent
+}

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseHomeScreen.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseHomeScreen.kt
@@ -1,0 +1,257 @@
+package com.simtop.feature.beerbrowse.presentation
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.simtop.beerdomain.domain.models.BeerStyle
+import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
+import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
+import com.simtop.core.core.CommonUiState
+import com.simtop.presentation_utils.R
+import com.simtop.presentation_utils.core.resolvedMessage
+import com.simtop.presentation_utils.custom_views.ComposeErrorView
+import dev.zacsweers.metrox.viewmodel.metroViewModel
+
+private const val TAB_STYLES = 0
+private const val TAB_BREWERIES = 1
+
+@Composable
+internal fun BrowseHomeScreen(
+  onBack: () -> Unit,
+  onStyleClick: (BeerStyle) -> Unit,
+  onBreweryClick: (Brewery) -> Unit,
+  viewModel: BrowseViewModel = metroViewModel(),
+) {
+  val styles by viewModel.styles.collectAsState()
+  val breweries by viewModel.breweries.collectAsState()
+  var selectedTab by rememberSaveable { mutableIntStateOf(TAB_STYLES) }
+
+  // Runs on selection *and* on process-death restore with the breweries tab selected - the
+  // recreated ViewModel must be told the tab is visible or its list would stay Loading forever.
+  LaunchedEffect(selectedTab) {
+    if (selectedTab == TAB_BREWERIES) viewModel.onBreweriesTabSelected()
+  }
+
+  BrowseHomeContent(
+    styles = styles,
+    breweries = breweries,
+    selectedTab = selectedTab,
+    onTabSelected = { selectedTab = it },
+    onStyleClick = onStyleClick,
+    onBreweryClick = onBreweryClick,
+    onBack = onBack,
+    onRetryStyles = { viewModel.retryStyles() },
+    onRetryBreweries = { viewModel.retryBreweries() },
+  )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun BrowseHomeContent(
+  styles: CommonUiState<List<BeerStyle>>,
+  breweries: CommonUiState<List<Brewery>>,
+  selectedTab: Int,
+  onTabSelected: (Int) -> Unit,
+  onStyleClick: (BeerStyle) -> Unit,
+  onBreweryClick: (Brewery) -> Unit,
+  onBack: () -> Unit,
+  onRetryStyles: () -> Unit,
+  onRetryBreweries: () -> Unit,
+) {
+  Scaffold(
+    topBar = {
+      TopAppBar(
+        navigationIcon = {
+          IconButton(onClick = onBack) {
+            Icon(
+              Icons.AutoMirrored.Filled.ArrowBack,
+              contentDescription = stringResource(R.string.browse_back),
+            )
+          }
+        },
+        title = { Text(stringResource(R.string.browse_title)) },
+      )
+    }
+  ) { padding ->
+    Column(modifier = Modifier.fillMaxSize().padding(top = padding.calculateTopPadding())) {
+      TabRow(selectedTabIndex = selectedTab) {
+        Tab(
+          selected = selectedTab == TAB_STYLES,
+          onClick = { onTabSelected(TAB_STYLES) },
+          text = { Text(stringResource(R.string.browse_tab_styles)) },
+        )
+        Tab(
+          selected = selectedTab == TAB_BREWERIES,
+          onClick = { onTabSelected(TAB_BREWERIES) },
+          text = { Text(stringResource(R.string.browse_tab_breweries)) },
+        )
+      }
+
+      when (selectedTab) {
+        TAB_STYLES ->
+          BrowseListState(state = styles, onRetry = onRetryStyles) { items ->
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+              items(items.size) { index ->
+                val style = items[index]
+                ListItem(
+                  headlineContent = { Text(style.name) },
+                  modifier = Modifier.clickable { onStyleClick(style) },
+                )
+                HorizontalDivider()
+              }
+            }
+          }
+        TAB_BREWERIES ->
+          BrowseListState(state = breweries, onRetry = onRetryBreweries) { items ->
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+              items(items.size) { index ->
+                val brewery = items[index]
+                ListItem(
+                  headlineContent = { Text(brewery.name) },
+                  supportingContent = {
+                    breweryCaption(brewery)?.let { caption -> Text(caption) }
+                  },
+                  modifier = Modifier.clickable { onBreweryClick(brewery) },
+                )
+                HorizontalDivider()
+              }
+            }
+          }
+      }
+    }
+  }
+}
+
+/** The one Loading/Error/Empty/Success wrapper both unpaged browse lists share. */
+@Composable
+private fun <T> BrowseListState(
+  state: CommonUiState<List<T>>,
+  onRetry: () -> Unit,
+  content: @Composable (List<T>) -> Unit,
+) {
+  when (state) {
+    CommonUiState.Loading ->
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+      }
+    is CommonUiState.Error ->
+      ComposeErrorView(message = state.resolvedMessage().orEmpty(), onRetry = onRetry)
+    CommonUiState.Empty -> CenteredHint(stringResource(R.string.empty_state))
+    is CommonUiState.Success -> content(state.data)
+  }
+}
+
+/** "KP · Founded 1972", degrading gracefully when either half is missing. */
+@Composable
+private fun breweryCaption(brewery: Brewery): String? {
+  val foundedYear = brewery.foundedYear
+  return when {
+    brewery.countryCode.isNotEmpty() && foundedYear != null ->
+      stringResource(R.string.browse_brewery_founded, brewery.countryCode, foundedYear)
+    brewery.countryCode.isNotEmpty() -> brewery.countryCode
+    else -> null
+  }
+}
+
+@Composable
+internal fun CenteredHint(text: String) {
+  Box(
+    modifier = Modifier.fillMaxSize().padding(BillionBeersTheme.spacing.large),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text(
+      text = text,
+      style = MaterialTheme.typography.bodyLarge,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      textAlign = TextAlign.Center,
+    )
+  }
+}
+
+class BrowseHomePreviewParameterProvider :
+  PreviewParameterProvider<BrowseHomePreviewParameterProvider.Case> {
+
+  data class Case(
+    val styles: CommonUiState<List<BeerStyle>>,
+    val breweries: CommonUiState<List<Brewery>>,
+    val selectedTab: Int,
+  )
+
+  private val sampleStyles =
+    listOf(
+      BeerStyle(id = "1", name = "IPA (Indian Pale Ale)"),
+      BeerStyle(id = "2", name = "Stout"),
+      BeerStyle(id = "3", name = "Lager"),
+    )
+
+  private val sampleBreweries =
+    listOf(
+      Brewery(
+        id = "1",
+        name = "Supreme Suds Collective",
+        countryCode = "KP",
+        foundedYear = 1972,
+        imageUrl = "",
+      ),
+      Brewery(id = "2", name = "Hop Haven", countryCode = "BE", foundedYear = null, imageUrl = ""),
+    )
+
+  override val values =
+    sequenceOf(
+      Case(CommonUiState.Success(sampleStyles), CommonUiState.Loading, 0),
+      Case(CommonUiState.Success(sampleStyles), CommonUiState.Success(sampleBreweries), 1),
+      Case(CommonUiState.Error(messageRes = R.string.error_no_internet), CommonUiState.Loading, 0),
+    )
+}
+
+@PreviewLightDark
+@Composable
+fun BrowseHomeScreenPreview(
+  @PreviewParameter(BrowseHomePreviewParameterProvider::class)
+  case: BrowseHomePreviewParameterProvider.Case
+) {
+  BillionBeersTheme {
+    BrowseHomeContent(
+      styles = case.styles,
+      breweries = case.breweries,
+      selectedTab = case.selectedTab,
+      onTabSelected = {},
+      onStyleClick = {},
+      onBreweryClick = {},
+      onBack = {},
+      onRetryStyles = {},
+      onRetryBreweries = {},
+    )
+  }
+}

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseViewModel.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseViewModel.kt
@@ -1,0 +1,74 @@
+package com.simtop.feature.beerbrowse.presentation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.simtop.beerdomain.domain.errors.FetchBeersError
+import com.simtop.beerdomain.domain.models.BeerStyle
+import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.core.core.CommonUiState
+import com.simtop.core.core.CoroutineDispatcherProvider
+import com.simtop.core.core.Either
+import com.simtop.feature.beerbrowse.presentation.di.FeatureBrowseScope
+import com.simtop.presentation_utils.core.toErrorState
+import dev.zacsweers.metro.ContributesIntoMap
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metrox.viewmodel.ViewModelKey
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/**
+ * The browse landing screen: 17 styles and 38 breweries, each a single unpaged fetch (deliberately
+ * no pager - see rod plan §6.4's "knowing when not to plug it in"). Styles load immediately (the
+ * first tab on screen); breweries wait for their tab to be selected once, so a user who never
+ * switches tabs never spends the request.
+ */
+@ContributesIntoMap(FeatureBrowseScope::class)
+@ViewModelKey(BrowseViewModel::class)
+@Inject
+class BrowseViewModel(
+  private val coroutineDispatcher: CoroutineDispatcherProvider,
+  private val beersRepository: BeersRepository,
+) : ViewModel() {
+
+  private val _styles = MutableStateFlow<CommonUiState<List<BeerStyle>>>(CommonUiState.Loading)
+  val styles: StateFlow<CommonUiState<List<BeerStyle>>> = _styles.asStateFlow()
+
+  private val _breweries = MutableStateFlow<CommonUiState<List<Brewery>>>(CommonUiState.Loading)
+  val breweries: StateFlow<CommonUiState<List<Brewery>>> = _breweries.asStateFlow()
+
+  private var breweriesRequested = false
+
+  init {
+    retryStyles()
+  }
+
+  /** First selection triggers the fetch; later selections are free tab switches. */
+  fun onBreweriesTabSelected() {
+    if (breweriesRequested) return
+    breweriesRequested = true
+    retryBreweries()
+  }
+
+  fun retryStyles() {
+    viewModelScope.launch(coroutineDispatcher.io) {
+      _styles.value = CommonUiState.Loading
+      _styles.value = beersRepository.getBeerStyles().toUiState()
+    }
+  }
+
+  fun retryBreweries() {
+    viewModelScope.launch(coroutineDispatcher.io) {
+      _breweries.value = CommonUiState.Loading
+      _breweries.value = beersRepository.getBreweries().toUiState()
+    }
+  }
+
+  private fun <T> Either<FetchBeersError, List<T>>.toUiState(): CommonUiState<List<T>> =
+    either(
+      fnL = { error -> error.toErrorState() },
+      fnR = { list -> if (list.isEmpty()) CommonUiState.Empty else CommonUiState.Success(list) },
+    )
+}

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/di/FeatureBrowseComponent.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/di/FeatureBrowseComponent.kt
@@ -1,0 +1,17 @@
+package com.simtop.feature.beerbrowse.presentation.di
+
+import com.simtop.billionbeers.di.DynamicDependencies
+import com.simtop.core.di.DefaultMetroViewModelFactory
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Includes
+import dev.zacsweers.metrox.viewmodel.MetroViewModelMultibindings
+
+@DependencyGraph(FeatureBrowseScope::class)
+interface FeatureBrowseComponent : MetroViewModelMultibindings {
+  val metroViewModelFactory: DefaultMetroViewModelFactory
+
+  @DependencyGraph.Factory
+  fun interface Factory {
+    fun create(@Includes dependencies: DynamicDependencies): FeatureBrowseComponent
+  }
+}

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/di/FeatureBrowseScope.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/di/FeatureBrowseScope.kt
@@ -1,0 +1,3 @@
+package com.simtop.feature.beerbrowse.presentation.di
+
+abstract class FeatureBrowseScope private constructor()

--- a/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/BrowseBeersViewModelTest.kt
+++ b/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/BrowseBeersViewModelTest.kt
@@ -1,0 +1,166 @@
+package com.simtop.feature.beerbrowse
+
+import app.cash.turbine.test
+import com.simtop.beerdomain.domain.errors.FetchBeersError
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.beerdomain.fakes.FakeBeersPagerFactory
+import com.simtop.beerdomain.fakes.FakeBeersRepository
+import com.simtop.core.core.CommonUiState
+import com.simtop.core.core.CoroutineDispatcherProvider
+import com.simtop.core.core.PagedListFooter
+import com.simtop.core.core.PagedListUiModel
+import com.simtop.core.core.PagingEvent
+import com.simtop.core.core.PagingState
+import com.simtop.feature.beerbrowse.presentation.BrowseBeersEvent
+import com.simtop.feature.beerbrowse.presentation.BrowseBeersViewModel
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+
+@ExperimentalCoroutinesApi
+class BrowseBeersViewModelTest {
+
+  private val coroutineDispatcherProvider = mockk<CoroutineDispatcherProvider>()
+  private val fakeRepository = FakeBeersRepository()
+  private val fakeFactory = FakeBeersPagerFactory(fakeRepository)
+
+  private lateinit var testDispatcher: TestDispatcher
+
+  private val styleQuery = BeersQuery(styleId = "style-1")
+
+  @BeforeEach
+  fun setUp() {
+    testDispatcher = UnconfinedTestDispatcher()
+    Dispatchers.setMain(testDispatcher)
+    every { coroutineDispatcherProvider.io } returns testDispatcher
+    every { coroutineDispatcherProvider.main } returns testDispatcher
+  }
+
+  @AfterEach fun tearDown() = Dispatchers.resetMain()
+
+  private fun buildViewModel(query: BeersQuery = styleQuery) =
+    BrowseBeersViewModel(coroutineDispatcherProvider, fakeFactory, query)
+
+  @Test
+  fun `creates one pager for its query and loads the first page`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        runCurrent()
+
+        expectThat(fakeFactory.createdQueries.toList()).isEqualTo(listOf(styleQuery))
+        expectThat(fakeFactory.searchPagers.last().loadFirstPageCallCount).isEqualTo(1)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+  @Test
+  fun `results surface with the server total`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        runCurrent()
+        val pager = fakeFactory.searchPagers.last()
+        pager.setData(listOf(Beer.empty.copy(id = "1")))
+        pager.setPagingState(PagingState.Success(totalCount = 9))
+        runCurrent()
+
+        val state = expectMostRecentItem()
+        expectThat(state).isA<CommonUiState.Success<PagedListUiModel<Beer>>>()
+        val model = (state as CommonUiState.Success).data
+        expectThat(model.items.map { it.id }).isEqualTo(listOf("1"))
+        expectThat(model.totalCount).isEqualTo(9)
+      }
+    }
+
+  @Test
+  fun `a selection with no beers exposes zero results, not Empty`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        runCurrent()
+        val pager = fakeFactory.searchPagers.last()
+        pager.setData(emptyList())
+        pager.setPagingState(PagingState.EndOfPagination)
+        runCurrent()
+
+        val state = expectMostRecentItem()
+        expectThat(state).isA<CommonUiState.Success<PagedListUiModel<Beer>>>()
+        expectThat((state as CommonUiState.Success).data.items).isEqualTo(emptyList())
+      }
+    }
+
+  @Test
+  fun `a first-page failure surfaces the error state`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        runCurrent()
+        fakeFactory.searchPagers
+          .last()
+          .setPagingState(PagingState.Error(FetchBeersError.RateLimited, isFirstPage = true))
+        runCurrent()
+
+        expectThat(expectMostRecentItem()).isA<CommonUiState.Error>()
+      }
+    }
+
+  @Test
+  fun `a failed load more keeps the list, shows the retry footer and emits the one-shot event`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.events.test {
+        viewModel.viewState.test {
+          runCurrent()
+          val pager = fakeFactory.searchPagers.last()
+          pager.setData(listOf(Beer.empty.copy(id = "1")))
+          pager.setPagingState(PagingState.Error(FetchBeersError.Network, isFirstPage = false))
+          pager.emitEvent(PagingEvent.LoadMoreFailed(FetchBeersError.Network))
+          runCurrent()
+
+          val state = expectMostRecentItem()
+          val model = (state as CommonUiState.Success).data
+          expectThat(model.footer).isEqualTo(PagedListFooter.Retry)
+          cancelAndIgnoreRemainingEvents()
+        }
+        expectThat(awaitItem()).isEqualTo(BrowseBeersEvent.ShowLoadMoreError)
+      }
+    }
+
+  @Test
+  fun `scroll to bottom and retry both load the next page of the same pager`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        runCurrent()
+        val pager = fakeFactory.searchPagers.last()
+
+        viewModel.onScrollToBottom()
+        viewModel.onRetryLoadMore()
+        runCurrent()
+
+        expectThat(pager.loadNextPageCallCount).isEqualTo(2)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+}

--- a/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/BrowseViewModelTest.kt
+++ b/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/BrowseViewModelTest.kt
@@ -1,0 +1,127 @@
+package com.simtop.feature.beerbrowse
+
+import com.simtop.beerdomain.domain.errors.FetchBeersError
+import com.simtop.beerdomain.domain.models.BeerStyle
+import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.beerdomain.fakes.FakeBeersRepository
+import com.simtop.core.core.CommonUiState
+import com.simtop.core.core.CoroutineDispatcherProvider
+import com.simtop.core.core.Either
+import com.simtop.feature.beerbrowse.presentation.BrowseViewModel
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+
+@ExperimentalCoroutinesApi
+class BrowseViewModelTest {
+
+  private val coroutineDispatcherProvider = mockk<CoroutineDispatcherProvider>()
+  private val fakeRepository = FakeBeersRepository()
+
+  private lateinit var testDispatcher: TestDispatcher
+
+  @BeforeEach
+  fun setUp() {
+    testDispatcher = UnconfinedTestDispatcher()
+    Dispatchers.setMain(testDispatcher)
+    every { coroutineDispatcherProvider.io } returns testDispatcher
+    every { coroutineDispatcherProvider.main } returns testDispatcher
+  }
+
+  @AfterEach fun tearDown() = Dispatchers.resetMain()
+
+  private fun buildViewModel() = BrowseViewModel(coroutineDispatcherProvider, fakeRepository)
+
+  @Test
+  fun `styles load on start and expose Success`() =
+    runTest(testDispatcher) {
+      val styles = listOf(BeerStyle(id = "1", name = "IPA"))
+      fakeRepository.beerStyles = Either.Right(styles)
+
+      val viewModel = buildViewModel()
+      runCurrent()
+
+      expectThat(viewModel.styles.value).isEqualTo(CommonUiState.Success(styles))
+    }
+
+  @Test
+  fun `a failed styles load exposes the classified error and retry re-fetches`() =
+    runTest(testDispatcher) {
+      fakeRepository.beerStyles = Either.Left(FetchBeersError.Network)
+
+      val viewModel = buildViewModel()
+      runCurrent()
+
+      expectThat(viewModel.styles.value).isA<CommonUiState.Error>()
+
+      fakeRepository.beerStyles = Either.Right(listOf(BeerStyle(id = "1", name = "IPA")))
+      viewModel.retryStyles()
+      runCurrent()
+
+      expectThat(viewModel.styles.value).isA<CommonUiState.Success<List<BeerStyle>>>()
+    }
+
+  @Test
+  fun `breweries are not fetched until their tab is selected`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+      runCurrent()
+
+      expectThat(fakeRepository.breweriesCallCount).isEqualTo(0)
+      expectThat(viewModel.breweries.value).isEqualTo(CommonUiState.Loading)
+
+      val breweries =
+        listOf(
+          Brewery(
+            id = "1",
+            name = "Hop Haven",
+            countryCode = "BE",
+            foundedYear = 1898,
+            imageUrl = "",
+          )
+        )
+      fakeRepository.breweries = Either.Right(breweries)
+      viewModel.onBreweriesTabSelected()
+      runCurrent()
+
+      expectThat(viewModel.breweries.value).isEqualTo(CommonUiState.Success(breweries))
+    }
+
+  @Test
+  fun `re-selecting the breweries tab does not re-fetch`() =
+    runTest(testDispatcher) {
+      fakeRepository.breweries = Either.Right(emptyList())
+      val viewModel = buildViewModel()
+
+      viewModel.onBreweriesTabSelected()
+      viewModel.onBreweriesTabSelected()
+      runCurrent()
+
+      expectThat(fakeRepository.breweriesCallCount).isEqualTo(1)
+    }
+
+  @Test
+  fun `an empty brewery list exposes Empty`() =
+    runTest(testDispatcher) {
+      fakeRepository.breweries = Either.Right(emptyList())
+      val viewModel = buildViewModel()
+
+      viewModel.onBreweriesTabSelected()
+      runCurrent()
+
+      expectThat(viewModel.breweries.value).isEqualTo(CommonUiState.Empty)
+    }
+}

--- a/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/FeatureConstantsTest.kt
+++ b/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/FeatureConstantsTest.kt
@@ -1,0 +1,17 @@
+package com.simtop.feature.beerbrowse
+
+import com.simtop.feature.beerbrowse.presentation.BeerBrowseProviderImpl
+import com.simtop.navigation.FeatureConstants
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FeatureConstantsTest {
+
+  @Test
+  fun `verify beer browse provider class name matches constant`() {
+    assertEquals(
+      BeerBrowseProviderImpl::class.java.name,
+      FeatureConstants.BEER_BROWSE_PROVIDER_CLASS,
+    )
+  }
+}

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersScreenPreview_0]_browsebeersscreenpreview_0.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersScreenPreview_0]_browsebeersscreenpreview_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42c8d71b14a0d9878d4c4522e592f58379db6b5ca59ae95be586bbaddce24dc2
+size 32238

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersScreenPreview_1]_browsebeersscreenpreview_1.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersScreenPreview_1]_browsebeersscreenpreview_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dbf62fdcbdbabc013df7ac60909c812730849bc27016060bbd215726940f140
+size 8072

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersScreenPreview_2]_browsebeersscreenpreview_2.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersScreenPreview_2]_browsebeersscreenpreview_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57a194c70ae33fd54a5d4a016771b357c3b81910572346ba5029d38c8edd4d0a
+size 14730

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeScreenPreview_0]_browsehomescreenpreview_0.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeScreenPreview_0]_browsehomescreenpreview_0.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57ea4e61f0b48ca8f52dbd2d8f584167e10021347003f4b09fae39a9f88b1599
+size 14363

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeScreenPreview_1]_browsehomescreenpreview_1.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeScreenPreview_1]_browsehomescreenpreview_1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2991098bd3b710338f81996faf4c3d48fb05c4f47e56e90f694650833495a7ef
+size 17249

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeScreenPreview_2]_browsehomescreenpreview_2.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeScreenPreview_2]_browsehomescreenpreview_2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b7a91fee483ff45f025d00052a2c69e4b0c91d3a58ebd364aa4f89f2625d033
+size 15392

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/BeerDetailProviderImpl.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/BeerDetailProviderImpl.kt
@@ -2,14 +2,16 @@ package com.simtop.feature.beerdetail.presentation
 
 import androidx.annotation.Keep
 import androidx.compose.runtime.Composable
+import androidx.navigation3.runtime.NavKey
 import com.simtop.navigation.BeerDetail
 import com.simtop.navigation.DynamicFeatureContentProvider
 
 @Suppress("MISSING_DEPENDENCY_SUPERCLASS_IN_TYPE_ARGUMENT")
 @Keep
 class BeerDetailProviderImpl : DynamicFeatureContentProvider<BeerDetail> {
+  // Detail is a leaf screen: it never navigates forward, so onNavigate is unused.
   @Composable
-  override fun Content(key: BeerDetail, onBack: () -> Unit) {
+  override fun Content(key: BeerDetail, onBack: () -> Unit, onNavigate: (NavKey) -> Unit) {
     BeerDetailScreenImpl(beer = key.beer, onBackClick = onBack)
   }
 }

--- a/navigation/src/main/java/com/simtop/navigation/DynamicFeatureContentProvider.kt
+++ b/navigation/src/main/java/com/simtop/navigation/DynamicFeatureContentProvider.kt
@@ -5,15 +5,18 @@ import androidx.compose.runtime.remember
 import androidx.navigation3.runtime.NavKey
 
 /**
- * + * Contract implemented by a screen that lives inside a dynamic feature module.
- * + *
- * + * The base module only knows this interface; the concrete implementation is loaded by
- * + * reflection once the module is installed. Being generic over the [NavKey] keeps the
- * + * contract reusable for every future dynamic feature instead of needing a bespoke
- * + * interface per feature. +
+ * Contract implemented by a screen that lives inside a dynamic feature module.
+ *
+ * The base module only knows this interface; the concrete implementation is loaded by reflection
+ * once the module is installed. Being generic over the [NavKey] keeps the contract reusable for
+ * every future dynamic feature instead of needing a bespoke interface per feature.
+ *
+ * [onNavigate] pushes a key onto the app back stack, so a non-leaf feature screen (browse) can
+ * navigate forward to another destination (a beer's detail). Leaf screens (detail) simply ignore
+ * it.
  */
 fun interface DynamicFeatureContentProvider<T : NavKey> {
-  @Composable fun Content(key: T, onBack: () -> Unit)
+  @Composable fun Content(key: T, onBack: () -> Unit, onNavigate: (NavKey) -> Unit)
 }
 
 /**
@@ -28,12 +31,17 @@ fun interface DynamicFeatureContentProvider<T : NavKey> {
  * stack, so the lookup here is guaranteed to succeed.
  */
 @Composable
-fun <T : NavKey> DynamicFeatureContent(key: T, className: String, onBack: () -> Unit) {
+fun <T : NavKey> DynamicFeatureContent(
+  key: T,
+  className: String,
+  onBack: () -> Unit,
+  onNavigate: (NavKey) -> Unit = {},
+) {
   val provider =
     remember(className) {
       @Suppress("UNCHECKED_CAST")
       (Class.forName(className).getDeclaredConstructor().newInstance()
         as DynamicFeatureContentProvider<T>)
     }
-  provider.Content(key = key, onBack = onBack)
+  provider.Content(key = key, onBack = onBack, onNavigate = onNavigate)
 }

--- a/navigation/src/main/java/com/simtop/navigation/FeatureConstants.kt
+++ b/navigation/src/main/java/com/simtop/navigation/FeatureConstants.kt
@@ -4,4 +4,8 @@ object FeatureConstants {
   const val BEER_DETAIL_MODULE = "beerdetail"
   const val BEER_DETAIL_PROVIDER_CLASS =
     "com.simtop.feature.beerdetail.presentation.BeerDetailProviderImpl"
+
+  const val BEER_BROWSE_MODULE = "beerbrowse"
+  const val BEER_BROWSE_PROVIDER_CLASS =
+    "com.simtop.feature.beerbrowse.presentation.BeerBrowseProviderImpl"
 }

--- a/navigation/src/main/java/com/simtop/navigation/Routes.kt
+++ b/navigation/src/main/java/com/simtop/navigation/Routes.kt
@@ -8,4 +8,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable object BeersSearch : NavKey
 
+@Serializable object BeerBrowse : NavKey
+
 @Serializable data class BeerDetail(val beer: Beer) : NavKey

--- a/presentation_utils/src/main/res/values-es/strings.xml
+++ b/presentation_utils/src/main/res/values-es/strings.xml
@@ -29,4 +29,12 @@
     <string name="error_access_denied">Acceso denegado</string>
     <string name="error_rate_limited">Demasiadas solicitudes. Espera un momento.</string>
     <string name="error_failed_to_load_beers">No se pudieron cargar las cervezas</string>
+    <string name="browse_title">Explorar</string>
+    <string name="browse_back">Atrás</string>
+    <string name="browse_tab_styles">Estilos</string>
+    <string name="browse_tab_breweries">Cervecerías</string>
+    <string name="browse_brewery_founded">%1$s · Fundada en %2$d</string>
+    <string name="browse_beers_count">%1$d cervezas</string>
+    <string name="browse_beers_end_of_list">Eso es todo: %1$d cervezas</string>
+    <string name="browse_no_beers">Aún no hay cervezas aquí</string>
 </resources>

--- a/presentation_utils/src/main/res/values-fr/strings.xml
+++ b/presentation_utils/src/main/res/values-fr/strings.xml
@@ -29,4 +29,12 @@
     <string name="error_access_denied">Accès refusé</string>
     <string name="error_rate_limited">Trop de requêtes. Veuillez patienter un instant.</string>
     <string name="error_failed_to_load_beers">Impossible de charger les bières</string>
+    <string name="browse_title">Explorer</string>
+    <string name="browse_back">Retour</string>
+    <string name="browse_tab_styles">Styles</string>
+    <string name="browse_tab_breweries">Brasseries</string>
+    <string name="browse_brewery_founded">%1$s · Fondée en %2$d</string>
+    <string name="browse_beers_count">%1$d bières</string>
+    <string name="browse_beers_end_of_list">C\'est tout : %1$d bières</string>
+    <string name="browse_no_beers">Pas encore de bières ici</string>
 </resources>

--- a/presentation_utils/src/main/res/values/strings.xml
+++ b/presentation_utils/src/main/res/values/strings.xml
@@ -29,4 +29,12 @@
     <string name="error_access_denied">Access denied</string>
     <string name="error_rate_limited">Too many requests. Please wait a moment.</string>
     <string name="error_failed_to_load_beers">Failed to load beers</string>
+    <string name="browse_title">Browse</string>
+    <string name="browse_back">Back</string>
+    <string name="browse_tab_styles">Styles</string>
+    <string name="browse_tab_breweries">Breweries</string>
+    <string name="browse_brewery_founded">%1$s · Founded %2$d</string>
+    <string name="browse_beers_count">%1$d beers</string>
+    <string name="browse_beers_end_of_list">That\'s all %1$d beers</string>
+    <string name="browse_no_beers">No beers here yet</string>
 </resources>


### PR DESCRIPTION
Second Phase 3 (Browse) PR: the `feature/beerbrowse` **dynamic feature module** — the second on-demand module after `beerdetail`, and the reuse proof for the paging machinery: the beers-by-style / beers-by-brewery screens are a `BeersQuery` + the shared `PagedListReducer`/`pagedListFooter`/`InfiniteListHandler` pieces, with **zero `core-common` changes**.

**The module.** A Browse landing screen with Styles (17) and Breweries (38) tabs — both deliberately *unpaged* single fetches (`BrowseViewModel`; breweries wait until their tab is first selected so an unused tab never spends a request, including after process death). Tapping a row drills into `BrowseBeersScreen`: one assisted `BrowseBeersViewModel` per selection mints a fresh in-memory pager (the query-surface invalidation rule), with count header, footer retry/end states and the load-more toast. Drill-in state is module-internal `rememberSaveable`; only `BeerDetail` crosses onto the app back stack, gated behind the same `DynamicFeatureLoader` install flow the catalog uses. All user-facing strings live in `presentation_utils` (en/es/fr) per the feature-module-resource constraint.

**Contract change.** `DynamicFeatureContentProvider.Content` gains `onNavigate: (NavKey) -> Unit` so a non-leaf dynamic screen can navigate forward; `beerdetail`'s provider ignores it (leaf). `DynamicFeatureContent` defaults it to no-op, so existing call sites are untouched.

**Build fix this surfaced.** With a *second* dynamic feature, AGP rejected both modules packaging `navigation-dynamic-features-runtime` — a leftover fragment-navigation dep the convention plugin gave every dynamic module and nothing imports (the app is Compose + Navigation 3). Dropped it from `billionbeers.android.dynamic.feature`.

**Not yet reachable in-app**: the app back-stack entry, catalog browse icon and its own install gate land in 3c together with the instrumented install-flow proof and an emulator walkthrough; this PR registers the module in `dynamicFeatures` so it builds and packages.

Tests: ViewModel suites (lazy/once breweries fetch, per-selection pager creation, retry paths, footer + one-shot event on failed load-more, zero-results vs Empty), the provider-class/constant guard test, and Paparazzi goldens for both screens (tabs, results, error, empty). `make test`, `screenshot-verify`, `lint`, `konsist` all green.