### PR TITLE
Android Lint in CI with a checked-in baseline (5.6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,41 @@ jobs:
       - name: Run Detekt
         run: make lint
 
+  android-lint:
+    name: Android Lint
+    needs: format-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+        with:
+          gradle-version: wrapper
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      # Google's Android-platform corpus (NewApi/minSdk, a11y, manifest, security, resources) -
+      # orthogonal to Detekt and Konsist. checkDependencies lints the whole app graph in one pass;
+      # new errors fail against app/lint-baseline.xml.
+      - name: Run Android Lint
+        run: make android-lint
+
+      - name: Archive Lint Reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: android-lint-reports
+          path: '**/build/reports/lint-results-*.html'
+
   unit-tests:
     name: Unit Tests
     needs: format-check

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UI_TEST_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,:app:)
 # Wrapper for Gradle to support build-brief (bb) or rtk if available
 GRADLE_RUNNER := $(shell if command -v bb >/dev/null 2>&1; then echo "bb ./gradlew"; elif command -v build-brief >/dev/null 2>&1; then echo "build-brief --gradle ./gradlew"; elif command -v rtk >/dev/null 2>&1; then echo "rtk ./gradlew"; else echo "./gradlew"; fi)
 
-.PHONY: help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist compose-metrics ui-test screenshot-record screenshot-verify screenshot-clean lint format check check-duplicates check-unused-deps benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse new-feature-module new-dev-app
+.PHONY: help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist compose-metrics ui-test screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse new-feature-module new-dev-app
 
 help: ## Show this help message.
 	@echo "\n📊 BillionBeers Makefile Help"
@@ -136,6 +136,9 @@ screenshot-clean: ## Clean and re-record golden images.
 # Quality & Analysis
 lint: ## Run static analysis (Detekt).
 	$(GRADLE_RUNNER) $(MODULE_PREFIX)detekt
+
+android-lint: ## Run Android Lint over the app and its whole library graph (checkDependencies), gated by app/lint-baseline.xml.
+	$(GRADLE_RUNNER) :app:lintDebug
 
 detekt-baseline: ## Update Detekt baselines for all modules.
 	$(GRADLE_RUNNER) $(MODULE_PREFIX)detektBaseline

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,0 +1,573 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<issues format="6" by="lint 9.2.1" type="baseline" client="gradle" dependencies="true" name="AGP (9.2.1)" variant="all" version="9.2.1">
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 33 (current min is 28): `android.animation.ValueAnimator#getDurationScale`"
+        errorLine1="      if (ValueAnimator.getDurationScale() == 0f) 0 else SCREEN_STATE_ANIMATION_DURATION_MS"
+        errorLine2="                        ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt"
+            line="177"
+            column="25"/>
+    </issue>
+
+    <issue
+        id="NewApi"
+        message="Call requires API level 33 (current min is 28): `android.animation.ValueAnimator#getDurationScale`"
+        errorLine1="    if (ValueAnimator.getDurationScale() == 0f) 0 else AVAILABILITY_ANIMATION_DURATION_MS"
+        errorLine2="                      ~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt"
+            line="53"
+            column="23"/>
+    </issue>
+
+    <issue
+        id="OldTargetApi"
+        message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the `android.os.Build.VERSION_CODES` javadoc for details."
+        errorLine1="targetSdk = &quot;36&quot;"
+        errorLine2="            ~~~~">
+        <location
+            file="../gradle/libs.versions.toml"
+            line="9"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedAttribute"
+        message="Attribute `shell` is only used in API level 29 and higher (current min is 28)"
+        errorLine1="        &lt;profileable android:shell=&quot;true&quot; />"
+        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/AndroidManifest.xml"
+            line="39"
+            column="22"/>
+    </issue>
+
+    <issue
+        id="ModifierParameter"
+        message="Modifier parameter should be the first optional parameter"
+        errorLine1="  modifier: Modifier = Modifier,"
+        errorLine2="  ~~~~~~~~">
+        <location
+            file="src/main/java/com/simtop/presentation_utils/custom_views/ComposeErrorView.kt"
+            line="35"
+            column="3"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;beers&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;beers_end_of_list&quot;>That\&apos;s all %1$d beers&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="6"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;results&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;search_result_count&quot;>%1$d results&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="6"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;results&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;search_end_of_list&quot;>That\&apos;s all %1$d results&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="7"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;beers&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;browse_beers_count&quot;>%1$d beers&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="37"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="PluralsCandidate"
+        message="Formatting %d followed by words (&quot;beers&quot;): This should probably be a plural rather than a string"
+        errorLine1="    &lt;string name=&quot;browse_beers_end_of_list&quot;>That\&apos;s all %1$d beers&lt;/string>"
+        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/res/values/strings.xml"
+            line="38"
+            column="5"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="This folder configuration (`v24`) is unnecessary; `minSdkVersion` is 28. Merge all the resources in this folder into `drawable`.">
+        <location
+            file="src/main/res/drawable-v24"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
+        message="This folder configuration (`v26`) is unnecessary; `minSdkVersion` is 28. Merge all the resources in this folder into `mipmap-anydpi`.">
+        <location
+            file="src/main/res/mipmap-anydpi-v26"/>
+    </issue>
+
+    <issue
+        id="AutoboxingStateCreation"
+        message="Prefer `mutableFloatStateOf` instead of `mutableStateOf`"
+        errorLine1="  var simulatedNumber by remember { mutableStateOf(number) }"
+        errorLine2="                                    ~~~~~~~~~~~~~~">
+        <location
+            file="src/main/java/com/simtop/billionbeers/core/designsystem/component/DialogWithProgressBar.kt"
+            line="63"
+            column="37"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.colorBlack` appears to be unused"
+        errorLine1="    &lt;color name=&quot;colorBlack&quot;>#000000&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/colors.xml"
+            line="6"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.colorRed` appears to be unused"
+        errorLine1="    &lt;color name=&quot;colorRed&quot;>#FF0000&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/colors.xml"
+            line="7"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.color.colorYellowy` appears to be unused"
+        errorLine1="    &lt;color name=&quot;colorYellowy&quot;>#FF9800&lt;/color>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/colors.xml"
+            line="8"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.super_big_text` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;super_big_text&quot;>64sp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/dimen.xml"
+            line="3"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.big_text` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;big_text&quot;>32sp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/dimen.xml"
+            line="4"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.normal_text` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;normal_text&quot;>16sp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/dimen.xml"
+            line="5"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.big_margin` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;big_margin&quot;>32sp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/dimen.xml"
+            line="7"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.normal_margin` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;normal_margin&quot;>16sp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/dimen.xml"
+            line="8"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.dimen.small_margin` appears to be unused"
+        errorLine1="    &lt;dimen name=&quot;small_margin&quot;>8sp&lt;/dimen>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/dimen.xml"
+            line="9"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.mipmap.ic_launcher` appears to be unused">
+        <location
+            file="src/main/res/mipmap-hdpi/ic_launcher.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_launcher_background` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable/ic_launcher_background.xml"
+            line="2"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_launcher_foreground` appears to be unused"
+        errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/drawable-v24/ic_launcher_foreground.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.mipmap.ic_launcher_round` appears to be unused">
+        <location
+            file="src/main/res/mipmap-hdpi/ic_launcher_round.png"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.menu.menu_main` appears to be unused"
+        errorLine1="&lt;menu xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;"
+        errorLine2="^">
+        <location
+            file="src/main/res/menu/menu_main.xml"
+            line="1"
+            column="1"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.drawable.real_beer` appears to be unused">
+        <location
+            file="../presentation_utils/src/main/res/drawable/real_beer.jpg"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.action_settings` appears to be unused"
+        errorLine1="    &lt;string name=&quot;action_settings&quot;>Settings&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="3"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.beer_detail` appears to be unused"
+        errorLine1="    &lt;string name=&quot;beer_detail&quot;>beerdetail&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../presentation_utils/src/main/res/values/strings.xml"
+            line="3"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.beers_list_fragment_label` appears to be unused"
+        errorLine1="    &lt;string name=&quot;beers_list_fragment_label&quot;>Beers List Fragment&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="4"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.beer_detail_fragment_label` appears to be unused"
+        errorLine1="    &lt;string name=&quot;beer_detail_fragment_label&quot;>Beer Detail Fragment&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="5"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.emergency_emergency_we_run_out_of_this_beer` appears to be unused"
+        errorLine1="    &lt;string name=&quot;emergency_emergency_we_run_out_of_this_beer&quot;>EMERGENCY!!\nEMERGENCY!!\nWE RUN OUT OF THIS BEER&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../presentation_utils/src/main/res/values/strings.xml"
+            line="5"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.next` appears to be unused"
+        errorLine1="    &lt;string name=&quot;next&quot;>Next&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="6"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.previous` appears to be unused"
+        errorLine1="    &lt;string name=&quot;previous&quot;>Previous&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="7"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.empty_barrels` appears to be unused"
+        errorLine1="    &lt;string name=&quot;empty_barrels&quot;>EMPTY BARRELS&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="9"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.search_open` appears to be unused"
+        errorLine1="    &lt;string name=&quot;search_open&quot;>Search&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../feature/beersearch/src/main/res/values/strings.xml"
+            line="10"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.abv` appears to be unused"
+        errorLine1="    &lt;string name=&quot;abv&quot;>&quot;ABV: %s&quot;&lt;/string>"
+        errorLine2="            ~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="11"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.ibu` appears to be unused"
+        errorLine1="    &lt;string name=&quot;ibu&quot;>&quot;IBU: %s&quot;&lt;/string>"
+        errorLine2="            ~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="12"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.please_try_again_when_you_connect_to_the_internet` appears to be unused"
+        errorLine1="    &lt;string name=&quot;please_try_again_when_you_connect_to_the_internet&quot;>PLEASE TRY AGAIN WHEN YOU CONNECT TO THE INTERNET&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="13"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.string.beer_detail_text` appears to be unused"
+        errorLine1="    &lt;string name=&quot;beer_detail_text&quot;>Beer Detail&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/strings.xml"
+            line="14"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.AppTheme_AppBarOverlay` appears to be unused"
+        errorLine1="    &lt;style name=&quot;AppTheme.AppBarOverlay&quot; parent=&quot;ThemeOverlay.AppCompat.Dark.ActionBar&quot; />"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/styles.xml"
+            line="15"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.AppTheme_PopupOverlay` appears to be unused"
+        errorLine1="    &lt;style name=&quot;AppTheme.PopupOverlay&quot; parent=&quot;ThemeOverlay.AppCompat.Light&quot; />"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/styles.xml"
+            line="17"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.big_text_title` appears to be unused"
+        errorLine1="    &lt;style name=&quot;big_text_title&quot;>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/styles.xml"
+            line="18"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.normal_text_regular` appears to be unused"
+        errorLine1="    &lt;style name=&quot;normal_text_regular&quot;>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/styles.xml"
+            line="25"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.normal_text_regular_not_centered` appears to be unused"
+        errorLine1="    &lt;style name=&quot;normal_text_regular_not_centered&quot;>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/styles.xml"
+            line="30"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.big_text_emergency` appears to be unused"
+        errorLine1="    &lt;style name=&quot;big_text_emergency&quot;>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/styles.xml"
+            line="34"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="UnusedResources"
+        message="The resource `R.style.empty_warning` appears to be unused"
+        errorLine1="    &lt;style name=&quot;empty_warning&quot;>"
+        errorLine2="           ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../core/src/main/res/values/styles.xml"
+            line="42"
+            column="12"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/beer_launcher.png` in densityless folder">
+        <location
+            file="src/main/res/drawable/beer_launcher.png"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/beer_launcher_round.png` in densityless folder">
+        <location
+            file="src/main/res/drawable/beer_launcher_round.png"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/blue_image.png` in densityless folder">
+        <location
+            file="src/main/res/drawable/blue_image.png"/>
+    </issue>
+
+    <issue
+        id="IconLocation"
+        message="Found bitmap drawable `res/drawable/real_beer.jpg` in densityless folder">
+        <location
+            file="src/main/res/drawable/real_beer.jpg"/>
+    </issue>
+
+    <issue
+        id="UseKtx"
+        message="Use the KTX extension function `String.toUri` instead?"
+        errorLine1="            .clickable { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(entry.uri))) }"
+        errorLine2="                                                                          ~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/debug/java/com/simtop/billionbeers/debug/DebugDrawerContent.kt"
+            line="104"
+            column="75"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="  androidTestImplementation(&quot;androidx.compose.ui:ui-test-junit4&quot;)"
+        errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="65"
+            column="29"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="  debugImplementation(&quot;androidx.compose.ui:ui-test-manifest&quot;)"
+        errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="66"
+            column="23"/>
+    </issue>
+
+</issues>

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
@@ -78,6 +78,27 @@ android.apply {
             excludes += "META-INF/*.kotlin_module"
         }
     }
+
+    lint {
+        // One Android Lint pass over the app and its entire library graph (checkDependencies), so
+        // a single `:app:lintDebug` covers the whole product with one checked-in baseline. This is
+        // Google's Android-platform corpus (NewApi/minSdk misuse, a11y, manifest, security,
+        // resources) - orthogonal to Detekt (Kotlin smells) and Konsist (our architecture rules),
+        // none of which understand the framework. New errors fail CI; everything present at
+        // adoption is grandfathered in lint-baseline.xml and burned down over time - never by
+        // regenerating the baseline to bury a regression.
+        baseline = file("lint-baseline.xml")
+        checkDependencies = true
+        abortOnError = true
+        warningsAsErrors = false
+        // Lint runs as its own CI job via lintDebug, so it need not also gate release assembly.
+        checkReleaseBuilds = false
+        // Dependency-freshness checks are Dependabot's job (ADR 0005); leaving them on would only
+        // add stale, version-churning noise to the baseline. Cosmetic - they are warning severity,
+        // so with warningsAsErrors=false they never gated CI anyway; this just keeps the baseline
+        // meaningful (latent bugs, not "an update exists").
+        disable += setOf("NewerVersionAvailable", "GradleDependency", "AndroidGradlePluginVersion")
+    }
 }
 
 // The AndroidX Baseline Profile plugin auto-generates `nonMinifiedRelease` and `benchmarkRelease`


### PR DESCRIPTION
Fourth base-ratchet PR (`5.4 ✅ → 5.8 (#94) → 5.6 (this) → japicmp`). **Zero app-code diff** — build-logic + CI + baseline + Makefile only.

## What it adds
- Android Lint on `:app` with **`checkDependencies = true`**, so one `:app:lintDebug` lints the app and its entire library graph in a single pass, gated by a checked-in **`app/lint-baseline.xml`**.
- A parallel CI job (`Android Lint`, `needs: format-check`) + a `make android-lint` target.
- New errors fail against the baseline; the ~55 existing issues are grandfathered and burned down over time (never by regenerating the baseline to bury a regression).

This is Google's Android-platform corpus — `NewApi`/minSdk misuse, accessibility, manifest, security, resources — **orthogonal to Detekt** (Kotlin smells) and **Konsist** (our architecture rules); none of those understand the framework, so this covers a category nothing else did.

Dependency-freshness checks (`NewerVersionAvailable`/`GradleDependency`/`AndroidGradlePluginVersion`) are disabled: Dependabot owns that (ADR 0005), and they'd only add version-churning noise. Cosmetic — they're warning-severity so never gated CI anyway; this just keeps the baseline meaningful.

## 🔴 Headline finding: Lint immediately caught 2 real crashes
`ValueAnimator.getDurationScale()` (requires **API 33**) is called **unguarded at minSdk 28** in two places, to honor the system "Remove animations" a11y setting:
- `feature/beerslist/.../BeersListScreen.kt:177`
- `feature/beerdetail/.../ComposeBeerDetail.kt:53`

On API 28–32 this is a latent crash. Baselined here per the standard adoption workflow (this PR didn't introduce it, and keeping 5.6 app-code-free keeps it trivially reviewable). **Fix is the immediate next PR** — swap to `Settings.Global.ANIMATOR_DURATION_SCALE` (the same value `getDurationScale()` reads, API 17+, no permission), then drop both from the baseline.

## Verification
`make android-lint` passes against the committed baseline (second run green); `spotlessCheck`, `make konsist`, and ci.yml YAML all green.