### PR TITLE
Weekly health report — aggregate the read-only checks (capstone)

### DIFF
--- a/.github/workflows/health-report.yml
+++ b/.github/workflows/health-report.yml
@@ -1,0 +1,59 @@
+name: Weekly Health Report
+
+# Aggregates the read-only health checks (Lint backlog, Detekt, Compose stability, coverage,
+# dependency graph) into one markdown table - "what's wrong and what needs solving." Written to
+# the run's Step Summary (always current) and committed to docs/health/REPORT.md so git history
+# is the trend line. Weekly, because these are burn-down signals, not per-PR gates.
+
+on:
+  schedule:
+    # 07:00 UTC every Saturday (after the forward-compat lane at 06:00).
+    - cron: '0 7 * * 6'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  health-report:
+    name: Generate health report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+        with:
+          gradle-version: wrapper
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Generate health report
+        run: bash scripts/health-report.sh --run docs/health/REPORT.md
+
+      - name: Publish to run summary
+        if: always()
+        run: cat docs/health/REPORT.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit report if it changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/health/REPORT.md
+          if git diff --cached --quiet; then
+            echo "Health report unchanged - nothing to commit."
+          else
+            # [skip ci]: a report-only commit must not trigger the whole Android CI on master.
+            git commit -m "chore: update weekly health report [skip ci]"
+            # Rebase onto any commits that landed since checkout - closes the weekly race window.
+            git pull --rebase origin master
+            git push origin HEAD:master
+          fi

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ UI_TEST_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,:app:)
 # Wrapper for Gradle to support build-brief (bb) or rtk if available
 GRADLE_RUNNER := $(shell if command -v bb >/dev/null 2>&1; then echo "bb ./gradlew"; elif command -v build-brief >/dev/null 2>&1; then echo "build-brief --gradle ./gradlew"; elif command -v rtk >/dev/null 2>&1; then echo "rtk ./gradlew"; else echo "./gradlew"; fi)
 
-.PHONY: help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist compose-metrics ui-test screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse new-feature-module new-dev-app
+.PHONY: help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist compose-metrics ui-test screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline health benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark jacoco-report install-profiler install-diffuse new-feature-module new-dev-app
 
 help: ## Show this help message.
 	@echo "\n📊 BillionBeers Makefile Help"
@@ -160,6 +160,9 @@ dependency-guard: ## Verify the app's release runtime dependency graph against i
 
 dependency-guard-baseline: ## Re-baseline the dependency graph after an intentional change (review the diff before committing).
 	$(GRADLE_RUNNER) :app:dependencyGuardBaseline
+
+health: ## Aggregate the read-only health checks into a markdown report (docs/health/REPORT.md).
+	@bash scripts/health-report.sh --run docs/health/REPORT.md
 
 # Benchmarking
 benchmark-micro: ## Run microbenchmarks on a connected device.

--- a/docs/health/REPORT.md
+++ b/docs/health/REPORT.md
@@ -1,0 +1,13 @@
+# BillionBeers Health Report
+
+_Generated 2026-07-23 20:05 UTC_ · read-only checks only. Regenerate with `make health`.
+
+| Check | Metric | Status | What to do |
+|---|---|---|---|
+| Android Lint backlog | 54 baselined | 🟡 burn down | top: UnusedResources×35 PluralsCandidate×5 IconLocation×4 · `make android-lint`, fix, re-baseline |
+| Detekt findings | 20 | 🟡 review | `make lint`; baseline or fix |
+| Compose unstable params | 1 | 🟢 good | 1 = the framework Uri?, expected |
+| Line coverage | n/a | 🔴 broken | `jacocoRootReport` fails: benchmark variant wants a non-existent testBenchmarkReleaseUnitTest — repair to restore coverage |
+| Dependency graph | n/a | ⚪ | `make dependency-guard-baseline` |
+
+> Legend: 🟢 healthy · 🟡 backlog to burn down · ℹ️ informational · ⚪ not measured this run.

--- a/scripts/health-report.sh
+++ b/scripts/health-report.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Aggregates BillionBeers' read-only health checks into one markdown table:
+# "what's wrong and what needs solving." Powers the weekly health job
+# (.github/workflows/health-report.yml) and `make health`.
+#
+# Usage:
+#   scripts/health-report.sh [--run] [OUTPUT.md]
+#     --run       first execute the Gradle checks that produce the artifacts this script
+#                 parses (slow, full build); omit to render from whatever artifacts already
+#                 exist (fast local preview).
+#     OUTPUT.md   write the report here (default: stdout).
+#
+# Design: each check is best-effort. A missing artifact yields an "n/a" row with how to
+# produce it, never a hard failure - the report must always render, even when a check can't.
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+bt='`' # literal backtick for markdown inline code, built as a var so it never triggers
+       # command substitution inside the double-quoted row strings below.
+
+RUN=0
+OUT=""
+for arg in "$@"; do
+  case "$arg" in
+    --run) RUN=1 ;;
+    *) OUT="$arg" ;;
+  esac
+done
+
+if [[ "$RUN" == "1" ]]; then
+  echo "Running health checks (this builds the project)..." >&2
+  # --continue: one check failing must not stop the others from producing their artifacts;
+  # failures surface as report rows, not by aborting. Only tasks whose *artifacts* this script
+  # parses are run here - the Lint and dependency-guard rows read committed baseline files, so
+  # those tasks are deliberately not invoked.
+  # jacocoRootReport is intentionally absent: it currently fails at configuration
+  # (:app:jacocoBenchmarkReleaseReport wants a non-existent testBenchmarkReleaseUnitTest), which
+  # the coverage row reports as a finding. Re-add it here once that task is repaired.
+  ./gradlew --console=plain --continue -PcomposeCompilerReports=true \
+    detekt compileReleaseKotlin \
+    >&2 2>&1 || true
+fi
+
+ROWS=()
+row() { ROWS+=("| $1 | $2 | $3 | $4 |"); }
+
+# --- 1. Android Lint backlog (parse the committed baseline; no build needed) ----------------
+lint_row() {
+  local f="app/lint-baseline.xml"
+  if [[ -f "$f" ]]; then
+    local n top
+    n=$(grep -c '<issue' "$f" 2>/dev/null || echo 0)
+    top=$(grep -oE 'id="[^"]+"' "$f" | sed 's/id="//;s/"//' | sort | uniq -c | sort -rn | head -3 \
+          | awk '{printf "%s×%s ", $2, $1}')
+    if [[ "$n" -eq 0 ]]; then
+      row "Android Lint backlog" "0" "🟢 clean" "—"
+    else
+      row "Android Lint backlog" "$n baselined" "🟡 burn down" "top: ${top:-—}· ${bt}make android-lint${bt}, fix, re-baseline"
+    fi
+  else
+    row "Android Lint backlog" "n/a" "⚪" "no baseline (${bt}make android-lint${bt})"
+  fi
+}
+
+# --- 2. Detekt (current, non-baselined findings) ------------------------------------------
+detekt_row() {
+  if find . -name 'detekt.xml' -path '*/build/reports/detekt/*' 2>/dev/null | grep -q .; then
+    local n
+    n=$(find . -name 'detekt.xml' -path '*/build/reports/detekt/*' -exec grep -oh '<error ' {} + 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$n" -eq 0 ]]; then
+      row "Detekt findings" "0" "🟢 clean" "—"
+    else
+      row "Detekt findings" "$n" "🟡 review" "${bt}make lint${bt}; baseline or fix"
+    fi
+  else
+    row "Detekt findings" "n/a" "⚪" "run with --run (or ${bt}make lint${bt})"
+  fi
+}
+
+# --- 3. Compose unstable params ------------------------------------------------------------
+compose_row() {
+  if find . -name '*composables.txt' -path '*/compose_compiler/*' 2>/dev/null | grep -q .; then
+    local n
+    n=$(find . -name '*composables.txt' -path '*/compose_compiler/*' -exec grep -oh 'unstable ' {} + 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$n" -le 1 ]]; then
+      row "Compose unstable params" "$n" "🟢 good" "1 = the framework Uri?, expected"
+    else
+      row "Compose unstable params" "$n" "🟡 review" "stabilise immutable types in compose-stability.conf"
+    fi
+  else
+    row "Compose unstable params" "n/a" "⚪" "${bt}make compose-metrics${bt}"
+  fi
+}
+
+# --- 4. Line coverage (jacoco root report) -------------------------------------------------
+coverage_row() {
+  local xml
+  xml=$(find . -name 'jacocoRootReport.xml' -path '*/build/*' 2>/dev/null | head -1)
+  if [[ -n "$xml" && -f "$xml" ]]; then
+    local pct
+    pct=$(python3 - "$xml" <<'PY'
+import sys, re
+data = open(sys.argv[1], encoding="utf-8", errors="ignore").read()
+m = re.findall(r'<counter type="LINE" missed="(\d+)" covered="(\d+)"', data)
+if m:
+    missed, covered = map(int, m[-1])
+    total = missed + covered
+    print(f"{100*covered/total:.1f}" if total else "0.0")
+else:
+    print("?")
+PY
+)
+    row "Line coverage" "${pct}%" "ℹ️" "raise covered paths; see jacocoRootReport"
+  else
+    row "Line coverage" "n/a" "🔴 broken" "${bt}jacocoRootReport${bt} fails: benchmark variant wants a non-existent testBenchmarkReleaseUnitTest — repair to restore coverage"
+  fi
+}
+
+# --- 5. Dependency graph lock --------------------------------------------------------------
+depguard_row() {
+  local f="app/dependencies/releaseRuntimeClasspath.txt"
+  if [[ -f "$f" ]]; then
+    local n; n=$(grep -c . "$f")
+    row "Dependency graph" "$n deps locked" "🟢 guarded" "drift fails CI; re-baseline intentionally"
+  else
+    row "Dependency graph" "n/a" "⚪" "${bt}make dependency-guard-baseline${bt}"
+  fi
+}
+
+lint_row
+detekt_row
+compose_row
+coverage_row
+depguard_row
+
+# --- render --------------------------------------------------------------------------------
+{
+  echo "# BillionBeers Health Report"
+  echo
+  echo "_Generated $(date -u '+%Y-%m-%d %H:%M UTC')_ · read-only checks only. Regenerate with ${bt}make health${bt}."
+  echo
+  echo "| Check | Metric | Status | What to do |"
+  echo "|---|---|---|---|"
+  printf '%s\n' "${ROWS[@]}"
+  echo
+  echo "> Legend: 🟢 healthy · 🟡 backlog to burn down · ℹ️ informational · ⚪ not measured this run."
+} > "${OUT:-/dev/stdout}"
+
+[[ -n "$OUT" ]] && echo "Wrote $OUT" >&2
+exit 0


### PR DESCRIPTION
The capstone of the base-ratchet series. Makes the whole effort *legible*: one page answering "what's wrong and what to burn down."

## What it adds
- **`scripts/health-report.sh`** — aggregates the read-only checks into one markdown table: **Android Lint backlog** (by category), **Detekt findings**, **Compose unstable params**, **line coverage**, and the **dependency-graph lock**. `--run` first builds the artifacts it parses; without it, it renders from existing ones (fast local preview). Every check is best-effort — a missing artifact yields an `n/a` row with how to produce it, never a hard failure.
- **`.github/workflows/health-report.yml`** — weekly (+ `workflow_dispatch`) job that writes the table to the run's **Step Summary** (always current) and commits **`docs/health/REPORT.md`** so git history is the trend line. Report-only commits carry `[skip ci]`.
- **`make health`** + an initial committed `REPORT.md`.

## Why not Metabase (you asked)
Metabase is a **live Java server + backing DB** — it can't live "on the repo" (a repo is static; you'd host it on a VPS and feed it a metrics DB, then maintain all of it for a solo project), and its strength (ad-hoc SQL exploration) isn't what a health board needs. The **Step Summary + committed md** is the server-free "dashboard on the repo"; a **GitHub Pages** static view is the natural future upgrade if charted trends are wanted. Verdict: no Metabase.

## 🔴 Surfaced while building (the report earning its keep on day one)
- **`jacocoRootReport` is broken** — the `benchmark` build type's generated jacoco task wants a non-existent `testBenchmarkReleaseUnitTest`. The coverage row reports it as a finding until repaired; re-adding `jacocoRootReport` to the script's `--run` list is a one-line follow-up once fixed.
- Current backlog it makes visible: **54 Lint** issues (mostly UnusedResources), **20 Detekt** findings — both burn-down candidates.

## Verification
- Ran the real `make health` (`--run`) end-to-end — the shipping command — confirming the detekt/compose artifact paths parse on a fresh run; `REPORT.md` is that output.
- Workflow YAML valid; `bash -n` clean; `make health` wired.
- `git push origin HEAD:master` is allowed by branch protection (`require_pr:false`, `restrictions:false`); I'll `workflow_dispatch` once after merge to confirm the commit step live.

Depends on nothing, but the `Dependency graph` row shows `n/a` until #97 (dependency-guard) merges, then self-populates on the next run.