### PR TITLE
feat: browse entry point, nav wiring and install-flow proof (Paging 2.0 3c)

### DIFF
--- a/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/MainActivity.kt
+++ b/app-dev-beerslist/src/main/java/com/simtop/billionbeers/devbeerslist/MainActivity.kt
@@ -28,7 +28,9 @@ class MainActivity : ComponentActivity() {
         LocalMetroViewModelFactory provides appGraph.metroViewModelFactory,
         LocalSplitInstallManager provides appGraph.splitInstallManager,
       ) {
-        BillionBeersTheme { BeersListScreen(onBeerClick = {}, onSearchClick = {}) }
+        BillionBeersTheme {
+          BeersListScreen(onBeerClick = {}, onSearchClick = {}, onBrowseClick = {})
+        }
       }
     }
   }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
   implementation(project(":feature:beerslist"))
   implementation(project(":feature:beersearch"))
   androidTestImplementation(project(":feature:beerdetail"))
+  androidTestImplementation(project(":feature:beerbrowse"))
   implementation(project(":core"))
   implementation(project(":core:designsystem"))
   implementation(project(":navigation"))

--- a/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
@@ -3,11 +3,15 @@ package com.simtop.billionbeers
 import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.BeerStyle
+import com.simtop.beerdomain.domain.models.Brewery
 import com.simtop.billionbeers.di.BaseAppGraph
 import com.simtop.billionbeers.di.FakeBeersRepositoryModule
+import com.simtop.billionbeers.utils.browseScreen
 import com.simtop.billionbeers.utils.detailScreen
 import com.simtop.billionbeers.utils.homeScreen
 import com.simtop.billionbeers.utils.runMainActivityTest
+import com.simtop.core.core.Either
 import dev.zacsweers.metro.createGraphFactory
 import org.junit.Before
 import org.junit.Rule
@@ -32,12 +36,24 @@ class MainActivityComposeTest {
       availability = true,
     )
 
+  private val fakeStyle = BeerStyle(id = "style-1", name = "IPA (Indian Pale Ale)")
+  private val fakeBrewery =
+    Brewery(
+      id = "brewery-1",
+      name = "Supreme Suds Collective",
+      countryCode = "KP",
+      foundedYear = 1972,
+      imageUrl = "",
+    )
+
   @Before
   fun setup() {
     val context = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
     val app = context as BillionBeersApplication
 
     FakeBeersRepositoryModule.fakeBeersRepository.setBeers(listOf(fakeBeer))
+    FakeBeersRepositoryModule.fakeBeersRepository.beerStyles = Either.Right(listOf(fakeStyle))
+    FakeBeersRepositoryModule.fakeBeersRepository.breweries = Either.Right(listOf(fakeBrewery))
     val testGraph =
       createGraphFactory<TestAppGraph.Factory>().create(context = context) as BaseAppGraph
 
@@ -81,5 +97,31 @@ class MainActivityComposeTest {
         waitUntilNodeWithTextIsDisplayed(fakeBeer.name)
         assertBeerIsUnavailable(fakeBeer.name)
       }
+    }
+
+  // The §10.7 proof: the browse destination lives in the *second* on-demand module, reached
+  // through the same install gate as beerdetail (the fake installer reports it installed, so the
+  // gate passes straight through to navigation - the dialog flow itself can't run without Play).
+  @Test
+  fun browseOpensTheDynamicModuleAndListsStylesAndBreweries() =
+    runMainActivityTest(composeTestRule) {
+      homeScreen {
+        waitUntilNodeWithTextIsDisplayed(fakeBeer.name)
+        clickOnBrowse()
+      }
+
+      browseScreen {
+        waitUntilNodeWithTextIsDisplayed(fakeStyle.name)
+        assertBrowseTitleIsDisplayed()
+        assertStyleIsDisplayed(fakeStyle.name)
+
+        clickOnBreweriesTab()
+        waitUntilNodeWithTextIsDisplayed(fakeBrewery.name)
+        assertBreweryIsDisplayed(fakeBrewery.name)
+
+        pressBack()
+      }
+
+      homeScreen { waitUntilNodeWithTextIsDisplayed(fakeBeer.name) }
     }
 }

--- a/app/src/androidTest/java/com/simtop/billionbeers/fakes/FakeSplitInstallManager.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/fakes/FakeSplitInstallManager.kt
@@ -8,7 +8,8 @@ import com.google.android.play.core.splitinstall.SplitInstallStateUpdatedListene
 import com.simtop.navigation.FeatureConstants
 
 class FakeSplitInstallManager : SplitInstallManager {
-  private val installed = mutableSetOf(FeatureConstants.BEER_DETAIL_MODULE)
+  private val installed =
+    mutableSetOf(FeatureConstants.BEER_DETAIL_MODULE, FeatureConstants.BEER_BROWSE_MODULE)
 
   override fun startInstall(
     request: com.google.android.play.core.splitinstall.SplitInstallRequest

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/BaseTestRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/BaseTestRobot.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -20,6 +21,10 @@ open class BaseTestRobot(private val composeTestRule: ComposeTestRule) {
 
   fun clickOnNodeWithText(text: String) {
     composeTestRule.onNodeWithText(text).performClick()
+  }
+
+  fun clickOnNodeWithContentDescription(label: String) {
+    composeTestRule.onNodeWithContentDescription(label).performClick()
   }
 
   fun assertTextIsDisplayed(text: String) {

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/BrowseScreenRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/BrowseScreenRobot.kt
@@ -1,0 +1,27 @@
+package com.simtop.billionbeers.robots
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.simtop.presentation_utils.R
+
+class BrowseScreenRobot(composeTestRule: ComposeTestRule) : BaseTestRobot(composeTestRule) {
+
+  fun assertBrowseTitleIsDisplayed() {
+    assertTextIsDisplayed(string(R.string.browse_title))
+  }
+
+  fun assertStyleIsDisplayed(styleName: String) {
+    assertTextIsDisplayed(styleName)
+  }
+
+  fun clickOnBreweriesTab() {
+    clickOnNodeWithText(string(R.string.browse_tab_breweries))
+  }
+
+  fun assertBreweryIsDisplayed(breweryName: String) {
+    assertTextIsDisplayed(breweryName)
+  }
+
+  fun clickOnStyle(styleName: String) {
+    clickOnNodeWithText(styleName)
+  }
+}

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/HomeScreenRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/HomeScreenRobot.kt
@@ -1,12 +1,17 @@
 package com.simtop.billionbeers.robots
 
 import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.simtop.feature.beerslist.R as BeersListR
 import com.simtop.presentation_utils.R
 
 fun homeScreen(composeTestRule: ComposeTestRule, func: HomeScreenRobot.() -> Unit) =
   HomeScreenRobot(composeTestRule).apply { func() }
 
 class HomeScreenRobot(composeTestRule: ComposeTestRule) : BaseTestRobot(composeTestRule) {
+
+  fun clickOnBrowse() {
+    clickOnNodeWithContentDescription(string(BeersListR.string.beers_browse))
+  }
 
   fun assertBeerNameIsDisplayed(beerName: String) {
     assertTextIsDisplayed(beerName)

--- a/app/src/androidTest/java/com/simtop/billionbeers/utils/MainTestScope.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/utils/MainTestScope.kt
@@ -3,6 +3,7 @@ package com.simtop.billionbeers.utils
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.test.core.app.ActivityScenario
 import com.simtop.billionbeers.presentation.MainActivity
+import com.simtop.billionbeers.robots.BrowseScreenRobot
 import com.simtop.billionbeers.robots.DetailScreenRobot
 import com.simtop.billionbeers.robots.HomeScreenRobot
 
@@ -12,6 +13,10 @@ fun ComposeTestRule.homeScreen(func: HomeScreenRobot.() -> Unit) {
 
 fun ComposeTestRule.detailScreen(func: DetailScreenRobot.() -> Unit) {
   DetailScreenRobot(this).apply(func)
+}
+
+fun ComposeTestRule.browseScreen(func: BrowseScreenRobot.() -> Unit) {
+  BrowseScreenRobot(this).apply(func)
 }
 
 fun runMainActivityTest(composeTestRule: ComposeTestRule, block: ComposeTestRule.() -> Unit) {

--- a/app/src/main/java/com/simtop/billionbeers/presentation/AppNavigation.kt
+++ b/app/src/main/java/com/simtop/billionbeers/presentation/AppNavigation.kt
@@ -13,6 +13,7 @@ import androidx.navigation3.ui.NavDisplay
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.feature.beersearch.BeersSearchScreen
 import com.simtop.feature.beerslist.BeersListScreen
+import com.simtop.navigation.BeerBrowse
 import com.simtop.navigation.BeerDetail
 import com.simtop.navigation.BeersList
 import com.simtop.navigation.BeersSearch
@@ -54,6 +55,7 @@ fun AppNavigation(deepLinkUri: Uri? = null, viewModel: AppNavigationViewModel = 
           BeersListScreen(
             onBeerClick = { beer -> backStack.add(BeerDetail(beer)) },
             onSearchClick = { backStack.add(BeersSearch) },
+            onBrowseClick = { backStack.add(BeerBrowse) },
           )
         }
 
@@ -72,6 +74,18 @@ fun AppNavigation(deepLinkUri: Uri? = null, viewModel: AppNavigationViewModel = 
             key = key,
             className = FeatureConstants.BEER_DETAIL_PROVIDER_CLASS,
             onBack = { backStack.removeLastOrNull() },
+          )
+        }
+
+        entry<BeerBrowse> { key ->
+          // Same install guarantee as BeerDetail (gated on the list screen's browse icon).
+          // onNavigate lets browse push a beer's detail onto this back stack from inside the
+          // module.
+          DynamicFeatureContent(
+            key = key,
+            className = FeatureConstants.BEER_BROWSE_PROVIDER_CLASS,
+            onBack = { backStack.removeLastOrNull() },
+            onNavigate = { destination -> backStack.add(destination) },
           )
         }
       },

--- a/docs/adr/0002-hand-rolled-paging.md
+++ b/docs/adr/0002-hand-rolled-paging.md
@@ -95,5 +95,14 @@ entirely.
   costs one request instead of 26. This is data-layer groundwork, independent of the paging state
   machine, but it directly protects the rate-limit budget (60/min) that Paging 2.0's
   search-as-you-type spends deliberately.
+- (Update, July 2026 — Paging 2.0 Phase 3) The "any future paged screen needs to reuse
+  `PagingMediator` or write its own" consequence has now been exercised twice and held: search
+  (an in-memory `q=` surface) and browse-by-style/brewery (in-memory `typology.id=`/`brewery.id=`
+  surfaces inside the on-demand `beerbrowse` module) each shipped as a `BeersQuery` value plus the
+  shared `PagedListReducer`/footer UI, with **zero changes to `core-common`** — the plug-and-play
+  goal Paging 2.0 set as its acceptance test. The deliberate counter-example landed alongside:
+  styles (17 rows) and breweries (38 rows) are plain unpaged fetches, because a pager for a list
+  that small is machinery without a customer. Pagers are per-query values (a changed query is a
+  new pager, never a mutation), which is what keeps invalidation out of the mediator.
 - Revisit if Paging3 ships a multiplatform target and a `PagingData`-free consumption API; until
   then this is the right trade for a KMP-bound clean-architecture codebase.

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -94,6 +95,7 @@ private val BeerSaver: Saver<Beer?, String> =
 fun BeersListScreen(
   onBeerClick: (Beer) -> Unit,
   onSearchClick: () -> Unit,
+  onBrowseClick: () -> Unit,
   viewModel: BeersListViewModel = metroViewModel(),
 ) {
   val rawState by viewModel.beerListViewState.collectAsState()
@@ -118,11 +120,15 @@ fun BeersListScreen(
   // State to track if we are installing the feature for a specific beer - saved across process
   // death so the install flow resumes instead of silently dropping the in-flight navigation.
   var installingBeer by rememberSaveable(stateSaver = BeerSaver) { mutableStateOf<Beer?>(null) }
+  // The same gate for the beerbrowse module: the browse destination is only pushed once the
+  // module is installed.
+  var installingBrowse by rememberSaveable { mutableStateOf(false) }
 
   BeersListContent(
     viewState = rawState,
     onBeerClick = { beer -> installingBeer = beer },
     onSearchClick = onSearchClick,
+    onBrowseClick = { installingBrowse = true },
     onScrollToBottom = { viewModel.onScrollToBottom() },
     onRefresh = { viewModel.refresh() },
     onRetry = { viewModel.refresh() },
@@ -141,6 +147,18 @@ fun BeersListScreen(
       }
     }
   }
+
+  if (installingBrowse) {
+    DynamicFeatureLoader(
+      featureName = FeatureConstants.BEER_BROWSE_MODULE,
+      onCancelled = { installingBrowse = false },
+    ) {
+      LaunchedEffect(Unit) {
+        onBrowseClick()
+        installingBrowse = false
+      }
+    }
+  }
 }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -149,6 +167,7 @@ fun BeersListContent(
   viewState: CommonUiState<PagedListUiModel<Beer>>,
   onBeerClick: (Beer) -> Unit,
   onSearchClick: () -> Unit,
+  onBrowseClick: () -> Unit,
   onScrollToBottom: () -> Unit,
   onRefresh: () -> Unit,
   onRetry: () -> Unit,
@@ -181,6 +200,12 @@ fun BeersListContent(
           }
         },
         actions = {
+          IconButton(onClick = onBrowseClick) {
+            Icon(
+              Icons.AutoMirrored.Filled.List,
+              contentDescription = stringResource(R.string.beers_browse),
+            )
+          }
           IconButton(onClick = onSearchClick) {
             Icon(Icons.Filled.Search, contentDescription = stringResource(R.string.beers_search))
           }
@@ -382,6 +407,7 @@ fun BeersListScreenPreview(
       viewState = state.uiState,
       onBeerClick = {},
       onSearchClick = {},
+      onBrowseClick = {},
       onScrollToBottom = {},
       onRefresh = {},
       onRetry = {},

--- a/feature/beerslist/src/main/res/values-es/strings.xml
+++ b/feature/beerslist/src/main/res/values-es/strings.xml
@@ -5,4 +5,5 @@
     <string name="beers_refresh_failed">No se pudo actualizar</string>
     <string name="beers_end_of_list">Eso es todo: %1$d cervezas</string>
     <string name="beers_search">Buscar</string>
+    <string name="beers_browse">Explorar</string>
 </resources>

--- a/feature/beerslist/src/main/res/values-fr/strings.xml
+++ b/feature/beerslist/src/main/res/values-fr/strings.xml
@@ -5,4 +5,5 @@
     <string name="beers_refresh_failed">Impossible d\'actualiser</string>
     <string name="beers_end_of_list">C\'est tout : %1$d bières</string>
     <string name="beers_search">Rechercher</string>
+    <string name="beers_browse">Explorer</string>
 </resources>

--- a/feature/beerslist/src/main/res/values/strings.xml
+++ b/feature/beerslist/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="beers_refresh_failed">Couldn\'t refresh</string>
     <string name="beers_end_of_list">That\'s all %1$d beers</string>
     <string name="beers_search">Search</string>
+    <string name="beers_browse">Browse</string>
 </resources>

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_EMPTY]_beerslistscreenpreview_empty.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_EMPTY]_beerslistscreenpreview_empty.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:84d01be3f80ac4826b6b48e0b22e7b7d4fd000b22729b2efeffcbb64d7afcc15
-size 12956
+oid sha256:3a137322fa7e72bea2caec2d3819a55cf09fd821534ac58fd2888ff34fa19a12
+size 13231

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_ERROR]_beerslistscreenpreview_error.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_ERROR]_beerslistscreenpreview_error.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4b1a020de53618f3eb309100aa5ef4df6bcfee63bd3a0989744b59da2a150a4f
-size 18317
+oid sha256:89d4a46763b6dea97af7d22ba87194c051c7371469c661ac98d5c69998bcd69f
+size 18577

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_LOADING]_beerslistscreenpreview_loading.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_LOADING]_beerslistscreenpreview_loading.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:efb933bff9178ede5079a8d84a28bb28ff99963149d959a95c03cb9615191bad
-size 29313
+oid sha256:81fef8bd43c438839f605b5f3eee8d2167ebe11b9d9694329ebc1b130b4741f6
+size 29570

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_END_OF_LIST]_beerslistscreenpreview_success_end_of_list.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_END_OF_LIST]_beerslistscreenpreview_success_end_of_list.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:38c9ef8fbb1f36bf2fa4ccd07aaf9855386857bddd5ef2eeb0bbd4441ccc3db1
-size 21921
+oid sha256:8b70f2d2a008f562c12d4a4cf6d7ae08fd95f21fed69e0e8686b14284cd1e732
+size 22145

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_LOADING_MORE]_beerslistscreenpreview_success_loading_more.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_LOADING_MORE]_beerslistscreenpreview_success_loading_more.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:48e1daf03f452b3e1f03e684ef111d7bd29b318011805f6b93214c7cb05ff8b9
-size 20107
+oid sha256:eb077d3bf73da03e60e72174d855ba9924fbbb9dd80ea89cabe824c1f68cff5f
+size 20377

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_LOAD_MORE_FAILED]_beerslistscreenpreview_success_load_more_failed.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_LOAD_MORE_FAILED]_beerslistscreenpreview_success_load_more_failed.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:251e2e1fc486886f3780a9706b7e296289096559d961f439ef81dd088ddc9712
-size 23672
+oid sha256:692c5f029205526e361f5ff0dfda9eba17d2ff35ac7e3bd1b5c21f54f09fc0b3
+size 23882

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_MULTIPLE_ITEMS]_beerslistscreenpreview_success_multiple_items.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_SUCCESS_MULTIPLE_ITEMS]_beerslistscreenpreview_success_multiple_items.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d49d5a2d8e4b290942e2c53cf793fd29800b5f6e4c7e938513f970fa4f167ecb
-size 32756
+oid sha256:ddafd7c51ebce2dada46ef907bdf89553439248d1b9659da2c0ff423fce9ad04
+size 32999


### PR DESCRIPTION
Final Phase 3 (Browse) PR: makes the `beerbrowse` module reachable and proves the on-demand install flow generalizes beyond `beerdetail` (plan §10.7).

- **Catalog entry point:** a browse icon in the beers-list top bar, gated behind `DynamicFeatureLoader(BEER_BROWSE_MODULE)` exactly like the beer-tap gate — the `BeerBrowse` key is only pushed once the module is installed. Gate state survives process death.
- **Nav wiring:** `entry<BeerBrowse>` renders the module via `DynamicFeatureContent` with `onNavigate = backStack::add`, which is how browse pushes a beer's detail onto the app back stack from inside the module.
- **Instrumented proof:** `browseOpensTheDynamicModuleAndListsStylesAndBreweries` drives catalog → install gate → browse → styles → breweries tab → back, on the second on-demand module (new `BrowseScreenRobot`; the fake installer reports the module installed — the dialog flow itself can't run without Play). All 14 connected tests pass on the emulator.
- **ADR 0002** consequences updated: the "any future paged screen reuses the mediator or writes its own" clause has now been exercised twice (search, browse) with zero `core-common` changes, plus the deliberate unpaged counter-example.
- beerslist goldens re-recorded (the new top-bar icon appears in every state).

**Emulator walkthrough** (real API, bundletool local-testing install): browse installs on demand → 17 styles → IPA → paged results ending in "That's all 14 beers" → breweries tab (38, country + founded captions) → brewery → 2 beers → tapping a beer opens the beerdetail module from inside browse. Also exercised the install-*failure* dialog (error −5 with retry/cancel) — surfaced by a tooling gotcha worth knowing: `adb pm clear` wipes bundletool's locally staged split APKs, so on-demand installs fail until `install-local-testing.sh` is re-run.

One follow-up observation, deliberately not fixed here (it would touch `core-common`): on single-page surfaces the "N beers" count *header* never renders, because `totalCount` is only latched from `PagingState.Success` and a first-page-is-last goes straight to `EndOfPagination` (PR #77 behavior). Search shares this quirk (any query with ≤25 hits). The end-of-list footer covers the information, so it may even be preferable — flagging rather than fixing.

`make test`, `screenshot-verify`, `lint`, `konsist`, and `:app:connectedDebugAndroidTest` all green.