### PR TITLE
Fix GMD instrumented-tests lane: remove system-image cache that broke device setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,15 +220,12 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      - name: Cache Android system images
-        # Downloading the emulator + system image cost ~2m45s on the first run. Keyed on the
-        # device definitions, so changing a device invalidates the cache instead of serving a
-        # stale image. AVD snapshots are deliberately NOT cached - they are flaky across emulator
-        # versions, and boot time is not reliably cacheable anyway.
-        uses: actions/cache@v4
-        with:
-          path: /usr/local/lib/android/sdk/system-images
-          key: android-system-images-${{ hashFiles('build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts') }}
+      # A `system-images` cache was removed here on purpose. Restoring a partial system-image cache
+      # breaks Gradle Managed Devices' `atdApi35Setup` (device provisioning) task: every CI run
+      # with a cache *miss* (fresh sdkmanager download) passed, and every run with a cache *hit*
+      # failed at setup. GMD now downloads the image each run (~2m45s). Do NOT re-add a bare
+      # `system-images` cache - a correct re-introduction has to capture the whole SDK/AVD state
+      # (licenses + package registry + the created AVD), and must be proven on a live CI run.
 
       - name: Run instrumented tests on the managed devices
         # The `ci` group is the ATD fast lane. The slower API 37 lane is the `compat` group and

--- a/.github/workflows/weekly-compat.yml
+++ b/.github/workflows/weekly-compat.yml
@@ -73,11 +73,11 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      - name: Cache Android system images
-        uses: actions/cache@v4
-        with:
-          path: /usr/local/lib/android/sdk/system-images
-          key: android-system-images-${{ hashFiles('build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts') }}
+      # Removed precautionarily alongside the same cache in ci.yml: a restored partial
+      # `system-images` cache breaks GMD device setup there. This lane has only ever run once (a
+      # cache miss, which passed), so it never hit the bug - but it uses the identical cache
+      # mechanism and key, so the next weekly run would have been the first cache hit. See ci.yml
+      # for the full rationale and the conditions for a correct re-introduction.
 
       - name: Run forward-compat instrumented tests
         # The `compat` device group - defined in build-logic, not named here.


### PR DESCRIPTION
## The bug
CI's instrumented-tests lane has been **red on `master` since 2026-07-20 21:53**. It is not a test failure — it fails at `:app:atdApi35Setup`, Gradle Managed Devices' *device-provisioning* task, before any test runs.

## Root cause (from the run history, not a guess)
The job flipped mid-evening on 07-20. Correlating the runs:
- **4 runs that passed** all logged `Cache not found ... android-system-images` → **cache miss** → fresh `sdkmanager` download.
- **every run after** logs `Cache hit ... android-system-images` → **cache hit** → restored image → setup fails.

The failing runs do zero license/install work and die on `Cannot query the value of this property because it has no value available` inside `ManagedDeviceSetupRunnable`: the restored image dir makes AGP skip installation, but the SDK package registry (not in the cache) has no record of the package, so a provider the setup task queries is unset. The system-image cache was added in #86; it survived its own PR run (a cache miss) and has poisoned every run since.

## The fix
Remove the `Cache Android system images` step. This **reverts CI to the exact no-cache condition that was proven green four times on the same x86_64 runner** — the same path local instrumented runs already take (they never touch the Actions cache). Also removed from `weekly-compat.yml`: same mechanism and key, one eviction cycle away from the same failure (see correction below).

Cost: GMD re-downloads the image each run (~2m45s), as it did on every green run. A guard comment documents why a bare `system-images` cache must not be re-added; a correct re-introduction (full SDK/AVD state) is a follow-up that needs a live CI run to validate.

## Validation
**Confirmed live post-merge: the first `master` run after this change is fully green, including the instrumented-tests job** ([run 30030957541](https://github.com/simtop/BillionBeers/actions/runs/30030957541), 07-23). YAML was validated on both workflows before landing.

## Post-merge correction (2026-07-23 verification pass)
This PR originally claimed weekly-compat's single run was "a passing cache **miss**". Wrong: its log shows a cache **hit** — and it still passed, because the cache held only the API 35 ATD image while that lane provisions the API 37 image, so its install path never touched the restored dir. This sharpens the root cause (the failure is specific to a device whose *own* image is restored without the registry) and replaces the removal rationale for weekly-compat: it wasn't "ahead of its first cache hit", it was one cache-eviction cycle away from caching its own image and failing identically. The in-tree comment was corrected on the follow-up branch (`feature/ci-supply-chain-hardening`).
