### PR TITLE
feat: cache TTL policy and language-switch invalidation (Paging 2.0 4a)

### DIFF
--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersPagerFactoryImpl.kt
@@ -4,6 +4,7 @@ import com.simtop.beer_network.network.BeersService
 import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.models.BeersQuery
+import com.simtop.beerdomain.domain.models.CatalogCacheStatus
 import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.beerdomain.domain.repositories.BeersRepository
 import com.simtop.core.core.InMemoryPagingStorage
@@ -22,23 +23,27 @@ class BeersPagerFactoryImpl(
 ) : BeersPagerFactory {
 
   override fun create(): Pager<Beer, FetchBeersError> {
-    // One paged surface, keyed by language so a future language switch can invalidate it (Phase 4);
-    // for now the key just scopes the bookmark. Read (resume) and write (store) share this value.
-    val surface = CATALOG_SURFACE_PREFIX + languageProvider.currentLanguageCode()
+    // One paged surface, keyed by language (shared with the repository's cache-status check via
+    // catalogSurface). Read (resume) and write (store) share this value.
+    val surface = catalogSurface(languageProvider)
     return PagingMediator(
       initialKey = FIRST_PAGE,
       fetchRemote = fetchPage(BeersQuery()),
       classifyError = { it.toFetchBeersError() },
       storage = BeersPagingStorage(repository, surface),
       // Exact resume: the paging_state bookmark records the first uncached page, written in the
-      // same
-      // transaction as the rows. It falls back to the row-count estimate (N fully cached pages ->
-      // page N+1) only when no bookmark exists yet - a fresh install, or a cache written before
-      // paging_state existed (the v1->v2 migration gap). Either way "load more" resumes after
-      // everything cached instead of silently re-fetching cached pages over the network.
+      // same transaction as the rows. On a bookmark miss the fallback depends on *why* it missed:
+      // - LanguageMismatch (rows fetched under another language): restart from page 1, so
+      //   "load more" re-walks and re-translates the stale pages through the upsert instead of
+      //   skipping them - the count estimate would jump past rows that still need re-fetching.
+      // - Otherwise (fresh install, or a legacy cache from before paging_state existed): the
+      //   row-count estimate (N fully cached pages -> page N+1) keeps its original job.
       nextKeyFromStorage = {
         repository.pagingNextKey(surface)
-          ?: (repository.countDBEntries() / BeersService.DEFAULT_ITEMS_PER_PAGE + FIRST_PAGE)
+          ?: when (repository.catalogCacheStatus()) {
+            CatalogCacheStatus.LanguageMismatch -> FIRST_PAGE
+            else -> repository.countDBEntries() / BeersService.DEFAULT_ITEMS_PER_PAGE + FIRST_PAGE
+          }
       },
     )
   }
@@ -69,7 +74,6 @@ class BeersPagerFactoryImpl(
 
   private companion object {
     const val FIRST_PAGE = 1
-    const val CATALOG_SURFACE_PREFIX = "catalog:"
   }
 }
 

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/BeersRepositoryImpl.kt
@@ -10,8 +10,11 @@ import com.simtop.beerdomain.domain.models.BeerPage
 import com.simtop.beerdomain.domain.models.BeerStyle
 import com.simtop.beerdomain.domain.models.BeersQuery
 import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.beerdomain.domain.models.CatalogCacheStatus
 import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.core.core.CachePolicy
 import com.simtop.core.core.Either
+import com.simtop.core.core.LanguageProvider
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
@@ -26,6 +29,7 @@ class BeersRepositoryImpl(
   private val beersRemoteSource: BeersRemoteSource,
   private val beersLocalSource: BeersLocalSource,
   private val beersMapper: BeersMapper,
+  private val languageProvider: LanguageProvider,
 ) : BeersRepository {
 
   override suspend fun getBeersPageFromApi(page: Int, query: BeersQuery): BeerPage {
@@ -89,6 +93,21 @@ class BeersRepositoryImpl(
 
   override suspend fun pagingNextKey(surface: String): Int? =
     beersLocalSource.getPagingState(surface)?.nextKey
+
+  override suspend fun catalogCacheStatus(policy: CachePolicy): CatalogCacheStatus {
+    if (beersLocalSource.getCountFromDB() == 0) return CatalogCacheStatus.Empty
+    val state = beersLocalSource.getPagingState(catalogSurface(languageProvider))
+    return when {
+      // No bookmark for this language: either a legacy cache from before paging_state existed
+      // (age unknowable -> treat as stale) or bookmarks that all belong to another language.
+      state == null ->
+        if (beersLocalSource.countPagingStates() == 0) CatalogCacheStatus.Stale
+        else CatalogCacheStatus.LanguageMismatch
+      System.currentTimeMillis() - state.refreshedAt > policy.staleAfter.inWholeMilliseconds ->
+        CatalogCacheStatus.Stale
+      else -> CatalogCacheStatus.Fresh
+    }
+  }
 
   override fun observeBeers(): Flow<List<Beer>> =
     beersLocalSource.getAllBeersFromDB().map { list ->

--- a/beer_data/src/main/java/com/simtop/beer_data/repositories/CatalogSurface.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/repositories/CatalogSurface.kt
@@ -1,0 +1,14 @@
+package com.simtop.beer_data.repositories
+
+import com.simtop.core.core.LanguageProvider
+
+/**
+ * The one place the catalog's paged-surface key is built - the factory (bookmark read/write) and
+ * the repository (cache-status classification) must agree on it byte for byte. The key is
+ * language-scoped so a device language switch reads as a bookmark miss (`LanguageMismatch`) instead
+ * of silently serving rows fetched under another language.
+ */
+internal fun catalogSurface(languageProvider: LanguageProvider): String =
+  CATALOG_SURFACE_PREFIX + languageProvider.currentLanguageCode()
+
+private const val CATALOG_SURFACE_PREFIX = "catalog:"

--- a/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersLocalSource.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/fakes/FakeBeersLocalSource.kt
@@ -52,6 +52,19 @@ class FakeBeersLocalSource : BeersLocalSource {
 
   override suspend fun getPagingState(surface: String): PagingStateDbModel? = pagingState[surface]
 
+  override suspend fun countPagingStates(): Int = pagingState.size
+
+  /** Test helper: seed a bookmark as a warm cache would leave it, with a steerable timestamp. */
+  fun setPagingState(surface: String, nextKey: Int?, refreshedAt: Long) {
+    pagingState[surface] =
+      PagingStateDbModel(
+        surface = surface,
+        nextKey = nextKey,
+        totalCount = null,
+        refreshedAt = refreshedAt,
+      )
+  }
+
   override suspend fun updateBeer(primaryKey: String, availability: Boolean) {
     val current = beersFlow.value.toMutableList()
     val index = current.indexOfFirst { it.id == primaryKey }

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -39,7 +39,13 @@ class BeersPagerFactoryImplTest {
     beersRemoteSource = FakeBeersRemoteSource()
     beersLocalSource = FakeBeersLocalSource()
     val beersMapper = BeersMapper(LanguageProvider { "en" }, NoOpLogger())
-    repository = BeersRepositoryImpl(beersRemoteSource, beersLocalSource, beersMapper)
+    repository =
+      BeersRepositoryImpl(
+        beersRemoteSource,
+        beersLocalSource,
+        beersMapper,
+        LanguageProvider { "en" },
+      )
     factory = BeersPagerFactoryImpl(repository, LanguageProvider { "en" })
   }
 
@@ -92,6 +98,27 @@ class BeersPagerFactoryImplTest {
 
       expectThat(beersRemoteSource.requestedPages.toList()).isEqualTo(listOf(2))
       expectThat(repository.countDBEntries()).isEqualTo(26)
+    }
+
+  // Language switch (Paging 2.0 Phase 4): the cached rows and bookmark belong to another
+  // language's surface, so "load more" must restart from page 1 and re-walk (re-translating via
+  // the upsert) - the row-count estimate would skip pages 1-2 and leave them in the old language.
+  @Test
+  fun `load more over a language-mismatched cache restarts from page 1`() =
+    runTest(testDispatcher) {
+      // Two full pages cached under Spanish; the estimate would resume at page 3.
+      repository.insertPage(
+        (1..50).map { Beer.empty.copy(id = "$it") },
+        surface = "catalog:es",
+        nextKey = 3,
+        totalCount = 206,
+      )
+      beersRemoteSource.setBeersResponse(listOf(apiItem(id = "1")), totalCount = 206)
+      val pager = factory.create() // built for "catalog:en"
+
+      pager.loadNextPage()
+
+      expectThat(beersRemoteSource.requestedPages.toList()).isEqualTo(listOf(1))
     }
 
   // Regression test: refresh upserts into the cache without deleting, so afterwards the cache -

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersRepositoryTest.kt
@@ -15,6 +15,7 @@ import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.models.BeerStyle
 import com.simtop.beerdomain.domain.models.BeersQuery
 import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.beerdomain.domain.models.CatalogCacheStatus
 import com.simtop.core.core.Either
 import com.simtop.core.core.LanguageProvider
 import com.simtop.core.core.NoOpLogger
@@ -40,7 +41,13 @@ class BeersRepositoryTest {
     beersRemoteSource = FakeBeersRemoteSource()
     beersLocalSource = FakeBeersLocalSource()
     val beersMapper = BeersMapper(LanguageProvider { "en" }, NoOpLogger())
-    beersRepository = BeersRepositoryImpl(beersRemoteSource, beersLocalSource, beersMapper)
+    beersRepository =
+      BeersRepositoryImpl(
+        beersRemoteSource,
+        beersLocalSource,
+        beersMapper,
+        LanguageProvider { "en" },
+      )
   }
 
   @Test
@@ -146,6 +153,62 @@ class BeersRepositoryTest {
     }
 
   @Test
+  fun `cache status is Empty with no rows`() =
+    runTest(testDispatcher) {
+      expectThat(beersRepository.catalogCacheStatus()).isEqualTo(CatalogCacheStatus.Empty)
+    }
+
+  @Test
+  fun `cache status is Fresh with a recent bookmark for the current language`() =
+    runTest(testDispatcher) {
+      beersLocalSource.insertAllToDB(listOf(dbBeer("1")))
+      beersLocalSource.setPagingState(
+        "catalog:en",
+        nextKey = 2,
+        refreshedAt = System.currentTimeMillis() - ONE_HOUR_MILLIS,
+      )
+
+      expectThat(beersRepository.catalogCacheStatus()).isEqualTo(CatalogCacheStatus.Fresh)
+    }
+
+  @Test
+  fun `cache status is Stale once the bookmark is older than the policy TTL`() =
+    runTest(testDispatcher) {
+      beersLocalSource.insertAllToDB(listOf(dbBeer("1")))
+      beersLocalSource.setPagingState(
+        "catalog:en",
+        nextKey = 2,
+        refreshedAt = System.currentTimeMillis() - TWENTY_FIVE_HOURS_MILLIS,
+      )
+
+      expectThat(beersRepository.catalogCacheStatus()).isEqualTo(CatalogCacheStatus.Stale)
+    }
+
+  // A cache written before the paging_state table existed: rows but zero bookmarks anywhere.
+  // Its age is unknowable, so it counts as stale rather than trusted.
+  @Test
+  fun `cache status is Stale for a legacy cache with no bookmarks at all`() =
+    runTest(testDispatcher) {
+      beersLocalSource.insertAllToDB(listOf(dbBeer("1")))
+
+      expectThat(beersRepository.catalogCacheStatus()).isEqualTo(CatalogCacheStatus.Stale)
+    }
+
+  @Test
+  fun `cache status is LanguageMismatch when bookmarks belong to another language`() =
+    runTest(testDispatcher) {
+      beersLocalSource.insertAllToDB(listOf(dbBeer("1")))
+      beersLocalSource.setPagingState(
+        "catalog:es",
+        nextKey = 2,
+        refreshedAt = System.currentTimeMillis(),
+      )
+
+      expectThat(beersRepository.catalogCacheStatus())
+        .isEqualTo(CatalogCacheStatus.LanguageMismatch)
+    }
+
+  @Test
   fun `updateAvailability should call local source`() =
     runTest(testDispatcher) {
       // Arrange
@@ -229,4 +292,22 @@ class BeersRepositoryTest {
         expectThat(beers[0].id).isEqualTo("6")
       }
     }
+
+  private fun dbBeer(id: String) =
+    BeerDbModel(
+      id = id,
+      name = "Beer $id",
+      tagline = "",
+      description = "",
+      imageUrl = "",
+      abv = 0.0,
+      ibu = 0.0,
+      foodPairing = "[]",
+      availability = true,
+    )
+
+  private companion object {
+    const val ONE_HOUR_MILLIS = 60 * 60 * 1000L
+    const val TWENTY_FIVE_HOURS_MILLIS = 25 * ONE_HOUR_MILLIS
+  }
 }

--- a/beer_database/src/androidTest/java/com/simtop/beer_database/database/BeersDaoPagingStateTest.kt
+++ b/beer_database/src/androidTest/java/com/simtop/beer_database/database/BeersDaoPagingStateTest.kt
@@ -68,4 +68,16 @@ class BeersDaoPagingStateTest {
     assertEquals(2, dao.getPagingState("catalog:en")?.nextKey)
     assertEquals(9, dao.getPagingState("catalog:fr")?.nextKey)
   }
+
+  // Zero distinguishes a legacy pre-paging_state cache from one whose bookmarks belong to
+  // other surfaces (the language-switch case) - the cache-status classification relies on it.
+  @Test
+  fun countPagingStates_countsBookmarksAcrossSurfaces() = runBlocking {
+    assertEquals(0, dao.countPagingStates())
+
+    dao.insertPage(listOf(beer("1")), surface = "catalog:en", nextKey = 2, totalCount = 206, 0L)
+    dao.insertPage(listOf(beer("2")), surface = "catalog:fr", nextKey = 9, totalCount = 300, 0L)
+
+    assertEquals(2, dao.countPagingStates())
+  }
 }

--- a/beer_database/src/main/java/com/simtop/beer_database/database/BeersDao.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/database/BeersDao.kt
@@ -86,6 +86,10 @@ abstract class BeersDao {
   @Query("SELECT * FROM paging_state WHERE surface = :surface")
   abstract suspend fun getPagingState(surface: String): PagingStateDbModel?
 
+  // Distinguishes a legacy pre-paging_state cache (rows, zero bookmarks) from a cache whose
+  // bookmarks all belong to other surfaces (a language switch).
+  @Query("SELECT COUNT(surface) FROM paging_state") abstract suspend fun countPagingStates(): Int
+
   @Upsert abstract suspend fun upsertPagingState(state: PagingStateDbModel)
 
   /**

--- a/beer_database/src/main/java/com/simtop/beer_database/localsources/BeersLocalSource.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/localsources/BeersLocalSource.kt
@@ -31,6 +31,11 @@ interface BeersLocalSource {
 
   suspend fun getPagingState(surface: String): PagingStateDbModel?
 
+  /**
+   * Total bookmarks across all surfaces - zero means a legacy cache written before paging_state.
+   */
+  suspend fun countPagingStates(): Int
+
   suspend fun updateBeer(primaryKey: String, availability: Boolean)
 
   suspend fun deleteAllFromDB()
@@ -53,6 +58,8 @@ class BeersLocalSourceImpl(private val db: BeersDatabase) : BeersLocalSource {
   ) = db.beersDao().insertPage(beers, surface, nextKey, totalCount, System.currentTimeMillis())
 
   override suspend fun getPagingState(surface: String) = db.beersDao().getPagingState(surface)
+
+  override suspend fun countPagingStates() = db.beersDao().countPagingStates()
 
   override suspend fun updateBeer(primaryKey: String, availability: Boolean) =
     db.beersDao().updateBeer(primaryKey, availability)

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/CatalogCacheStatus.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/CatalogCacheStatus.kt
@@ -1,0 +1,27 @@
+package com.simtop.beerdomain.domain.models
+
+/**
+ * How the catalog's cached rows relate to the current language and TTL policy - what the list
+ * screen consults on start to decide between doing nothing, a cold load, and a background refresh.
+ */
+sealed interface CatalogCacheStatus {
+  /** No cached rows at all: cold start, full-screen loading. */
+  data object Empty : CatalogCacheStatus
+
+  /** Rows + a bookmark for the current language surface, within the TTL: show as-is. */
+  data object Fresh : CatalogCacheStatus
+
+  /**
+   * Rows exist but are past the TTL - or predate the `paging_state` table entirely (legacy cache
+   * with no bookmarks), which makes their age unknowable. Either way: background refresh.
+   */
+  data object Stale : CatalogCacheStatus
+
+  /**
+   * Rows exist but every bookmark belongs to another language's surface: the device language
+   * changed since they were fetched. Background refresh re-translates them page by page through the
+   * availability-preserving upsert; the resume key restarts from page 1 so load-more re-walks the
+   * stale pages instead of skipping them.
+   */
+  data object LanguageMismatch : CatalogCacheStatus
+}

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/repositories/BeersRepository.kt
@@ -7,6 +7,8 @@ import com.simtop.beerdomain.domain.models.BeerPage
 import com.simtop.beerdomain.domain.models.BeerStyle
 import com.simtop.beerdomain.domain.models.BeersQuery
 import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.beerdomain.domain.models.CatalogCacheStatus
+import com.simtop.core.core.CachePolicy
 import com.simtop.core.core.Either
 import kotlinx.coroutines.flow.Flow
 
@@ -46,6 +48,13 @@ interface BeersRepository {
    * fall back to a row-count estimate in that case.
    */
   suspend fun pagingNextKey(surface: String): Int?
+
+  /**
+   * Classifies the catalog cache against the current language and [policy]'s TTL (using the
+   * `refreshed_at` recorded with each page write). See [CatalogCacheStatus] for the states and what
+   * each asks of the caller.
+   */
+  suspend fun catalogCacheStatus(policy: CachePolicy = CachePolicy()): CatalogCacheStatus
 
   suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit>
 

--- a/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
+++ b/beerdomain/fakes/src/main/java/com/simtop/beerdomain/fakes/FakeBeersRepository.kt
@@ -7,7 +7,9 @@ import com.simtop.beerdomain.domain.models.BeerPage
 import com.simtop.beerdomain.domain.models.BeerStyle
 import com.simtop.beerdomain.domain.models.BeersQuery
 import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.beerdomain.domain.models.CatalogCacheStatus
 import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.core.core.CachePolicy
 import com.simtop.core.core.Either
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -78,6 +80,17 @@ class FakeBeersRepository(initialBeers: List<Beer> = emptyList()) : BeersReposit
   }
 
   override suspend fun pagingNextKey(surface: String): Int? = pagingNextKeys[surface]
+
+  /**
+   * What [catalogCacheStatus] reports. Left null it derives from the data - empty cache -> Empty,
+   * seeded beers -> Fresh - so cold- and warm-start fixtures stay one-liners; tests exercising the
+   * TTL/language paths set Stale or LanguageMismatch explicitly.
+   */
+  var catalogCacheStatus: CatalogCacheStatus? = null
+
+  override suspend fun catalogCacheStatus(policy: CachePolicy): CatalogCacheStatus =
+    catalogCacheStatus
+      ?: if (beersFlow.value.isEmpty()) CatalogCacheStatus.Empty else CatalogCacheStatus.Fresh
 
   override suspend fun updateAvailability(beer: Beer): Either<UpdateAvailabilityError, Unit> {
     exceptionToThrow?.let {

--- a/core-common/src/main/kotlin/com/simtop/core/core/CachePolicy.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/CachePolicy.kt
@@ -1,0 +1,11 @@
+package com.simtop.core.core
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+
+/**
+ * How long a cached paged surface counts as fresh. Until Paging 2.0 Phase 4 this was an emergent
+ * behavior (cache-first forever); naming it makes "show cached data immediately, refresh in the
+ * background once it's older than [staleAfter]" an explicit, testable policy.
+ */
+data class CachePolicy(val staleAfter: Duration = 24.hours)

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt
@@ -4,8 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.CatalogCacheStatus
 import com.simtop.beerdomain.domain.repositories.BeersPagerFactory
 import com.simtop.beerdomain.domain.repositories.BeersRepository
+import com.simtop.core.core.CachePolicy
 import com.simtop.core.core.CommonUiState
 import com.simtop.core.core.CoroutineDispatcherProvider
 import com.simtop.core.core.PagedListReducer
@@ -57,7 +59,7 @@ class BeersListViewModel(
   init {
     observeEvents()
     observeRefreshFailures()
-    loadFirstPageIfCacheIsEmpty()
+    loadFirstPageUnlessCacheIsFresh()
   }
 
   private fun observeEvents() {
@@ -86,9 +88,16 @@ class BeersListViewModel(
       .launchIn(viewModelScope)
   }
 
-  private fun loadFirstPageIfCacheIsEmpty() {
+  /**
+   * The cache policy at work: cached rows always show immediately, and anything non-fresh also
+   * triggers a first-page load. Empty is the cold start (full-screen Loading, as before); Stale and
+   * LanguageMismatch load *behind* the visible list - the reducer turns that into the refresh
+   * spinner, the upsert keeps the list stable under it, and a failure degrades to the existing
+   * one-shot refresh-failed toast.
+   */
+  private fun loadFirstPageUnlessCacheIsFresh() {
     viewModelScope.launch(coroutineDispatcher.io) {
-      if (beersRepository.countDBEntries() == 0) {
+      if (beersRepository.catalogCacheStatus(CACHE_POLICY) != CatalogCacheStatus.Fresh) {
         pager.loadFirstPage()
       }
     }
@@ -105,6 +114,12 @@ class BeersListViewModel(
 
   fun refresh() {
     viewModelScope.launch(coroutineDispatcher.io) { pager.loadFirstPage() }
+  }
+
+  private companion object {
+    // The default 24h TTL; becomes an injected/screen-specific value only when a second surface
+    // wants a different one.
+    val CACHE_POLICY = CachePolicy()
   }
 }
 

--- a/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
+++ b/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
@@ -3,6 +3,7 @@ package com.simtop.feature.beerslist
 import app.cash.turbine.test
 import com.simtop.beerdomain.domain.errors.FetchBeersError
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.domain.models.CatalogCacheStatus
 import com.simtop.beerdomain.fakes.FakeBeersPagerFactory
 import com.simtop.beerdomain.fakes.FakeBeersRepository
 import com.simtop.core.core.CommonUiState
@@ -186,6 +187,34 @@ class BeersListViewModelTest {
           .isEqualTo(listOf("1", "2"))
       }
       expectThat(fakeBeersPagerFactory.pager.loadFirstPageCallCount).isEqualTo(0)
+    }
+
+  // The TTL policy (Paging 2.0 Phase 4): a warm cache past its staleAfter still shows instantly,
+  // but start also kicks a background first-page load - the reducer renders it as the refresh
+  // spinner over the intact list.
+  @Test
+  fun `a stale warm cache loads the first page in the background on start`() =
+    runTest(testDispatcher) {
+      fakeBeersRepository.setBeers(listOf(Beer.empty.copy(id = "1")))
+      fakeBeersRepository.catalogCacheStatus = CatalogCacheStatus.Stale
+
+      val viewModel = buildViewModel()
+
+      viewModel.beerListViewState.test {
+        expectThat(awaitItem()).isA<CommonUiState.Success<PagedListUiModel<Beer>>>()
+      }
+      expectThat(fakeBeersPagerFactory.pager.loadFirstPageCallCount).isEqualTo(1)
+    }
+
+  @Test
+  fun `a language-mismatched cache loads the first page in the background on start`() =
+    runTest(testDispatcher) {
+      fakeBeersRepository.setBeers(listOf(Beer.empty.copy(id = "1")))
+      fakeBeersRepository.catalogCacheStatus = CatalogCacheStatus.LanguageMismatch
+
+      buildViewModel()
+
+      expectThat(fakeBeersPagerFactory.pager.loadFirstPageCallCount).isEqualTo(1)
     }
 
   // Regression test: PagingState.Loading over an already-shown list is a refresh in progress, so


### PR DESCRIPTION
First Phase 4 PR: the catalog's cache policy stops being an accident of the upsert and becomes an explicit, tested value (plan §5.5), and the language-switch hole (§3.3) closes for real.

- **`CachePolicy(staleAfter = 24.hours)`** (core-common): names what was previously "cache-first forever". The `refreshed_at` column — written on every page insert since Phase 1 but never read — finally gets its consumer.
- **`BeersRepository.catalogCacheStatus(policy)`** classifies the cache: `Empty` (no rows), `Fresh` (bookmark for the current language within TTL), `Stale` (past TTL, **or** a legacy cache with no `paging_state` bookmarks at all — age unknowable), `LanguageMismatch` (rows whose bookmarks all belong to another language's surface). The surface-key construction moved to one shared `catalogSurface()` helper so the factory and repository can't drift.
- **Start policy** (`BeersListViewModel`): cached rows always show immediately; anything non-Fresh also triggers `loadFirstPage()`. Empty stays the cold start; Stale/LanguageMismatch load *behind* the visible list — the existing reducer renders that as the refresh spinner, the upsert keeps the list stable, and a failure degrades to the one-shot refresh-failed toast. `loadFirstPageIfCacheIsEmpty` is subsumed.
- **Language-switch resume fix:** on a bookmark miss the factory now distinguishes *why* it missed. `LanguageMismatch` → resume from page 1, so load-more re-walks and re-translates the stale pages through the availability-preserving upsert; the row-count estimate — which would have *skipped* pages 1..N and left them in the old language — keeps only its original job (the legacy pre-`paging_state` cache). Rows are deliberately never purged: deletion would reset local availability edits; old-language rows heal as far as the user scrolls.

Tests: repository classification across all five scenarios (incl. legacy), ViewModel start policy per status (the warm-Fresh case asserts **no** fetch — the cold-start-fixture-bias lesson), factory restart-from-page-1 on mismatch vs estimate on legacy, DAO test for the bookmark count query. `FakeBeersRepository` derives Empty/Fresh from its seeded data so existing fixtures stay one-liners. `make test`, `lint`, `konsist`, and the beer_database + app instrumented suites (5 + 14) all green; emulator smoke-verified (warm fresh cache renders instantly with no refetch).