### PR TITLE
feat: run instrumented tests on Gradle Managed Devices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,38 +183,51 @@ jobs:
           name: screenshot-test-reports
           path: '**/build/reports/paparazzi/'
 
-#   # UI test setup using Flank / Firebase Test Lab (Commented out until Firebase credentials & project setup are completed)
-#   # ui-tests:
-#   #   name: UI Tests via Flank
-#   #   needs: format-check
-#   #   runs-on: ubuntu-latest
-#   #   steps:
-#   #     - name: Checkout code
-#   #       uses: actions/checkout@v7
-#   #
-#   #     - name: Set up JDK 23
-#   #       uses: actions/setup-java@v5
-#   #       with:
-#   #         java-version: '23'
-#   #         distribution: 'temurin'
-#   #
-#   #     - name: Setup Gradle
-#   #       uses: gradle/actions/setup-gradle@v6
-#   #       with:
-#   #         gradle-version: wrapper
-#   #
-#   #     - name: Authenticate to Google Cloud
-#   #       uses: google-github-actions/auth@v2
-#   #       with:
-#   #         credentials_json: ${{ secrets.GCP_SA_KEY }}
-#   #
-#   #     - name: Setup Google Cloud SDK
-#   #       uses: google-github-actions/setup-gcloud@v2
-#   #
-#   #     - name: Build debug APK & AndroidTest APK
-#   #       run: ./gradlew :app:assembleDebug :app:assembleDebugAndroidTest
-#   #
-#   #     - name: Run UI Tests with Flank
-#   #       run: |
-#   #         wget -q https://github.com/Flank/flank/releases/latest/download/flank.jar -O flank.jar
-#   #         java -jar flank.jar android run
+  # Instrumented tests on a Gradle Managed Device. Replaces the previous Flank / Firebase Test
+  # Lab job, which never ran because it needed GCP credentials that were never set up. GMD runs
+  # the emulator on the runner itself via KVM - free, no cloud account, and the device spec lives
+  # in build-logic so CI and local runs are identical. Firebase Test Lab remains the right answer
+  # only for a *physical* device matrix, which this project does not need.
+  instrumented-tests:
+    name: Instrumented Tests (Gradle Managed Device)
+    needs: format-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Enable KVM
+        # GitHub's Linux runners support nested virtualization, but the device node is not
+        # writable by default. Without this the emulator falls back to software rendering and
+        # takes many minutes (or times out).
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Run instrumented tests on the managed devices
+        # The `ci` device group: the API 35 ATD fast lane plus the API 37 forward-compat lane.
+        # Which devices that means is defined in build-logic, not here.
+        run: ./gradlew ciGroupDebugAndroidTest
+
+      - name: Archive instrumented test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: instrumented-test-reports
+          path: '**/build/reports/androidTests/managedDevice/'

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,17 @@ endif
 konsist: ## Run Konsist architecture rules.
 	$(GRADLE_RUNNER) :konsist:test
 
-ui-test: ## Run connected Android tests (UI tests).
+ui-test: ## Run connected Android tests (UI tests) on an already-running device/emulator.
 	$(GRADLE_RUNNER) $(UI_TEST_PREFIX)connectedDebugAndroidTest
+
+ui-test-managed: ## Run instrumented tests on the ATD fast-lane managed device (boots/tears down its own emulator).
+	$(GRADLE_RUNNER) $(UI_TEST_PREFIX)atdApi35DebugAndroidTest
+
+ui-test-managed-newest: ## Run instrumented tests on the API 37 managed device (forward-compat lane).
+	$(GRADLE_RUNNER) $(UI_TEST_PREFIX)pixel9Api37DebugAndroidTest
+
+ui-test-managed-all: ## Run instrumented tests on both managed devices, every opted-in module (what CI runs).
+	$(GRADLE_RUNNER) ciGroupDebugAndroidTest
 
 # Screenshots (Paparazzi)
 screenshot-record: ## Record golden images for Paparazzi.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("billionbeers.android.application")
   id("billionbeers.android.compose")
   id("billionbeers.android.metro")
+  id("billionbeers.android.managed.device")
 
   id("billionbeers.duplicate-classes")
   id("billionbeers.unused-dependencies")

--- a/beer_database/build.gradle.kts
+++ b/beer_database/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("billionbeers.android.library")
   id("billionbeers.room")
   id("billionbeers.android.metro")
+  id("billionbeers.android.managed.device")
 }
 
 android {

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
@@ -1,0 +1,76 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.DynamicFeatureExtension
+import com.android.build.api.dsl.LibraryExtension
+import com.android.build.api.dsl.ManagedDevices
+import com.android.build.api.dsl.ManagedVirtualDevice
+
+/**
+ * Gradle Managed Devices: the test emulator is declared in the build, so Gradle provisions, boots,
+ * runs and tears it down. The same device spec runs locally and in CI, with no hand-started AVD.
+ *
+ * Two devices, deliberately:
+ *
+ * - **`atdApi35`** - the fast lane. ATD (Automated Test Device) images are headless and stripped
+ *   of most system apps, so they boot faster and use far less RAM than a full image. API 35 is the
+ *   *highest* level Google publishes ATD images for, so this is as new as the fast lane can get.
+ * - **`pixel9Api37`** - the newest lane, one API above the project's `targetSdk` (36), which is
+ *   what makes it forward-compatibility coverage rather than a duplicate of the fast lane. There
+ *   are no ATD images for 37, so this one pays full price.
+ *
+ *     ./gradlew :app:atdApi35DebugAndroidTest       # one device, one module
+ *     ./gradlew :app:ciGroupDebugAndroidTest        # both devices, one module
+ *     ./gradlew ciGroupDebugAndroidTest             # both devices, every opted-in module (CI)
+ *     ./gradlew allDevicesDebugAndroidTest          # every device, every opted-in module
+ *
+ * Opt in per module (`id("billionbeers.android.managed.device")`) rather than applying this from
+ * the shared convention - only modules with an `androidTest` source set have anything to run, and
+ * applying it everywhere would generate dead tasks in every module.
+ */
+fun ManagedDevices.configureBillionBeersDevices() {
+    // Task names derive from the device names: `atdApi35DebugAndroidTest`, `atdApi35Setup`, ...
+    val fastLane = localDevices.create("atdApi35") {
+        device = "Pixel 6"
+        sdkVersion = 35
+        // google_atd, not aosp_atd: the app depends on Play Core (SplitInstall) and needs the
+        // Google APIs present. ATD images have Google APIs but no Play Store - fine here, since
+        // dynamic features are staged by bundletool local-testing rather than fetched from Play.
+        systemImageSource = "google_atd"
+    }
+
+    val newest = localDevices.create("pixel9Api37") {
+        device = "Pixel 9"
+        sdkVersion = 37
+        // API 37 ships only google_apis / google_apis_playstore - there are no ATD images and no
+        // aosp images for it yet. Use google_apis: playstore images are not debuggable, so
+        // instrumented tests cannot run on them.
+        systemImageSource = "google_apis"
+        // Required, not cosmetic. Every API 37 image is 16 KB-page (`..._ps16k`), but AGP 9.2.1
+        // cannot yet infer that from sdkVersion 37 and would resolve a 4 KB image that does not
+        // exist. Forcing the alignment is what makes the device resolvable at all.
+        // Revisit when AGP learns API 37's page size - the config-time warning will disappear.
+        pageAlignment = ManagedVirtualDevice.PageAlignment.FORCE_16KB_PAGES
+    }
+
+    // The set CI runs. Kept as an explicit group so the CI job never has to name devices - if the
+    // lanes change, they change here and the workflow is untouched.
+    groups.create("ci") {
+        targetDevices.add(fastLane)
+        targetDevices.add(newest)
+    }
+}
+
+pluginManager.withPlugin("com.android.application") {
+    extensions.configure<ApplicationExtension> {
+        testOptions.managedDevices.configureBillionBeersDevices()
+    }
+}
+pluginManager.withPlugin("com.android.library") {
+    extensions.configure<LibraryExtension> {
+        testOptions.managedDevices.configureBillionBeersDevices()
+    }
+}
+pluginManager.withPlugin("com.android.dynamic-feature") {
+    extensions.configure<DynamicFeatureExtension> {
+        testOptions.managedDevices.configureBillionBeersDevices()
+    }
+}


### PR DESCRIPTION
Instrumented tests now run in CI. They previously did not: the workflow had a commented-out Flank / Firebase Test Lab job waiting on GCP credentials that were never set up.

Gradle Managed Devices boots the emulator on the GitHub runner itself via KVM — free, no cloud account — and the device spec lives in `build-logic`, so CI and local runs use the same devices instead of duplicating config. Firebase Test Lab stays the right answer only for a matrix of *physical* devices, which this project doesn't need.

## Two lanes, in a `ci` device group

| Device | Why |
|---|---|
| `atdApi35` | Fast lane. ATD images are headless and stripped of most system apps, so they boot faster and use less RAM. **API 35 is the highest level Google publishes ATD images for.** Uses `google_atd` rather than `aosp_atd` because the app depends on Play Core. |
| `pixel9Api37` | One API above `targetSdk` (36) — that's what makes it forward-compatibility coverage rather than a second copy of the fast lane. No ATD images exist for 37, so it pays full price. |

CI runs `ciGroupDebugAndroidTest`, so the workflow never names devices: change the lanes in `build-logic` and the workflow is untouched.

## One non-obvious bit

`pixel9Api37` needs `pageAlignment = FORCE_16KB_PAGES`. Every API 37 image is 16 KB-page (`..._ps16k`), but AGP 9.2.1 can't infer that from the sdk version — it warns that it will resolve a 4 KB image instead, and no such image exists for 37. Forcing the alignment is what makes the device resolvable at all. Commented in place with a note to drop it once AGP knows API 37's page size.

## Opt-in, not blanket

Modules apply the plugin id explicitly rather than getting it from the shared convention. Only `:app` and `:beer_database` have `androidTest` sources; applying it everywhere would generate dead device tasks in every module. `:benchmark:*` is deliberately excluded — benchmarks on an emulator are noise.

## Verified locally

Both devices, both modules: 14 tests on `:app`, 6 Room migration tests on `:beer_database`, all green. `make test`, `make konsist`, `make lint` pass.

New Makefile targets: `ui-test-managed` (fast lane), `ui-test-managed-newest` (API 37), `ui-test-managed-all` (what CI runs).

**The point of this PR is to see the job actually run on a GitHub runner** — local passes prove the config, not the CI environment.