### PR TITLE
chore: split the managed-device lanes and cache system images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,9 +220,20 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
+      - name: Cache Android system images
+        # Downloading the emulator + system image cost ~2m45s on the first run. Keyed on the
+        # device definitions, so changing a device invalidates the cache instead of serving a
+        # stale image. AVD snapshots are deliberately NOT cached - they are flaky across emulator
+        # versions, and boot time is not reliably cacheable anyway.
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/lib/android/sdk/system-images
+          key: android-system-images-${{ hashFiles('build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts') }}
+
       - name: Run instrumented tests on the managed devices
-        # The `ci` device group: the API 35 ATD fast lane plus the API 37 forward-compat lane.
-        # Which devices that means is defined in build-logic, not here.
+        # The `ci` group is the ATD fast lane. The slower API 37 lane is the `compat` group and
+        # runs weekly (.github/workflows/weekly-compat.yml). Which devices those mean is defined
+        # in build-logic, not here.
         run: ./gradlew ciGroupDebugAndroidTest
 
       - name: Archive instrumented test reports

--- a/.github/workflows/weekly-compat.yml
+++ b/.github/workflows/weekly-compat.yml
@@ -1,0 +1,91 @@
+name: Weekly Forward-Compat Tests
+
+# Instrumented tests on the newest device lane (API 37, one above targetSdk). Kept off the
+# per-push path because its full system image takes ~2m28s just to boot, against ~30s for the
+# API 35 ATD fast lane that every push already runs.
+#
+# Known limitation: skipping the run when nothing merged means a forward-compat break caused by
+# a new emulator/system image alone - with no repo change - is not caught until the next merge.
+# Accepted deliberately; use "Run workflow" to force a run any time.
+
+on:
+  schedule:
+    # 06:00 UTC every Saturday.
+    - cron: '0 6 * * 6'
+  workflow_dispatch:
+
+jobs:
+  gate:
+    name: Check for merges since the last run
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Check for commits in the last week
+        id: check
+        # The schedule is weekly, so "commits in the last 7 days" is exactly "merged since the
+        # last scheduled run". Queried through the API rather than `git log` on purpose: a
+        # checkout defaults to depth 1, which would make the window silently always-empty.
+        run: |
+          SINCE=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          COUNT=$(gh api "repos/${{ github.repository }}/commits?sha=master&since=$SINCE" --jq 'length')
+          echo "Commits on master since $SINCE: $COUNT"
+          if [ "$COUNT" -gt 0 ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "Nothing merged in the last week - skipping the compat run."
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  compat-tests:
+    name: Instrumented Tests (API 37 forward-compat)
+    needs: gate
+    # A manual dispatch always runs; the gate only suppresses the cron.
+    if: needs.gate.outputs.run == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Enable KVM
+        # GitHub's Linux runners support nested virtualization, but the device node is not
+        # writable by default. Without this the emulator falls back to software rendering and
+        # takes many minutes (or times out).
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v5
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: wrapper
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Cache Android system images
+        uses: actions/cache@v4
+        with:
+          path: /usr/local/lib/android/sdk/system-images
+          key: android-system-images-${{ hashFiles('build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts') }}
+
+      - name: Run forward-compat instrumented tests
+        # The `compat` device group - defined in build-logic, not named here.
+        run: ./gradlew compatGroupDebugAndroidTest
+
+      - name: Archive instrumented test reports
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: compat-test-reports
+          path: '**/build/reports/androidTests/managedDevice/'

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,11 @@ ui-test-managed: ## Run instrumented tests on the ATD fast-lane managed device (
 ui-test-managed-newest: ## Run instrumented tests on the API 37 managed device (forward-compat lane).
 	$(GRADLE_RUNNER) $(UI_TEST_PREFIX)pixel9Api37DebugAndroidTest
 
-ui-test-managed-all: ## Run instrumented tests on both managed devices, every opted-in module (what CI runs).
+ui-test-managed-ci: ## Run what CI runs per push: the ATD fast lane, every opted-in module.
 	$(GRADLE_RUNNER) ciGroupDebugAndroidTest
+
+ui-test-managed-all: ## Run instrumented tests on both managed devices, every opted-in module.
+	$(GRADLE_RUNNER) allDevicesDebugAndroidTest
 
 # Screenshots (Paparazzi)
 screenshot-record: ## Record golden images for Paparazzi.

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
@@ -17,9 +17,12 @@ import com.android.build.api.dsl.ManagedVirtualDevice
  *   what makes it forward-compatibility coverage rather than a duplicate of the fast lane. There
  *   are no ATD images for 37, so this one pays full price.
  *
+ * The fast lane runs on every push; the newest lane runs weekly, because booting its full image
+ * costs ~2m28s against the ATD's ~30s.
+ *
  *     ./gradlew :app:atdApi35DebugAndroidTest       # one device, one module
- *     ./gradlew :app:ciGroupDebugAndroidTest        # both devices, one module
- *     ./gradlew ciGroupDebugAndroidTest             # both devices, every opted-in module (CI)
+ *     ./gradlew ciGroupDebugAndroidTest             # fast lane, every opted-in module (per push)
+ *     ./gradlew compatGroupDebugAndroidTest         # newest lane, every opted-in module (weekly)
  *     ./gradlew allDevicesDebugAndroidTest          # every device, every opted-in module
  *
  * Opt in per module (`id("billionbeers.android.managed.device")`) rather than applying this from
@@ -51,10 +54,18 @@ fun ManagedDevices.configureBillionBeersDevices() {
         pageAlignment = ManagedVirtualDevice.PageAlignment.FORCE_16KB_PAGES
     }
 
-    // The set CI runs. Kept as an explicit group so the CI job never has to name devices - if the
-    // lanes change, they change here and the workflow is untouched.
+    // Groups exist so the workflows never name devices: lanes change here, CI stays untouched.
+    // Both are currently groups of one, which is deliberate - it keeps that indirection while the
+    // split is "fast lane on every push, slow lane weekly".
+
+    // Every push and PR. Measured on a GitHub runner: ~1m for both modules.
     groups.create("ci") {
         targetDevices.add(fastLane)
+    }
+
+    // Weekly only (.github/workflows/weekly-compat.yml). Measured at ~3m45s, of which 2m28s is
+    // just booting the full image - which is why it is not on the per-push path.
+    groups.create("compat") {
         targetDevices.add(newest)
     }
 }


### PR DESCRIPTION
Follow-up to #85. The instrumented job took **9m20s on every push**. Measured from that run's log:

| Phase | Time |
|---|---|
| Emulator + system image downloads | ~2m45s |
| API 35 ATD lane (both modules) | ~1m |
| API 37 lane (both modules) | ~3m45s — of which **2m28s is just booting** the full non-ATD image |

The ATD images are doing exactly what they promise: ~30s to boot versus ~2m28s. So the expensive lane moves off the per-push path, and the downloads get cached.

## Changes

- **`ci` group is now the ATD fast lane alone.** Every push pays ~1m of device time instead of ~4m45s. `ci.yml` still invokes `ciGroupDebugAndroidTest` — unchanged — which is the payoff of having the workflow name groups rather than devices.
- **New `compat` group** holds the API 37 lane, run by `weekly-compat.yml` on Saturdays at 06:00 UTC, plus manual dispatch.
- **Weekly run is skipped when nothing merged** in the preceding week. Since the schedule is weekly, a 7-day window is exactly "merged since the last scheduled run". Queried via the API rather than `git log`, because `actions/checkout` defaults to `fetch-depth: 1` and a `git log --since` check would silently see one commit forever. Verified both directions against the real repo: a 7-day window returns 30 commits, a future window returns 0.
- **Manual dispatch always runs**, gate or not — so a human re-run can never be suppressed, and the job is testable without waiting for Saturday.
- **System images cached**, keyed on the device-definition file so changing a device invalidates rather than serving a stale image. AVD snapshots deliberately *not* cached: flaky across emulator versions, and boot time isn't reliably cacheable anyway.

## Known limitation

Skipping the weekly run when nothing merged slightly cuts against the job's purpose — a forward-compat break caused by a new system image alone, with no repo change, won't be noticed until the next merge. Accepted deliberately for the cost saving; manual dispatch covers it.

## Verification

Group membership confirmed via `--dry-run`: `ci` resolves to `atdApi35` only, `compat` to `pixel9Api37` only, both across `:app` and `:beer_database`. `make test`, `make konsist`, `make lint` and the ATD lane all pass locally.

Two things can only be proven on GitHub, and are what to watch after merge: the cache actually restoring on a second run, and the instrumented job dropping to ~3m.