### PR TITLE
Fix NewApi crash: getDurationScale (API 33) → Settings.Global on minSdk 28

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -2,28 +2,6 @@
 <issues format="6" by="lint 9.2.1" type="baseline" client="gradle" dependencies="true" name="AGP (9.2.1)" variant="all" version="9.2.1">
 
     <issue
-        id="NewApi"
-        message="Call requires API level 33 (current min is 28): `android.animation.ValueAnimator#getDurationScale`"
-        errorLine1="      if (ValueAnimator.getDurationScale() == 0f) 0 else SCREEN_STATE_ANIMATION_DURATION_MS"
-        errorLine2="                        ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt"
-            line="177"
-            column="25"/>
-    </issue>
-
-    <issue
-        id="NewApi"
-        message="Call requires API level 33 (current min is 28): `android.animation.ValueAnimator#getDurationScale`"
-        errorLine1="    if (ValueAnimator.getDurationScale() == 0f) 0 else AVAILABILITY_ANIMATION_DURATION_MS"
-        errorLine2="                      ~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt"
-            line="53"
-            column="23"/>
-    </issue>
-
-    <issue
         id="OldTargetApi"
         message="Not targeting the latest versions of Android; compatibility modes apply. Consider testing and updating this version. Consult the `android.os.Build.VERSION_CODES` javadoc for details."
         errorLine1="targetSdk = &quot;36&quot;"

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
@@ -1,6 +1,6 @@
 package com.simtop.feature.beerdetail.presentation
 
-import android.animation.ValueAnimator
+import android.provider.Settings
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -48,9 +48,15 @@ import com.simtop.presentation_utils.R
 fun ComposeBeerDetail(beer: Beer, onBackClick: () -> Unit, onToggleAvailability: () -> Unit) {
   val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
   // Honours the system "Remove animations" accessibility setting (animator duration scale 0)
-  // instead of always animating for a fixed duration.
-  val animationDurationMs =
-    if (ValueAnimator.getDurationScale() == 0f) 0 else AVAILABILITY_ANIMATION_DURATION_MS
+  // instead of always animating for a fixed duration. Read via Settings.Global (API 17+) rather
+  // than ValueAnimator.getDurationScale(), which is API 33 and crashes on our minSdk 28.
+  val animationsDisabled =
+    Settings.Global.getFloat(
+      LocalContext.current.contentResolver,
+      Settings.Global.ANIMATOR_DURATION_SCALE,
+      1f,
+    ) == 0f
+  val animationDurationMs = if (animationsDisabled) 0 else AVAILABILITY_ANIMATION_DURATION_MS
 
   Scaffold(
     modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -1,6 +1,6 @@
 package com.simtop.feature.beerslist
 
-import android.animation.ValueAnimator
+import android.provider.Settings
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -172,9 +172,15 @@ fun BeersListContent(
   ) { paddingValues ->
     val dataVisibility = rememberSaveable { mutableStateOf(false) }
     // Honours the system "Remove animations" accessibility setting (animator duration scale 0)
-    // instead of always animating for a fixed duration.
-    val animationDurationMs =
-      if (ValueAnimator.getDurationScale() == 0f) 0 else SCREEN_STATE_ANIMATION_DURATION_MS
+    // instead of always animating for a fixed duration. Read via Settings.Global (API 17+) rather
+    // than ValueAnimator.getDurationScale(), which is API 33 and crashes on our minSdk 28.
+    val animationsDisabled =
+      Settings.Global.getFloat(
+        LocalContext.current.contentResolver,
+        Settings.Global.ANIMATOR_DURATION_SCALE,
+        1f,
+      ) == 0f
+    val animationDurationMs = if (animationsDisabled) 0 else SCREEN_STATE_ANIMATION_DURATION_MS
 
     AnimatedContent(
       targetState = viewState,


### PR DESCRIPTION
The Android Lint job from #95 caught this on its first run — the showcase beat: **added Lint, it immediately found 2 real crashes, here's the fix.**

## The bug
`ValueAnimator.getDurationScale()` is public only from **API 33**, but this app's minSdk is **28**. Two composables called it unguarded to honor the system "Remove animations" accessibility setting — a latent crash on API 28–32:
- `feature/beerslist/.../BeersListScreen.kt`
- `feature/beerdetail/.../ComposeBeerDetail.kt`

## The fix
Read the same value via **`Settings.Global.ANIMATOR_DURATION_SCALE`** — the exact setting `getDurationScale()` reads internally, available since **API 17**, no permission — through each composable's existing `LocalContext`. Both `NewApi` entries dropped from `app/lint-baseline.xml`, so the baseline shrinks (54 issues) rather than grandfathering a crash.

## Verification
- `:app:lintDebug` green with the two baseline entries removed (source is genuinely fixed — no stale-baseline error).
- **`screenshot-verify` green on both modules** — the previews execute this exact line, so this confirms Paparazzi's context handles `Settings.Global.getFloat` and the change is a visual no-op.
- Both modules' unit tests + `spotlessCheck` + `konsist` green.