### PR TITLE
Correct weekly-compat cache comment and ADR 0006 action count

### DIFF
--- a/.github/workflows/weekly-compat.yml
+++ b/.github/workflows/weekly-compat.yml
@@ -73,11 +73,14 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      # Removed precautionarily alongside the same cache in ci.yml: a restored partial
-      # `system-images` cache breaks GMD device setup there. This lane has only ever run once (a
-      # cache miss, which passed), so it never hit the bug - but it uses the identical cache
-      # mechanism and key, so the next weekly run would have been the first cache hit. See ci.yml
-      # for the full rationale and the conditions for a correct re-introduction.
+      # Removed alongside the same cache in ci.yml: a restored `system-images` cache breaks GMD
+      # setup for any device whose own image is in it (the image dir is restored without the SDK
+      # package registry, and setup fails on an unset property). This lane's one run actually HIT
+      # that cache and passed - but only because the cache held the API 35 ATD image while this
+      # lane provisions the API 37 image, so its install path never saw the restored dir. That
+      # protection is one eviction cycle away from gone: a weekly run on a cache miss would save
+      # the API 37 image and the next hit would fail setup exactly like ci.yml's lane did. See
+      # ci.yml for the conditions a correct re-introduction must meet.
 
       - name: Run forward-compat instrumented tests
         # The `compat` device group - defined in build-logic, not named here.

--- a/docs/adr/0006-ci-supply-chain-hardening.md
+++ b/docs/adr/0006-ci-supply-chain-hardening.md
@@ -67,7 +67,7 @@ survives contact with this repo's existing setup:
   landing.
 - **Readability is preserved** by the `# vX` comment.
 
-Residual cost: a one-time resolution of six action SHAs. That's the whole bill.
+Residual cost: a one-time resolution of five action SHAs. That's the whole bill.
 
 ---
 
@@ -156,7 +156,7 @@ document, not to ship a control that breaks every routine update.
 
 ## Consequences
 
-- All six Actions across the five workflows (`ci`, `format_fix`, `record_screenshots`,
+- All five Actions across the five workflows (`ci`, `format_fix`, `record_screenshots`,
   `weekly-compat`, `dependabot-auto-merge`) are SHA-pinned; Dependabot keeps them fresh.
 - `ci.yml` gains a PR-only `secret-scan` job gating on `format-check`, consistent with the other
   parallel jobs.


### PR DESCRIPTION
Comment/docs-only follow-up from the verification pass over #91/#92; the correction commit was pushed to the #91 branch but the squash-merge predated it, so master carries two stale claims:

- **`weekly-compat.yml`** claimed its one run was "a passing cache **miss**". Its log shows a cache **hit** that passed only because the cache held the API 35 ATD image while this lane provisions the API 37 image — so the poison is specific to a device whose *own* image is restored without the SDK package registry, and this lane was one cache-eviction cycle away from failing identically to ci.yml's. Comment rewritten to say that.
- **ADR 0006** counts "six" pinned actions; after #92's cache-step removals dropped `actions/cache` entirely, the pinned set is **five**.

No behavior change — comments and docs only.