### PR TITLE
Compose compiler health: stability config + metrics target (5.8)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UI_TEST_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,:app:)
 # Wrapper for Gradle to support build-brief (bb) or rtk if available
 GRADLE_RUNNER := $(shell if command -v bb >/dev/null 2>&1; then echo "bb ./gradlew"; elif command -v build-brief >/dev/null 2>&1; then echo "build-brief --gradle ./gradlew"; elif command -v rtk >/dev/null 2>&1; then echo "rtk ./gradlew"; else echo "./gradlew"; fi)
 
-.PHONY: help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist ui-test screenshot-record screenshot-verify screenshot-clean lint format check check-duplicates check-unused-deps benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse new-feature-module new-dev-app
+.PHONY: help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist compose-metrics ui-test screenshot-record screenshot-verify screenshot-clean lint format check check-duplicates check-unused-deps benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse new-feature-module new-dev-app
 
 help: ## Show this help message.
 	@echo "\n📊 BillionBeers Makefile Help"
@@ -100,6 +100,13 @@ endif
 
 konsist: ## Run Konsist architecture rules.
 	$(GRADLE_RUNNER) :konsist:test
+
+compose-metrics: ## Regenerate Compose compiler stability/skippability reports into each module's build/compose_compiler.
+	# --rerun-tasks so up-to-date modules re-emit; reports are opt-in (composeCompilerReports) to
+	# keep them off the normal build. Read <module>/build/compose_compiler/*-composables.txt for
+	# non-skippable composables and *-classes.txt for unstable classes; stabilise the genuinely
+	# immutable ones via compose-stability.conf (see that file's header).
+	$(GRADLE_RUNNER) --rerun-tasks -PcomposeCompilerReports=true $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,)compileReleaseKotlin
 
 ui-test: ## Run connected Android tests (UI tests) on an already-running device/emulator.
 	$(GRADLE_RUNNER) $(UI_TEST_PREFIX)connectedDebugAndroidTest

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.compose.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.compose.gradle.kts
@@ -10,6 +10,22 @@ plugins {
 
 val libs = the<LibrariesForLibs>()
 
+composeCompiler {
+    // Classes the compiler cannot infer as stable but that we know are: see the file's header
+    // for the contract each entry must uphold. Applies to every compose module via this plugin.
+    stabilityConfigurationFiles.add(
+        rootProject.layout.projectDirectory.file("compose-stability.conf")
+    )
+
+    // Metrics (module-level JSON) + reports (per-class stability, per-composable skippability)
+    // are opt-in because they add compiler work on every build. `make compose-metrics` sets the
+    // property; output lands in <module>/build/compose_compiler/.
+    if (providers.gradleProperty("composeCompilerReports").isPresent) {
+        metricsDestination.set(layout.buildDirectory.dir("compose_compiler"))
+        reportsDestination.set(layout.buildDirectory.dir("compose_compiler"))
+    }
+}
+
 pluginManager.withPlugin("com.android.base") {
     dependencies {
         "implementation"(platform(libs.androidxComposeBom))

--- a/compose-stability.conf
+++ b/compose-stability.conf
@@ -1,0 +1,32 @@
+// Compose compiler stability configuration (wired for every compose module in
+// build-logic/convention/src/main/kotlin/billionbeers.android.compose.gradle.kts).
+//
+// Why this file exists: the composables in this app are all skippable, but many take domain and
+// UI-state params the compiler infers as *unstable*, so under strong-skipping they recompose on
+// reference inequality even when the value is unchanged. The types below are immutable in
+// practice; the compiler just can't prove it (they live in modules compiled without the Compose
+// compiler, or hold read-only collection fields). Declaring them stable restores value-equality
+// skipping. Regenerate the evidence with `make compose-metrics`.
+
+// --- Deeply immutable types -------------------------------------------------------------------
+// Genuinely, provably immutable. The domain models are pure-Kotlin data classes in :beerdomain
+// whose no-android purity is Konsist-enforced (DomainLayerPurityTest), so they can never hold a
+// mutable framework type - the compiler only flags them because of read-only List fields like
+// Beer.foodPairing, and they cannot take @Immutable without pulling androidx into the domain
+// layer. The core-common types are immutable UI-state holders in a module compiled without the
+// Compose compiler, hence unstable to consumers by default.
+com.simtop.beerdomain.domain.models.*
+com.simtop.core.core.CommonUiState
+com.simtop.core.core.CommonUiState.*
+com.simtop.core.core.PagedListUiModel
+
+// --- Read-only-by-discipline collections ------------------------------------------------------
+// kotlin.collections.List/Set/Map are unstable as *types* (the interface permits a mutable impl),
+// so this is an assertion about how the app uses them, not about the type: every collection handed
+// to composition here is an immutable snapshot (Room / network results mapped to immutable models),
+// never a builder that is later mutated. That discipline is what makes value-equality safe. If a
+// composable is ever passed a list that is mutated in place, remove these and migrate the offending
+// path to kotlinx.collections.immutable instead of weakening the invariant.
+kotlin.collections.List
+kotlin.collections.Set
+kotlin.collections.Map


### PR DESCRIPTION
Third base-ratchet PR (`5.4 ✅ → 5.8 (this) → 5.6 Lint → japicmp`).

## What it adds
- **`make compose-metrics`** — regenerates Compose stability/skippability reports into each module's `build/compose_compiler/`. Reports are opt-in (`-PcomposeCompilerReports`), wired into the shared compose convention plugin, so normal builds are unaffected.
- **`compose-stability.conf`** — a stability configuration file, applied to every compose module via the same plugin.

## What the reports showed, and the fix
All **66 restartable composables were already skippable** — the codebase is clean at the composable level. But 19 composable params were inferred **unstable** (so under strong-skipping they recompose on reference inequality even when the value is unchanged):
- **Domain models** `Beer`/`Brewery`/`BeerStyle` — unstable only because of read-only `List` fields (e.g. `Beer.foodPairing`). They're pure-Kotlin `:beerdomain` with **Konsist-enforced no-android purity**, so they *cannot* take `@Immutable` without breaking that boundary. The config declares them stable instead.
- **UI-state holders** `CommonUiState`/`PagedListUiModel` in `:core-common` (compiled without the Compose compiler → unstable to consumers). Config-declared to keep core-common UI-framework-agnostic.
- **Read-only collections** `List`/`Set`/`Map` — a separate, clearly-caveated section: an assertion about the app's read-only-snapshot discipline, not the type. Documented reversal path (kotlinx.immutable) if a mutated-list-into-composition path ever appears.

Result: **unstable params 19 → 1** (the one remainder is a framework `Uri?` with a `@static null` default on the top-level nav composable — negligible, not worth asserting stability over an Android type).

## Verification
- All 12 compose modules re-emitted reports; the 19→1 flip confirms the config is actually applied.
- Normal (non-report) compile applies the config cleanly; `make konsist` green; `spotlessCheck` green.
- Immutability audited: zero `var`/`Mutable*`/`Array` members across the six classes the domain wildcard vouches for.

No behavior change — a stability config only affects recomposition skipping. Reports are gitignored build output.