### PR TITLE
fix: carry the server total on EndOfPagination so single-page surfaces show their count (Paging 2.0 4b)

### DIFF
--- a/core-common/src/main/kotlin/com/simtop/core/core/PagedListReducer.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagedListReducer.kt
@@ -47,7 +47,13 @@ class PagedListReducer<T, E : Any>(
   private var lastTotalCount: Int? = null
 
   fun reduce(items: List<T>, state: PagingState<E>): CommonUiState<PagedListUiModel<T>> {
-    if (state is PagingState.Success) state.totalCount?.let { lastTotalCount = it }
+    // Both total-carrying states latch: a surface whose first page is also its last never emits
+    // Success at all - EndOfPagination is its only chance to report "N results".
+    when (state) {
+      is PagingState.Success -> state.totalCount?.let { lastTotalCount = it }
+      is PagingState.EndOfPagination -> state.totalCount?.let { lastTotalCount = it }
+      else -> Unit
+    }
     return when (state) {
       PagingState.Idle -> if (items.isEmpty()) CommonUiState.Loading else success(items)
       PagingState.Loading ->
@@ -59,7 +65,7 @@ class PagedListReducer<T, E : Any>(
         // Success with no items yet: a DB-backed data flow may emit just after the state does, so
         // hold Loading until the rows arrive.
         if (items.isEmpty()) CommonUiState.Loading else success(items)
-      PagingState.EndOfPagination ->
+      is PagingState.EndOfPagination ->
         if (items.isEmpty()) endedEmpty() else success(items, footer = PagedListFooter.EndReached)
       is PagingState.Error ->
         when {

--- a/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/PagingMediator.kt
@@ -32,7 +32,12 @@ sealed class PagingState<out E : Any> {
    */
   data class Error<out E : Any>(val error: E, val isFirstPage: Boolean) : PagingState<E>()
 
-  data object EndOfPagination : PagingState<Nothing>()
+  /**
+   * Every page is loaded. Carries the last [totalCount] the fetch reported (null when the end was
+   * found by the empty-page probe on a header-less backend), so a surface whose *first* page is
+   * also its last - which never passes through [Success] - can still render its "N results" count.
+   */
+  data class EndOfPagination(val totalCount: Int? = null) : PagingState<Nothing>()
 }
 
 /**
@@ -252,7 +257,7 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
       // Empty-page probe: the fallback end signal when the server reports no total (nextKey stays
       // non-null) - preserves the pre-2.0 behaviour for a header-less backend.
       if (items.isEmpty()) {
-        endPagination()
+        endPagination(result.totalCount)
         return
       }
 
@@ -265,7 +270,7 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
         if (isFirstPage && result.nextKey != null) nextKeyFromStorage?.invoke() ?: result.nextKey
         else result.nextKey
       if (currentKey == null) {
-        endPagination()
+        endPagination(result.totalCount)
       } else {
         _pagingState.value = PagingState.Success(result.totalCount)
       }
@@ -281,8 +286,8 @@ class PagingMediator<Key : Any, Value : Any, E : Any>(
     }
   }
 
-  private fun endPagination() {
+  private fun endPagination(totalCount: Int?) {
     isLastPage = true
-    _pagingState.value = PagingState.EndOfPagination
+    _pagingState.value = PagingState.EndOfPagination(totalCount)
   }
 }

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagedListReducerTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagedListReducerTest.kt
@@ -68,7 +68,7 @@ class PagedListReducerTest {
 
   @Test
   fun `end of pagination with items shows the end footer`() {
-    val state = reducer().reduce(items, PagingState.EndOfPagination)
+    val state = reducer().reduce(items, PagingState.EndOfPagination())
 
     assertEquals(
       CommonUiState.Success(PagedListUiModel(items, footer = PagedListFooter.EndReached)),
@@ -76,9 +76,24 @@ class PagedListReducerTest {
     )
   }
 
+  // A single-page surface (browse-by-style, a short search) goes straight to EndOfPagination
+  // without ever passing through Success - the total it carries must still reach the ui model,
+  // or those screens can never render their "N results" header.
+  @Test
+  fun `a total carried by end of pagination is latched like one from Success`() {
+    val state = reducer().reduce(items, PagingState.EndOfPagination(totalCount = 14))
+
+    assertEquals(
+      CommonUiState.Success(
+        PagedListUiModel(items, footer = PagedListFooter.EndReached, totalCount = 14)
+      ),
+      state,
+    )
+  }
+
   @Test
   fun `end of pagination with nothing is Empty by default`() {
-    val state = reducer().reduce(emptyList(), PagingState.EndOfPagination)
+    val state = reducer().reduce(emptyList(), PagingState.EndOfPagination())
 
     assertEquals(CommonUiState.Empty, state)
   }
@@ -89,7 +104,7 @@ class PagedListReducerTest {
     val noResults = CommonUiState.Success(PagedListUiModel<String>())
     val reducer = reducer(endedEmpty = { noResults })
 
-    assertEquals(noResults, reducer.reduce(emptyList(), PagingState.EndOfPagination))
+    assertEquals(noResults, reducer.reduce(emptyList(), PagingState.EndOfPagination()))
   }
 
   @Test

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
@@ -173,7 +173,7 @@ class PagingMediatorTest {
     harness.mediator.loadFirstPage()
 
     harness.mediator.loadNextPage() // page 2 is empty
-    assertEquals(PagingState.EndOfPagination, harness.mediator.pagingState.value)
+    assertEquals(PagingState.EndOfPagination(), harness.mediator.pagingState.value)
 
     harness.mediator.loadNextPage()
     harness.mediator.loadNextPage()
@@ -194,8 +194,44 @@ class PagingMediatorTest {
 
     mediator.loadFirstPage()
 
-    assertEquals(PagingState.EndOfPagination, mediator.pagingState.value)
+    assertEquals(PagingState.EndOfPagination(), mediator.pagingState.value)
     assertEquals(listOf("only item"), storage.stored.value)
+  }
+
+  // A single-page surface never emits Success at all, so EndOfPagination is its only chance to
+  // carry the server total - without it the UI can never render "N results" for short datasets.
+  @Test
+  fun `EndOfPagination carries the total when the first page is also the last`() = runTest {
+    val mediator =
+      PagingMediator<Int, String, String>(
+        initialKey = 1,
+        fetchRemote = { PageResult(listOf("only item"), nextKey = null, totalCount = 14) },
+        classifyError = { "unused" },
+      )
+
+    mediator.loadFirstPage()
+
+    assertEquals(PagingState.EndOfPagination(totalCount = 14), mediator.pagingState.value)
+  }
+
+  @Test
+  fun `the empty-page probe carries the total when the header reports one`() = runTest {
+    val mediator =
+      PagingMediator<Int, String, String>(
+        initialKey = 1,
+        // A server that reports totals but whose nextKey math wasn't wired: page 2 comes back
+        // empty with the header still present.
+        fetchRemote = { page ->
+          if (page == 1) PageResult(listOf("item"), nextKey = 2, totalCount = 1)
+          else PageResult(emptyList(), nextKey = 3, totalCount = 1)
+        },
+        classifyError = { "unused" },
+      )
+
+    mediator.loadFirstPage()
+    mediator.loadNextPage()
+
+    assertEquals(PagingState.EndOfPagination(totalCount = 1), mediator.pagingState.value)
   }
 
   @Test
@@ -445,7 +481,7 @@ class PagingMediatorTest {
       )
 
     mediator.loadFirstPage()
-    assertEquals(PagingState.EndOfPagination, mediator.pagingState.value)
+    assertEquals(PagingState.EndOfPagination(), mediator.pagingState.value)
 
     mediator.loadNextPage() // must be a no-op, not a refetch of page 1
     assertEquals(listOf(1), fetchedKeys)
@@ -528,7 +564,7 @@ class PagingMediatorTest {
 
     mediator.loadFirstPage() // refresh: the stale item must not survive
 
-    assertEquals(PagingState.EndOfPagination, mediator.pagingState.value)
+    assertEquals(PagingState.EndOfPagination(), mediator.pagingState.value)
     mediator.data.test { assertEquals(emptyList<String>(), awaitItem()) }
   }
 }

--- a/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/BrowseBeersViewModelTest.kt
+++ b/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/BrowseBeersViewModelTest.kt
@@ -98,7 +98,7 @@ class BrowseBeersViewModelTest {
         runCurrent()
         val pager = fakeFactory.searchPagers.last()
         pager.setData(emptyList())
-        pager.setPagingState(PagingState.EndOfPagination)
+        pager.setPagingState(PagingState.EndOfPagination())
         runCurrent()
 
         val state = expectMostRecentItem()

--- a/feature/beersearch/src/test/java/com/simtop/feature/beersearch/BeersSearchViewModelTest.kt
+++ b/feature/beersearch/src/test/java/com/simtop/feature/beersearch/BeersSearchViewModelTest.kt
@@ -129,7 +129,7 @@ class BeersSearchViewModelTest {
         runCurrent()
         val pager = fakeFactory.searchPagers.last()
         pager.setData(emptyList())
-        pager.setPagingState(PagingState.EndOfPagination)
+        pager.setPagingState(PagingState.EndOfPagination())
         runCurrent()
 
         val state = expectMostRecentItem()

--- a/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
+++ b/feature/beerslist/src/test/java/com/simtop/feature/beerslist/BeersListViewModelTest.kt
@@ -129,7 +129,7 @@ class BeersListViewModelTest {
       viewModel.beerListViewState.test {
         expectThat(awaitItem()).isA<CommonUiState.Success<PagedListUiModel<Beer>>>()
 
-        pager.setPagingState(PagingState.EndOfPagination)
+        pager.setPagingState(PagingState.EndOfPagination())
 
         val state = awaitItem()
         expectThat((state as CommonUiState.Success).data.footer)
@@ -255,7 +255,7 @@ class BeersListViewModelTest {
       viewModel.beerListViewState.test {
         expectThat(awaitItem()).isA<CommonUiState.Loading>()
 
-        pager.setPagingState(PagingState.EndOfPagination)
+        pager.setPagingState(PagingState.EndOfPagination())
 
         expectThat(awaitItem()).isEqualTo(CommonUiState.Empty)
       }


### PR DESCRIPTION
Second Phase 4 PR — the count-header fix flagged in #81.

A surface whose first page is also its last (every browse-by-style/brewery drill-in, any search with ≤25 hits) goes straight from Loading to `EndOfPagination` and never passes through `Success` — but `Success` was the only state carrying `totalCount`, so the `PagedListReducer` never latched a total and the "N beers" / "N results" header simply never rendered on those screens.

- `PagingState.EndOfPagination` becomes `data class EndOfPagination(val totalCount: Int? = null)`; the mediator passes the fetch's total on both end paths (`nextKey == null`, and the empty-page probe — which can still carry a header total when the server reports one but the key math wasn't wired). A header-less backend still yields null, preserving the old rendering exactly.
- The reducer latches the total from `EndOfPagination` the same way it does from `Success`.
- Mechanical ripple: the former `data object`'s value references become constructor calls across the mediator/reducer/ViewModel test suites.

Deliberately a Phase 4 change: Phase 3's zero-`core-common` criterion is closed, and this is the smallest honest fix — the alternative (emitting a synthetic `Success` before ending) would add a transient non-ended state that #74 deliberately removed.

Tests: mediator carries the total on both end paths (named tests), reducer latches from `EndOfPagination` (single-page surface renders its header), all existing named guarantees keep their meaning. `make test`, `screenshot-verify`, `lint`, `konsist` green. Emulator-verified: browse → IPA now shows "14 beers" above the list (it was absent in the #81 walkthrough).