### PR TITLE
Enforce dynamic-feature resource and dev-app dependency invariants

### DIFF
--- a/feature/beerdetail/src/main/res/values-es/strings.xml
+++ b/feature/beerdetail/src/main/res/values-es/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="beer_detail">Detalle de la cerveza</string>
-</resources>

--- a/feature/beerdetail/src/main/res/values-fr/strings.xml
+++ b/feature/beerdetail/src/main/res/values-fr/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="beer_detail">Détail de la bière</string>
-</resources>

--- a/feature/beerdetail/src/main/res/values/strings.xml
+++ b/feature/beerdetail/src/main/res/values/strings.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <string name="beer_detail">Beer Detail</string>
-</resources>

--- a/konsist/src/test/kotlin/com/simtop/konsist/DevAppDependencyBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/DevAppDependencyBoundaryTest.kt
@@ -1,0 +1,56 @@
+package com.simtop.konsist
+
+import java.io.File
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * A dev-app (app-dev-<feature>) exists to build one feature in seconds instead of minutes: it
+ * binds the feature under development to :beerdomain:fakes instead of the real data layer, so the
+ * heavy :beer_data / :beer_database / :beer_network graph (Room, Retrofit, OkHttp) never enters
+ * its compilation. The moment a dev-app declares a dependency on a data-layer module, that
+ * guarantee is gone and the dev-app is just a slower copy of :app.
+ *
+ * The invariant lives in build.gradle.kts, not in Kotlin source, and Konsist's project scope does
+ * not surface build scripts (they are excluded, and .kts is not scanned at all), so this rule
+ * reads the dev-app build files directly. It matches the full project("...") call form on purpose:
+ * a bare ":beer_data" would also match the explanatory comment in the build file and fail correct
+ * code.
+ */
+class DevAppDependencyBoundaryTest {
+
+  private val forbiddenDataLayerModules = listOf(":beer_data", ":beer_database", ":beer_network")
+
+  @Test
+  fun `dev-apps do not depend on data-layer modules`() {
+    val root = repoRoot()
+    val devAppBuildScripts =
+      root
+        .listFiles { file -> file.isDirectory && file.name.startsWith("app-dev-") }
+        .orEmpty()
+        .map { File(it, "build.gradle.kts") }
+        .filter { it.exists() }
+
+    assertTrue(devAppBuildScripts.isNotEmpty()) {
+      "No app-dev-*/build.gradle.kts found under $root - the dev-app layout changed and this rule " +
+        "would pass vacuously"
+    }
+
+    devAppBuildScripts.forEach { script ->
+      val text = script.readText()
+      val violations =
+        forbiddenDataLayerModules.filter { module -> text.contains("project(\"$module\")") }
+      assertTrue(violations.isEmpty()) {
+        "${script.parentFile.name} depends on data-layer module(s) $violations - dev-apps must use " +
+          ":beerdomain:fakes, not the real data layer, to keep their build fast"
+      }
+    }
+  }
+
+  /** Walks up from the test working directory (the :konsist module) to the Gradle root. */
+  private fun repoRoot(): File {
+    var dir: File? = File(System.getProperty("user.dir"))
+    while (dir != null && !File(dir, "settings.gradle.kts").exists()) dir = dir.parentFile
+    return dir ?: error("Could not locate Gradle root (no settings.gradle.kts above user.dir)")
+  }
+}

--- a/konsist/src/test/kotlin/com/simtop/konsist/DynamicFeatureResourceBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/DynamicFeatureResourceBoundaryTest.kt
@@ -1,0 +1,45 @@
+package com.simtop.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.verify.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Dynamic-feature modules (feature/beerdetail, feature/beerbrowse) ship as on-demand split APKs.
+ * A user-facing string declared in the split's *own* package compiles fine but crashes at runtime
+ * under an instrumented test, because a split's resource table is not merged into the resolving
+ * context the way an installed base module's is - this has already bitten twice. The invariant:
+ * every string a dynamic feature renders lives in :presentation_utils (a base module) and is
+ * referenced through com.simtop.presentation_utils.R, never the feature's own R.
+ *
+ * The crash path is a *reference* to a split-owned resource, so that is what this rule catches: a
+ * dynamic-feature file importing its own module R. It does not (and cannot, being Kotlin-only)
+ * police a stray strings.xml that nothing references - a dead resource is harmless; a reference to
+ * one is the failure.
+ */
+class DynamicFeatureResourceBoundaryTest {
+
+  private val dynamicFeaturePackages =
+    listOf("com.simtop.feature.beerdetail", "com.simtop.feature.beerbrowse")
+
+  @Test
+  fun `dynamic-feature code references resources through presentation_utils, not its own R`() {
+    dynamicFeaturePackages.forEach { featurePackage ->
+      val files =
+        Konsist.scopeFromProject()
+          .files
+          .filter { it.packagee?.name?.startsWith(featurePackage) == true }
+
+      assertTrue(files.isNotEmpty()) {
+        "No files scoped for $featurePackage - the package filter no longer matches this module"
+      }
+
+      files.assertFalse { file ->
+        file.hasImport { import ->
+          import.name == "$featurePackage.R" || import.name.startsWith("$featurePackage.R.")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Two architecture invariants that lived only in docs and memory are now enforced by the `:konsist` suite (`make konsist`).

## `DynamicFeatureResourceBoundaryTest`
Dynamic-feature modules (`feature/beerdetail`, `feature/beerbrowse`) may not import their own module `R`. User-facing strings must come from `:presentation_utils` — a reference to a split-owned resource throws `Resources$NotFoundException` at runtime in instrumented tests (has bitten twice). Encoded as an import rule because that reference is the crash path; Konsist is Kotlin-only and can't police a stray XML file.

## `DevAppDependencyBoundaryTest`
`app-dev-*` build files may not depend on the data layer (`:beer_data`/`:beer_database`/`:beer_network`) — that exclusion is the dev-app's "seconds not minutes" build guarantee. Konsist's scope excludes `.kts` entirely, so this reads the build files via `File` (still inside the konsist suite). Matches the full `project("...")` call form so the explanatory build-file comment can't false-positive.

Both rules carry a non-empty-scope guard so neither can pass vacuously, and both were proven to go red on a real violation before landing.

Also removes the stale, unreferenced `beer_detail` `strings.xml` (values/fr/es) from `feature/beerdetail` — already canonical in `:presentation_utils`, with no manifest or XML reference depending on it.