### PR TITLE
feat: enrich the detail screen from embedded list-response fields (Paging 2.0 4c)

### DIFF
--- a/app/src/test/resources/json/fake_json_response.json
+++ b/app/src/test/resources/json/fake_json_response.json
@@ -46,81 +46,8 @@
       },
       "twist": null
     },
-    "ingredients": {
-      "malt": [
-        {
-          "name": "Maris Otter Extra Pale",
-          "amount": {
-            "value": 3.3,
-            "unit": "kilograms"
-          }
-        },
-        {
-          "name": "Caramalt",
-          "amount": {
-            "value": 0.2,
-            "unit": "kilograms"
-          }
-        },
-        {
-          "name": "Munich",
-          "amount": {
-            "value": 0.4,
-            "unit": "kilograms"
-          }
-        }
-      ],
-      "hops": [
-        {
-          "name": "Fuggles",
-          "amount": {
-            "value": 25,
-            "unit": "grams"
-          },
-          "add": "start",
-          "attribute": "bitter"
-        },
-        {
-          "name": "First Gold",
-          "amount": {
-            "value": 25,
-            "unit": "grams"
-          },
-          "add": "start",
-          "attribute": "bitter"
-        },
-        {
-          "name": "Fuggles",
-          "amount": {
-            "value": 37.5,
-            "unit": "grams"
-          },
-          "add": "middle",
-          "attribute": "flavour"
-        },
-        {
-          "name": "First Gold",
-          "amount": {
-            "value": 37.5,
-            "unit": "grams"
-          },
-          "add": "middle",
-          "attribute": "flavour"
-        },
-        {
-          "name": "Cascade",
-          "amount": {
-            "value": 37.5,
-            "unit": "grams"
-          },
-          "add": "end",
-          "attribute": "flavour"
-        }
-      ],
-      "yeast": "Wyeast 1056 - American Ale™"
-    },
-    "food_pairing": [
-    ],
+    "ingredients": null,
+    "food_pairing": [],
     "brewers_tips": "The earthy and floral aromas from the hops can be overpowering. Drop a little Cascade in at the end of the boil to lift the profile with a bit of citrus.",
     "contributed_by": "Sam Mason <samjbmason>"
   }

--- a/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
@@ -4,6 +4,7 @@ import com.simtop.beer_database.models.BeerDbModel
 import com.simtop.beer_database.utils.Converters
 import com.simtop.beer_network.models.BeersApiResponseItem
 import com.simtop.beer_network.models.BreweryApiResponseItem
+import com.simtop.beer_network.models.NamedEntity
 import com.simtop.beer_network.models.TypologyApiResponseItem
 import com.simtop.beer_network.network.BeersService
 import com.simtop.beerdomain.domain.models.Beer
@@ -38,8 +39,33 @@ constructor(private val languageProvider: LanguageProvider, private val logger: 
       // Seeds the row's initial availability on first insert only (the keyed upsert never rewrites
       // availability for an existing id, so a user's later edit survives refresh).
       availability = response?.available ?: true,
+      styleName = response?.typology?.name ?: "",
+      breweryName = response?.brewery?.name ?: "",
+      srm = response?.srm,
+      releasedYear = response?.releasedYear,
+      minServingTemperature = response?.minServingTemperature,
+      maxServingTemperature = response?.maxServingTemperature,
+      fermentationMethod = response?.fermentationMethod?.localizedName(languageCode) ?: "",
+      ingredients = response?.ingredients.localizedNames(languageCode),
+      recommendedGlasses = response?.recommendedGlasses.localizedNames(languageCode),
     )
   }
+
+  /**
+   * The display name in the requested language, falling back to the default language and then to
+   * whatever translation exists - the same tolerance the slogan/description lookup applies.
+   */
+  private fun NamedEntity.localizedName(languageCode: String): String {
+    val translations = translations.orEmpty()
+    val match =
+      translations.find { it.language?.code == languageCode }
+        ?: translations.find { it.language?.code == BeersService.DEFAULT_LANGUAGE_CODE }
+        ?: translations.firstOrNull()
+    return match?.name ?: ""
+  }
+
+  private fun List<NamedEntity>?.localizedNames(languageCode: String): List<String> =
+    orEmpty().map { it.localizedName(languageCode) }.filter { it.isNotEmpty() }
 
   private fun logMissingField(field: String, response: BeersApiResponseItem?) {
     logger.warn(TAG, "missing $field for beer id=${response?.id}, defaulting")
@@ -67,28 +93,46 @@ constructor(private val languageProvider: LanguageProvider, private val logger: 
 
   fun fromBeerToBeerDbModel(beer: Beer) =
     BeerDbModel(
-      beer.id,
-      beer.name,
-      beer.tagline,
-      beer.description,
-      beer.imageUrl,
-      beer.abv,
-      beer.ibu,
-      Converters.listToJson(beer.foodPairing),
-      beer.availability,
+      id = beer.id,
+      name = beer.name,
+      tagline = beer.tagline,
+      description = beer.description,
+      imageUrl = beer.imageUrl,
+      abv = beer.abv,
+      ibu = beer.ibu,
+      foodPairing = Converters.listToJson(beer.foodPairing),
+      availability = beer.availability,
+      styleName = beer.styleName,
+      breweryName = beer.breweryName,
+      srm = beer.srm,
+      releasedYear = beer.releasedYear,
+      minServingTemperature = beer.minServingTemperature,
+      maxServingTemperature = beer.maxServingTemperature,
+      fermentationMethod = beer.fermentationMethod,
+      ingredients = Converters.listToJson(beer.ingredients),
+      recommendedGlasses = Converters.listToJson(beer.recommendedGlasses),
     )
 
   fun fromBeerDbModelToBeer(beerDbModel: BeerDbModel) =
     Beer(
-      beerDbModel.id,
-      beerDbModel.name,
-      beerDbModel.tagline,
-      beerDbModel.description,
-      beerDbModel.imageUrl,
-      beerDbModel.abv,
-      beerDbModel.ibu,
-      Converters.jsonToList(beerDbModel.foodPairing),
-      beerDbModel.availability,
+      id = beerDbModel.id,
+      name = beerDbModel.name,
+      tagline = beerDbModel.tagline,
+      description = beerDbModel.description,
+      imageUrl = beerDbModel.imageUrl,
+      abv = beerDbModel.abv,
+      ibu = beerDbModel.ibu,
+      foodPairing = Converters.jsonToList(beerDbModel.foodPairing),
+      availability = beerDbModel.availability,
+      styleName = beerDbModel.styleName,
+      breweryName = beerDbModel.breweryName,
+      srm = beerDbModel.srm,
+      releasedYear = beerDbModel.releasedYear,
+      minServingTemperature = beerDbModel.minServingTemperature,
+      maxServingTemperature = beerDbModel.maxServingTemperature,
+      fermentationMethod = beerDbModel.fermentationMethod,
+      ingredients = Converters.jsonToList(beerDbModel.ingredients),
+      recommendedGlasses = Converters.jsonToList(beerDbModel.recommendedGlasses),
     )
 
   private companion object {

--- a/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
@@ -2,8 +2,12 @@ package com.simtop.beer_data.mappers
 
 import com.simtop.beer_database.models.BeerDbModel
 import com.simtop.beer_network.models.BeersApiResponseItem
+import com.simtop.beer_network.models.BreweryApiResponseItem
 import com.simtop.beer_network.models.EmbeddedImage
+import com.simtop.beer_network.models.EmbeddedTypology
 import com.simtop.beer_network.models.Language
+import com.simtop.beer_network.models.NamedEntity
+import com.simtop.beer_network.models.NamedTranslation
 import com.simtop.beer_network.models.Translation
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.core.core.LanguageProvider
@@ -152,6 +156,65 @@ class BeersMapperTest {
   }
 
   @Test
+  fun `fromBeersApiResponseItemToBeer maps the embedded detail fields`() {
+    val response =
+      fullResponse()
+        .copy(
+          srm = 9,
+          releasedYear = 1980,
+          minServingTemperature = 1,
+          maxServingTemperature = 9,
+          typology = EmbeddedTypology(name = "Stout"),
+          brewery = BreweryApiResponseItem(id = "b1", name = "ChuckleCraft Brewery"),
+          fermentationMethod = namedEntity("en" to "Lager", "it" to "Lager IT"),
+          ingredients = listOf(namedEntity("en" to "Dark malt")),
+          recommendedGlasses = listOf(namedEntity("en" to "Chalice")),
+        )
+
+    val beer = mapper.fromBeersApiResponseItemToBeer(response)
+
+    expectThat(beer.styleName).isEqualTo("Stout")
+    expectThat(beer.breweryName).isEqualTo("ChuckleCraft Brewery")
+    expectThat(beer.srm).isEqualTo(9)
+    expectThat(beer.releasedYear).isEqualTo(1980)
+    expectThat(beer.minServingTemperature).isEqualTo(1)
+    expectThat(beer.maxServingTemperature).isEqualTo(9)
+    expectThat(beer.fermentationMethod).isEqualTo("Lager")
+    expectThat(beer.ingredients).isEqualTo(listOf("Dark malt"))
+    expectThat(beer.recommendedGlasses).isEqualTo(listOf("Chalice"))
+  }
+
+  @Test
+  fun `named-entity fields fall back to en then to whatever translation exists`() {
+    languageCode = "fr"
+    val fallsBackToEn =
+      fullResponse().copy(fermentationMethod = namedEntity("en" to "Lager", "it" to "Lager IT"))
+    val fallsBackToFirst = fullResponse().copy(fermentationMethod = namedEntity("it" to "Lager IT"))
+
+    expectThat(mapper.fromBeersApiResponseItemToBeer(fallsBackToEn).fermentationMethod)
+      .isEqualTo("Lager")
+    expectThat(mapper.fromBeersApiResponseItemToBeer(fallsBackToFirst).fermentationMethod)
+      .isEqualTo("Lager IT")
+  }
+
+  @Test
+  fun `detail fields default to empty when the embedded objects are absent`() {
+    val beer = mapper.fromBeersApiResponseItemToBeer(fullResponse())
+
+    expectThat(beer.styleName).isEqualTo("")
+    expectThat(beer.breweryName).isEqualTo("")
+    expectThat(beer.srm).isEqualTo(null)
+    expectThat(beer.fermentationMethod).isEqualTo("")
+    expectThat(beer.ingredients).isEqualTo(emptyList())
+    expectThat(beer.recommendedGlasses).isEqualTo(emptyList())
+  }
+
+  private fun namedEntity(vararg nameByLanguage: Pair<String, String>) =
+    NamedEntity(
+      translations = nameByLanguage.map { (lang, name) -> NamedTranslation(name, Language(lang)) }
+    )
+
+  @Test
   fun `fromBeerToBeerDbModel converts a Beer into a BeerDbModel`() {
     val beer =
       Beer(
@@ -182,6 +245,34 @@ class BeersMapperTest {
           availability = false,
         )
       )
+  }
+
+  @Test
+  fun `fromBeerToBeerDbModel and back round-trips the detail fields`() {
+    val beer =
+      Beer(
+        id = "1",
+        name = "Buzz",
+        tagline = "",
+        description = "",
+        imageUrl = "",
+        abv = 4.5,
+        ibu = 60.0,
+        foodPairing = emptyList(),
+        styleName = "Stout",
+        breweryName = "ChuckleCraft Brewery",
+        srm = 9,
+        releasedYear = 1980,
+        minServingTemperature = 1,
+        maxServingTemperature = 9,
+        fermentationMethod = "Lager",
+        ingredients = listOf("Dark malt", "Roasted barley"),
+        recommendedGlasses = listOf("Chalice"),
+      )
+
+    val roundTripped = mapper.fromBeerDbModelToBeer(mapper.fromBeerToBeerDbModel(beer))
+
+    expectThat(roundTripped).isEqualTo(beer)
   }
 
   @Test

--- a/beer_database/schemas/com.simtop.beer_database.database.BeersDatabase/3.json
+++ b/beer_database/schemas/com.simtop.beer_database.database.BeersDatabase/3.json
@@ -1,0 +1,168 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "51afa20111c59708bf3066781416e9b9",
+    "entities": [
+      {
+        "tableName": "beers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `tagline` TEXT NOT NULL, `description` TEXT NOT NULL, `image_url` TEXT NOT NULL, `abv` REAL NOT NULL, `ibu` REAL NOT NULL, `food_pairing` TEXT NOT NULL, `availability` INTEGER NOT NULL, `style_name` TEXT NOT NULL DEFAULT '', `brewery_name` TEXT NOT NULL DEFAULT '', `srm` INTEGER, `released_year` INTEGER, `min_serving_temperature` INTEGER, `max_serving_temperature` INTEGER, `fermentation_method` TEXT NOT NULL DEFAULT '', `ingredients` TEXT NOT NULL DEFAULT '[]', `recommended_glasses` TEXT NOT NULL DEFAULT '[]', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagline",
+            "columnName": "tagline",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "abv",
+            "columnName": "abv",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ibu",
+            "columnName": "ibu",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "foodPairing",
+            "columnName": "food_pairing",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "availability",
+            "columnName": "availability",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "styleName",
+            "columnName": "style_name",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "breweryName",
+            "columnName": "brewery_name",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "srm",
+            "columnName": "srm",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "releasedYear",
+            "columnName": "released_year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "minServingTemperature",
+            "columnName": "min_serving_temperature",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "maxServingTemperature",
+            "columnName": "max_serving_temperature",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "fermentationMethod",
+            "columnName": "fermentation_method",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "ingredients",
+            "columnName": "ingredients",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "recommendedGlasses",
+            "columnName": "recommended_glasses",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "paging_state",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`surface` TEXT NOT NULL, `next_key` INTEGER, `total_count` INTEGER, `refreshed_at` INTEGER NOT NULL, PRIMARY KEY(`surface`))",
+        "fields": [
+          {
+            "fieldPath": "surface",
+            "columnName": "surface",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nextKey",
+            "columnName": "next_key",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalCount",
+            "columnName": "total_count",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "refreshedAt",
+            "columnName": "refreshed_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "surface"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '51afa20111c59708bf3066781416e9b9')"
+    ]
+  }
+}

--- a/beer_database/src/androidTest/java/com/simtop/beer_database/database/BeersDatabaseMigrationTest.kt
+++ b/beer_database/src/androidTest/java/com/simtop/beer_database/database/BeersDatabaseMigrationTest.kt
@@ -58,4 +58,49 @@ class BeersDatabaseMigrationTest {
     }
     db.close()
   }
+
+  @Test
+  fun migrate2To3_keepsBeersAndPagingState_andAddsDetailColumnsWithDefaults() {
+    val dbName = "migration-test-2-3"
+
+    // v2: seed one beer (locally edited availability) and a paging_state bookmark.
+    helper.createDatabase(dbName, 2).apply {
+      execSQL(
+        "INSERT INTO beers " +
+          "(id, name, tagline, description, image_url, abv, ibu, food_pairing, availability) " +
+          "VALUES ('1', 'Beer 1', '', '', '', 0.0, 0.0, '[]', 0)"
+      )
+      execSQL(
+        "INSERT INTO paging_state (surface, next_key, total_count, refreshed_at) " +
+          "VALUES ('catalog:en', 3, 206, 0)"
+      )
+      close()
+    }
+
+    val db = helper.runMigrationsAndValidate(dbName, 3, true, MIGRATION_2_3)
+
+    // The pre-existing beer and its edited availability survived...
+    db
+      .query(
+        "SELECT availability, style_name, brewery_name, srm, ingredients, recommended_glasses " +
+          "FROM beers WHERE id = '1'"
+      )
+      .use { cursor ->
+        assertTrue(cursor.moveToFirst())
+        assertEquals(0, cursor.getInt(0))
+        // ...and the new columns carry their defaults, matching BeerDbModel's Kotlin defaults.
+        assertEquals("", cursor.getString(1))
+        assertEquals("", cursor.getString(2))
+        assertTrue(cursor.isNull(3))
+        assertEquals("[]", cursor.getString(4))
+        assertEquals("[]", cursor.getString(5))
+      }
+
+    // paging_state (an unrelated table) is untouched by this migration.
+    db.query("SELECT next_key FROM paging_state WHERE surface = 'catalog:en'").use { cursor ->
+      assertTrue(cursor.moveToFirst())
+      assertEquals(3, cursor.getInt(0))
+    }
+    db.close()
+  }
 }

--- a/beer_database/src/main/java/com/simtop/beer_database/database/BeersDao.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/database/BeersDao.kt
@@ -34,7 +34,16 @@ abstract class BeersDao {
         image_url = :imageUrl,
         abv = :abv,
         ibu = :ibu,
-        food_pairing = :foodPairing
+        food_pairing = :foodPairing,
+        style_name = :styleName,
+        brewery_name = :breweryName,
+        srm = :srm,
+        released_year = :releasedYear,
+        min_serving_temperature = :minServingTemperature,
+        max_serving_temperature = :maxServingTemperature,
+        fermentation_method = :fermentationMethod,
+        ingredients = :ingredients,
+        recommended_glasses = :recommendedGlasses
         WHERE id = :id
         """
   )
@@ -47,6 +56,15 @@ abstract class BeersDao {
     abv: Double,
     ibu: Double,
     foodPairing: String,
+    styleName: String,
+    breweryName: String,
+    srm: Int?,
+    releasedYear: Int?,
+    minServingTemperature: Int?,
+    maxServingTemperature: Int?,
+    fermentationMethod: String,
+    ingredients: String,
+    recommendedGlasses: String,
   )
 
   @androidx.room.Transaction
@@ -64,6 +82,15 @@ abstract class BeersDao {
           beer.abv,
           beer.ibu,
           beer.foodPairing,
+          beer.styleName,
+          beer.breweryName,
+          beer.srm,
+          beer.releasedYear,
+          beer.minServingTemperature,
+          beer.maxServingTemperature,
+          beer.fermentationMethod,
+          beer.ingredients,
+          beer.recommendedGlasses,
         )
       }
     }

--- a/beer_database/src/main/java/com/simtop/beer_database/database/BeersDatabase.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/database/BeersDatabase.kt
@@ -5,7 +5,7 @@ import androidx.room.RoomDatabase
 import com.simtop.beer_database.models.BeerDbModel
 import com.simtop.beer_database.models.PagingStateDbModel
 
-@Database(entities = [BeerDbModel::class, PagingStateDbModel::class], version = 2)
+@Database(entities = [BeerDbModel::class, PagingStateDbModel::class], version = 3)
 abstract class BeersDatabase : RoomDatabase() {
   abstract fun beersDao(): BeersDao
 }

--- a/beer_database/src/main/java/com/simtop/beer_database/database/Migrations.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/database/Migrations.kt
@@ -23,3 +23,24 @@ val MIGRATION_1_2 =
       )
     }
   }
+
+/**
+ * v2 → v3: additive detail columns on `beers` (Paging 2.0 Phase 4 §6.5), defaults matching
+ * [com.simtop.beer_database.models.BeerDbModel]'s `defaultValue`s exactly. Existing rows -
+ * including the user-owned availability - are untouched; migrated rows carry the empty defaults
+ * until the next refresh's upsert fills the fields from the embedded API objects.
+ */
+val MIGRATION_2_3 =
+  object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+      db.execSQL("ALTER TABLE `beers` ADD COLUMN `style_name` TEXT NOT NULL DEFAULT ''")
+      db.execSQL("ALTER TABLE `beers` ADD COLUMN `brewery_name` TEXT NOT NULL DEFAULT ''")
+      db.execSQL("ALTER TABLE `beers` ADD COLUMN `srm` INTEGER")
+      db.execSQL("ALTER TABLE `beers` ADD COLUMN `released_year` INTEGER")
+      db.execSQL("ALTER TABLE `beers` ADD COLUMN `min_serving_temperature` INTEGER")
+      db.execSQL("ALTER TABLE `beers` ADD COLUMN `max_serving_temperature` INTEGER")
+      db.execSQL("ALTER TABLE `beers` ADD COLUMN `fermentation_method` TEXT NOT NULL DEFAULT ''")
+      db.execSQL("ALTER TABLE `beers` ADD COLUMN `ingredients` TEXT NOT NULL DEFAULT '[]'")
+      db.execSQL("ALTER TABLE `beers` ADD COLUMN `recommended_glasses` TEXT NOT NULL DEFAULT '[]'")
+    }
+  }

--- a/beer_database/src/main/java/com/simtop/beer_database/di/BeersDatabaseModule.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/di/BeersDatabaseModule.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import com.simtop.beer_database.database.BeersDao
 import com.simtop.beer_database.database.BeersDatabase
 import com.simtop.beer_database.database.MIGRATION_1_2
+import com.simtop.beer_database.database.MIGRATION_2_3
 import com.simtop.core.BuildConfig
 import com.simtop.core.core.BEERS_DB_NAME
 import com.simtop.core.di.ApplicationContext
@@ -25,7 +26,7 @@ interface BeersDatabaseModule {
       // throwaway DB - it must never run in release, where it would wipe user data. The debug flag
       // reuses :core's BuildConfig (already enabled there, precedent: NetworkingModule) instead of
       // turning buildConfig on in this library module.
-      .addMigrations(MIGRATION_1_2)
+      .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
       .apply { if (BuildConfig.DEBUG) fallbackToDestructiveMigration(dropAllTables = true) }
       .build()
 

--- a/beer_database/src/main/java/com/simtop/beer_database/models/BeerDbModel.kt
+++ b/beer_database/src/main/java/com/simtop/beer_database/models/BeerDbModel.kt
@@ -15,4 +15,17 @@ data class BeerDbModel(
   @ColumnInfo(name = "ibu") val ibu: Double,
   @ColumnInfo(name = "food_pairing") val foodPairing: String,
   @ColumnInfo(name = "availability") val availability: Boolean = true,
+  // Detail fields (v3). Kotlin defaults keep old call sites compiling; the SQL defaultValue
+  // mirrors the v2->v3 ALTER TABLE statements, so a migrated row and a fresh row agree.
+  @ColumnInfo(name = "style_name", defaultValue = "") val styleName: String = "",
+  @ColumnInfo(name = "brewery_name", defaultValue = "") val breweryName: String = "",
+  @ColumnInfo(name = "srm") val srm: Int? = null,
+  @ColumnInfo(name = "released_year") val releasedYear: Int? = null,
+  @ColumnInfo(name = "min_serving_temperature") val minServingTemperature: Int? = null,
+  @ColumnInfo(name = "max_serving_temperature") val maxServingTemperature: Int? = null,
+  @ColumnInfo(name = "fermentation_method", defaultValue = "") val fermentationMethod: String = "",
+  // JSON-encoded string lists, like food_pairing.
+  @ColumnInfo(name = "ingredients", defaultValue = "[]") val ingredients: String = "[]",
+  @ColumnInfo(name = "recommended_glasses", defaultValue = "[]")
+  val recommendedGlasses: String = "[]",
 )

--- a/beer_network/src/main/java/com/simtop/beer_network/models/BeersApiResponseItem.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/models/BeersApiResponseItem.kt
@@ -15,6 +15,16 @@ data class BeersApiResponseItem(
   val available: Boolean? = null,
   val translations: List<Translation>? = null,
   @SerialName("food_pairing") val foodPairing: List<String>? = null,
+  val srm: Int? = null,
+  @SerialName("released_year") val releasedYear: Int? = null,
+  @SerialName("minimum_serving_temperature") val minServingTemperature: Int? = null,
+  @SerialName("maximum_serving_temperature") val maxServingTemperature: Int? = null,
+  // `name` is language-neutral for typologies; only descriptions are translated (unrendered).
+  val typology: EmbeddedTypology? = null,
+  val brewery: BreweryApiResponseItem? = null,
+  @SerialName("fermentation_method") val fermentationMethod: NamedEntity? = null,
+  val ingredients: List<NamedEntity>? = null,
+  @SerialName("recommended_glasses") val recommendedGlasses: List<NamedEntity>? = null,
 )
 
 @Serializable data class EmbeddedImage(val url: String? = null)
@@ -23,3 +33,14 @@ data class BeersApiResponseItem(
 data class Translation(val language: Language, val slogan: String?, val description: String?)
 
 @Serializable data class Language(val code: String)
+
+@Serializable data class EmbeddedTypology(val name: String? = null)
+
+/**
+ * An embedded entity whose display name lives in per-language [translations] (an ingredient, a
+ * recommended glass, a fermentation method) - unlike a beer's [Translation], which carries
+ * slogan/description instead of a name.
+ */
+@Serializable data class NamedEntity(val translations: List<NamedTranslation>? = null)
+
+@Serializable data class NamedTranslation(val name: String? = null, val language: Language? = null)

--- a/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/Beer.kt
+++ b/beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/Beer.kt
@@ -14,6 +14,18 @@ data class Beer(
   val ibu: Double,
   val foodPairing: List<String>,
   val availability: Boolean = true,
+  // Detail-screen fields from the embedded list-response objects (Paging 2.0 Phase 4). All
+  // defaulted: a Beer serialized before they existed (nav key / SavedStateHandle across an app
+  // update) must still decode.
+  val styleName: String = "",
+  val breweryName: String = "",
+  val srm: Int? = null,
+  val releasedYear: Int? = null,
+  val minServingTemperature: Int? = null,
+  val maxServingTemperature: Int? = null,
+  val fermentationMethod: String = "",
+  val ingredients: List<String> = emptyList(),
+  val recommendedGlasses: List<String> = emptyList(),
 ) {
   companion object {
     val empty = Beer("1", "", "", "", "", 0.0, 0.0, emptyList(), true)

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
@@ -159,6 +159,21 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
           ),
       )
 
+      // Style · Brewery, only when the embedded data has both (older cached rows may have
+      // neither - Room migration backfills empty strings, not a re-fetch).
+      if (beer.styleName.isNotEmpty() && beer.breweryName.isNotEmpty()) {
+        Text(
+          text =
+            stringResource(
+              R.string.beer_detail_style_and_brewery,
+              beer.styleName,
+              beer.breweryName,
+            ),
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+
       Spacer(modifier = Modifier.height(BillionBeersTheme.spacing.large))
 
       // Stats Row
@@ -197,26 +212,96 @@ fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability:
       Spacer(modifier = Modifier.height(BillionBeersTheme.spacing.large))
 
       // Food Pairing
-      if (beer.foodPairing.isNotEmpty()) {
+      BeerDetailBulletSection(
+        title = stringResource(R.string.beer_detail_food_pairing),
+        items = beer.foodPairing,
+      )
+
+      // Details: released year / serving temperature / fermentation method / SRM, each row shown
+      // only when its field is present - a beer fetched before Phase 4 (or a legacy cache row)
+      // simply renders fewer rows instead of blanks.
+      val detailRows = beer.detailRows()
+      if (detailRows.isNotEmpty()) {
+        Spacer(modifier = Modifier.height(BillionBeersTheme.spacing.large))
         Text(
-          text = stringResource(R.string.beer_detail_food_pairing),
+          text = stringResource(R.string.beer_detail_details),
           style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
         )
-        Spacer(
-          modifier =
-            Modifier.height(BillionBeersTheme.spacing.medium - BillionBeersTheme.spacing.extraSmall)
-        )
-        beer.foodPairing.forEach { pairing ->
-          Row(modifier = Modifier.padding(vertical = BillionBeersTheme.spacing.extraSmall)) {
+        Spacer(modifier = Modifier.height(BillionBeersTheme.spacing.small))
+        detailRows.forEach { (label, value) ->
+          Row(
+            modifier =
+              Modifier.fillMaxWidth().padding(vertical = BillionBeersTheme.spacing.extraSmall),
+            horizontalArrangement = Arrangement.SpaceBetween,
+          ) {
             Text(
-              text = "•",
-              style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
-              modifier = Modifier.padding(end = BillionBeersTheme.spacing.small),
+              text = label,
+              style = MaterialTheme.typography.bodyLarge,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
-            Text(text = pairing, style = MaterialTheme.typography.bodyLarge)
+            Text(text = value, style = MaterialTheme.typography.bodyLarge)
           }
         }
       }
+
+      Spacer(modifier = Modifier.height(BillionBeersTheme.spacing.large))
+
+      BeerDetailBulletSection(
+        title = stringResource(R.string.beer_detail_ingredients),
+        items = beer.ingredients,
+      )
+
+      Spacer(modifier = Modifier.height(BillionBeersTheme.spacing.large))
+
+      BeerDetailBulletSection(
+        title = stringResource(R.string.beer_detail_recommended_glasses),
+        items = beer.recommendedGlasses,
+      )
+    }
+  }
+}
+
+/** The (label, value) rows for the Details section - only the fields this [Beer] actually has. */
+@Composable
+private fun Beer.detailRows(): List<Pair<String, String>> = buildList {
+  releasedYear?.let { add(stringResource(R.string.beer_detail_released_year_label) to "$it") }
+  val minTemp = minServingTemperature
+  val maxTemp = maxServingTemperature
+  if (minTemp != null && maxTemp != null) {
+    add(
+      stringResource(R.string.beer_detail_serving_temperature_label) to
+        stringResource(R.string.beer_detail_serving_temperature_value, minTemp, maxTemp)
+    )
+  }
+  if (fermentationMethod.isNotEmpty()) {
+    add(stringResource(R.string.beer_detail_fermentation_method_label) to fermentationMethod)
+  }
+  srm?.let { add(stringResource(R.string.beer_detail_srm_label) to "$it") }
+}
+
+/**
+ * A titled bullet list, hidden entirely when [items] is empty - the Food Pairing pattern reused for
+ * Ingredients and Recommended Glasses.
+ */
+@Composable
+private fun BeerDetailBulletSection(title: String, items: List<String>) {
+  if (items.isEmpty()) return
+  Text(
+    text = title,
+    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+  )
+  Spacer(
+    modifier =
+      Modifier.height(BillionBeersTheme.spacing.medium - BillionBeersTheme.spacing.extraSmall)
+  )
+  items.forEach { item ->
+    Row(modifier = Modifier.padding(vertical = BillionBeersTheme.spacing.extraSmall)) {
+      Text(
+        text = "•",
+        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+        modifier = Modifier.padding(end = BillionBeersTheme.spacing.small),
+      )
+      Text(text = item, style = MaterialTheme.typography.bodyLarge)
     }
   }
 }
@@ -280,6 +365,36 @@ fun ComposeBeerDetailPreview() {
           ibu = 60.0,
           foodPairing =
             listOf("Spicy chicken tikka masala", "Grilled chicken quesadilla", "Pastrami on rye"),
+          styleName = "IPA (Indian Pale Ale)",
+          breweryName = "ChuckleCraft Brewery",
+          srm = 9,
+          releasedYear = 1980,
+          minServingTemperature = 4,
+          maxServingTemperature = 8,
+          fermentationMethod = "Ale",
+          ingredients = listOf("Pale malt", "Cascade hops", "American ale yeast"),
+          recommendedGlasses = listOf("Pint glass", "Tulip"),
+        ),
+      onBackClick = {},
+      onToggleAvailability = {},
+    )
+  }
+}
+
+// A beer fetched before Phase 4 (or a legacy cache row post-migration): the Details/Ingredients/
+// Glasses sections must not render at all, not render with blanks.
+@PreviewLightDark
+@Composable
+fun ComposeBeerDetailWithoutEnrichedFieldsPreview() {
+  BillionBeersTheme {
+    ComposeBeerDetail(
+      beer =
+        Beer.empty.copy(
+          name = "Buzz",
+          tagline = "A Real Bitter Experience.",
+          description = "A light, crisp and bitter IPA.",
+          abv = 4.5,
+          ibu = 60.0,
         ),
       onBackClick = {},
       onToggleAvailability = {},

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailPreview]_composebeerdetailpreview.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailPreview]_composebeerdetailpreview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6a3556391cc7d969fca02adb8fb3064426093916b1fb6a4f7967b2043fbaba79
-size 69162
+oid sha256:dcdb9fe0f36e01f25edeac1683bd25ed9258c709ec3a82fac38305bc9e497cdb
+size 78134

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailWithoutEnrichedFieldsPreview]_composebeerdetailwithoutenrichedfieldspreview.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailWithoutEnrichedFieldsPreview]_composebeerdetailwithoutenrichedfieldspreview.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:987d9be29be53a53e0ac2c743c5833f1f25035a5535b68b3bc4bdb47240e5500
+size 48108

--- a/presentation_utils/src/main/res/values-es/strings.xml
+++ b/presentation_utils/src/main/res/values-es/strings.xml
@@ -37,4 +37,13 @@
     <string name="browse_beers_count">%1$d cervezas</string>
     <string name="browse_beers_end_of_list">Eso es todo: %1$d cervezas</string>
     <string name="browse_no_beers">Aún no hay cervezas aquí</string>
+    <string name="beer_detail_style_and_brewery">%1$s · %2$s</string>
+    <string name="beer_detail_details">Detalles</string>
+    <string name="beer_detail_srm_label">SRM</string>
+    <string name="beer_detail_released_year_label">Lanzamiento</string>
+    <string name="beer_detail_serving_temperature_label">Temperatura de servicio</string>
+    <string name="beer_detail_serving_temperature_value">%1$d–%2$d°C</string>
+    <string name="beer_detail_fermentation_method_label">Fermentación</string>
+    <string name="beer_detail_ingredients">Ingredientes</string>
+    <string name="beer_detail_recommended_glasses">Copas recomendadas</string>
 </resources>

--- a/presentation_utils/src/main/res/values-fr/strings.xml
+++ b/presentation_utils/src/main/res/values-fr/strings.xml
@@ -37,4 +37,13 @@
     <string name="browse_beers_count">%1$d bières</string>
     <string name="browse_beers_end_of_list">C\'est tout : %1$d bières</string>
     <string name="browse_no_beers">Pas encore de bières ici</string>
+    <string name="beer_detail_style_and_brewery">%1$s · %2$s</string>
+    <string name="beer_detail_details">Détails</string>
+    <string name="beer_detail_srm_label">SRM</string>
+    <string name="beer_detail_released_year_label">Sortie</string>
+    <string name="beer_detail_serving_temperature_label">Température de service</string>
+    <string name="beer_detail_serving_temperature_value">%1$d–%2$d°C</string>
+    <string name="beer_detail_fermentation_method_label">Fermentation</string>
+    <string name="beer_detail_ingredients">Ingrédients</string>
+    <string name="beer_detail_recommended_glasses">Verres recommandés</string>
 </resources>

--- a/presentation_utils/src/main/res/values/strings.xml
+++ b/presentation_utils/src/main/res/values/strings.xml
@@ -37,4 +37,13 @@
     <string name="browse_beers_count">%1$d beers</string>
     <string name="browse_beers_end_of_list">That\'s all %1$d beers</string>
     <string name="browse_no_beers">No beers here yet</string>
+    <string name="beer_detail_style_and_brewery">%1$s · %2$s</string>
+    <string name="beer_detail_details">Details</string>
+    <string name="beer_detail_srm_label">SRM</string>
+    <string name="beer_detail_released_year_label">Released</string>
+    <string name="beer_detail_serving_temperature_label">Serving temperature</string>
+    <string name="beer_detail_serving_temperature_value">%1$d–%2$d°C</string>
+    <string name="beer_detail_fermentation_method_label">Fermentation</string>
+    <string name="beer_detail_ingredients">Ingredients</string>
+    <string name="beer_detail_recommended_glasses">Recommended Glasses</string>
 </resources>


### PR DESCRIPTION
Final Phase 4 PR: the detail screen renders style, brewery, SRM, released year, serving temperature, fermentation method, ingredients and recommended glasses — all §2's embedded-field audit found in the list response and nothing has used until now.

- **`Beer` gains 9 detail fields**, all defaulted so a `Beer` serialized before this PR (a nav key or `SavedStateHandle` value surviving an app update) still decodes.
- **No by-id fetch added.** The list response already embeds everything the detail screen renders — the same reasoning Phase 3 applied to browse ("no machinery without a customer"). Detail stays SSOT: DB row first, refreshed by the catalog's normal upsert.
- **Room v2→v3**, the project's second migration: purely additive columns on `beers`, SQL `defaultValue`s mirroring `BeerDbModel`'s Kotlin defaults exactly so a migrated row and a freshly-upserted row agree. `debug` keeps `fallbackToDestructiveMigration`; this is the real, tested path for release upgrades.
- **Mapper:** `typology`/`brewery` names are language-neutral (used as-is); ingredients/glasses/fermentation-method are embedded objects whose *display name* lives in per-language translations — a new `NamedEntity.localizedName()` helper applies the same three-tier fallback (current language → `en` → first available) the slogan/description lookup already uses.
- **UI degrades gracefully, never shows blanks:** each Details row and the Ingredients/Recommended-Glasses sections render only when their field is present, so a legacy/pre-Phase-4 cached row (or a beer whose migration just backfilled empty defaults) shows fewer rows instead of empty ones — pinned by a new `ComposeBeerDetailWithoutEnrichedFieldsPreview` golden.
- **Stale-fixture fix along the way:** `fake_json_response.json` (a pre-brewbuddy.dev, punkapi-format fixture used only for header/query-param tests) had an `ingredients` object left over from the old API shape, incompatible with the new `List<NamedEntity>?` field and failing `BeersRemoteSourceTest` with a decode error. Nulled it to match the fixture's own already-stale state (its `typology`/`brewery` keys don't exist either).

Tests: mapper tests for the full mapping and the language-fallback chain, a `fromBeerToBeerDbModel`/back round-trip, the v2→v3 migration test (schema-validated, existing rows + availability survive, new columns carry their SQL defaults), two beerdetail screenshot goldens (fully enriched / gracefully degraded). `make test`, `lint`, `konsist`, `screenshot-verify` and the beer_database + app instrumented suites (6 + 14) all green. Emulator-verified end to end against the live API on a fresh install: style/brewery line, full Details section, Ingredients and Recommended Glasses all populate correctly on The Godfather.

This is the last PR in the Paging 2.0 plan (`rod/PAGING_2_0.md`) — Phases 0 through 4 are now complete.