### PR TITLE
Repair jacoco coverage (was silently empty + broke jacocoRootReport)

### DIFF
--- a/build-logic/convention/src/main/kotlin/billionbeers.jacoco.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.jacoco.gradle.kts
@@ -45,7 +45,12 @@ val jacocoTestReport = if (tasks.findByName("jacocoTestReport") != null) {
 }
 
 val androidComponents = extensions.findByType(com.android.build.api.variant.AndroidComponentsExtension::class.java)
-androidComponents?.onVariants { variant ->
+// Coverage is measured on the debug variant only. Registering a report for every variant made
+// jacoco<Variant>Report depend on a test<Variant>UnitTest task that doesn't exist for the AndroidX
+// baseline-profile variants (benchmarkRelease, nonMinifiedRelease), breaking jacocoRootReport at
+// configuration time. Scoping to debug is both the fix and the coverage convention.
+val debugVariants = androidComponents?.selector()?.withBuildType("debug")
+if (androidComponents != null && debugVariants != null) androidComponents.onVariants(debugVariants) { variant ->
     val testTaskName = "test${variant.name.capitalized()}UnitTest"
 
     val reportTask = tasks.register<JacocoReport>("jacoco${variant.name.capitalize()}Report") {
@@ -56,32 +61,38 @@ androidComponents?.onVariants { variant ->
             html.required.set(true)
         }
 
+        // AGP 9's built-in kotlinc writes classes under build/intermediates/built_in_kotlinc/...,
+        // not the old build/tmp/kotlin-classes/ this hardcoded (and it dropped the build/ segment
+        // too). Take the class output straight from the compile task so the path follows AGP
+        // wherever it moves it, and so the report gets an implicit dependency on compilation.
         classDirectories.setFrom(
-            fileTree("$projectDir/tmp/kotlin-classes/${variant.name}") {
-                exclude(
-                    "**/R.class",
-                    "**/R$*.class",
-                    "**/BuildConfig.*",
-                    "**/Manifest*.*",
-                    "**/*Test*.*",
-                    "android/**/*.*",
-                    "**/databinding/*",
-                    "**/generated/*",
-                    "**/model/*",
-                    "**/di/*",
-                    "**/*Activity*.*",
-                    "**/*Fragment*.*",
-                    "**/*_HiltModules*.*",
-                    "**/Hilt_*.*",
-                    "**/*_Factory*.*",
-                    "**/*_MembersInjector*.*",
-                    "**/*MapperImpl*.*",
-                    "**/*Module*.*",
-                    "**/*Component*.*",
-                    "**/*Screen*.*",
-                    "**/*Application*.*",
-                    "**/*CommonUiState*.*"
-                )
+            tasks.named("compile${variant.name.capitalized()}Kotlin").map { task ->
+                task.outputs.files.asFileTree.matching {
+                    exclude(
+                        "**/R.class",
+                        "**/R$*.class",
+                        "**/BuildConfig.*",
+                        "**/Manifest*.*",
+                        "**/*Test*.*",
+                        "android/**/*.*",
+                        "**/databinding/*",
+                        "**/generated/*",
+                        "**/model/*",
+                        "**/di/*",
+                        "**/*Activity*.*",
+                        "**/*Fragment*.*",
+                        "**/*_HiltModules*.*",
+                        "**/Hilt_*.*",
+                        "**/*_Factory*.*",
+                        "**/*_MembersInjector*.*",
+                        "**/*MapperImpl*.*",
+                        "**/*Module*.*",
+                        "**/*Component*.*",
+                        "**/*Screen*.*",
+                        "**/*Application*.*",
+                        "**/*CommonUiState*.*"
+                    )
+                }
             }
         )
 
@@ -92,7 +103,10 @@ androidComponents?.onVariants { variant ->
             )
         )
 
-        executionData.setFrom(file("$projectDir/jacoco/$testTaskName.exec"))
+        // Test tasks write coverage to build/jacoco/, not $projectDir/jacoco/ - the missing
+        // build/ segment meant this report (and the aggregated root report) had no execution data
+        // and produced empty coverage.
+        executionData.setFrom(layout.buildDirectory.file("jacoco/$testTaskName.exec"))
     }
 
     jacocoTestReport.configure { dependsOn(reportTask) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,12 @@ tasks.register("clean", Delete::class) {
 }
 
 tasks.register<JacocoReport>("jacocoRootReport") {
-    dependsOn(subprojects.map { it.tasks.withType<Test>() })
+    // Debug unit tests only. Depending on every Test task (or the `test` lifecycle task, which on
+    // an Android module aggregates all variants) pulled in the benchmark variant - which does not
+    // compile (its source set lacks the debug-drawer stub `src/release` has) and broke this task.
+    // The class/exec data below already reads only Debug-named reports, so JVM modules' `test`
+    // never contributed here regardless.
+    dependsOn(subprojects.map { sp -> sp.tasks.matching { it.name == "testDebugUnitTest" } })
     dependsOn(subprojects.map { it.tasks.withType<JacocoReport>() })
 
     val subprojectsWithJacoco = subprojects.filter {
@@ -97,7 +102,8 @@ tasks.register<JacocoReport>("jacocoRootReport") {
 
     reports {
         html.required.set(true)
-        xml.required.set(false)
+        // XML on: the health report (scripts/health-report.sh) and any coverage tooling parse it.
+        xml.required.set(true)
         csv.required.set(false)
     }
 

--- a/docs/health/REPORT.md
+++ b/docs/health/REPORT.md
@@ -1,13 +1,13 @@
 # BillionBeers Health Report
 
-_Generated 2026-07-23 20:05 UTC_ · read-only checks only. Regenerate with `make health`.
+_Generated 2026-07-23 21:26 UTC_ · read-only checks only. Regenerate with `make health`.
 
 | Check | Metric | Status | What to do |
 |---|---|---|---|
 | Android Lint backlog | 54 baselined | 🟡 burn down | top: UnusedResources×35 PluralsCandidate×5 IconLocation×4 · `make android-lint`, fix, re-baseline |
 | Detekt findings | 20 | 🟡 review | `make lint`; baseline or fix |
 | Compose unstable params | 1 | 🟢 good | 1 = the framework Uri?, expected |
-| Line coverage | n/a | 🔴 broken | `jacocoRootReport` fails: benchmark variant wants a non-existent testBenchmarkReleaseUnitTest — repair to restore coverage |
-| Dependency graph | n/a | ⚪ | `make dependency-guard-baseline` |
+| Line coverage | 51.2% | ℹ️ | raise covered paths; see jacocoRootReport |
+| Dependency graph | 211 deps locked | 🟢 guarded | drift fails CI; re-baseline intentionally |
 
 > Legend: 🟢 healthy · 🟡 backlog to burn down · ℹ️ informational · ⚪ not measured this run.

--- a/scripts/health-report.sh
+++ b/scripts/health-report.sh
@@ -35,11 +35,8 @@ if [[ "$RUN" == "1" ]]; then
   # failures surface as report rows, not by aborting. Only tasks whose *artifacts* this script
   # parses are run here - the Lint and dependency-guard rows read committed baseline files, so
   # those tasks are deliberately not invoked.
-  # jacocoRootReport is intentionally absent: it currently fails at configuration
-  # (:app:jacocoBenchmarkReleaseReport wants a non-existent testBenchmarkReleaseUnitTest), which
-  # the coverage row reports as a finding. Re-add it here once that task is repaired.
   ./gradlew --console=plain --continue -PcomposeCompilerReports=true \
-    detekt compileReleaseKotlin \
+    detekt jacocoRootReport compileReleaseKotlin \
     >&2 2>&1 || true
 fi
 


### PR DESCRIPTION
Follow-up to the health report, which flagged coverage as 🔴 broken. Turned out coverage was broken **five** ways — peeled one empirical layer at a time:

| # | Bug | Fix |
|---|---|---|
| 1 | Per-variant report registered for *every* variant → `jacoco<Variant>Report` depended on `test<Variant>UnitTest` tasks that don't exist for the baseline-profile variants (`benchmarkRelease`, `nonMinifiedRelease`) → config failure that broke `jacocoRootReport` | scope report generation to the **debug** variant (the coverage convention) |
| 2 | Root report depended on every subproject `Test` task — incl. the Android `test` lifecycle task that aggregates all variants → pulled in the non-compiling benchmark variant | scope to `testDebugUnitTest` |
| 3 | Root report had `xml.required=false` → no machine-readable output | enable XML |
| 4 | Per-module `executionData` pointed at `$projectDir/jacoco/` — **missing the `build/` segment** → read a non-existent `.exec`, so coverage was empty | `layout.buildDirectory.file("jacoco/…")` |
| 5 | `classDirectories` hardcoded `$projectDir/tmp/kotlin-classes/` — wrong for AGP 9's built-in kotlinc | take the class output from the **compile task's own output**, so it follows AGP |

**Result:** `jacocoRootReport` now produces real coverage — **51.2% line**. Re-added it to the health report's `--run`, so the coverage row is live (`docs/health/REPORT.md` refreshed: coverage + the dependency-graph row both populate now).

**Caveat — 51.2% is Android-debug modules only.** The root report filters to `Debug`-named reports, which excludes the JVM modules (`core-common`, `testing-utils`, whose exec is `test.exec`). Pre-existing and fine to ship; including them is a clean next-ratchet item, as is wiring coverage into per-PR CI (§4.5).

## Verification
- `jacocoRootReport --rerun-tasks` executes the full compile→exec→report chain cold-ish and yields 51.2% (684 LINE counters, 297 KB XML).
- `make konsist` + `spotlessCheck` green.
- **Mandatory on merge:** `workflow_dispatch` the health job once — it's the only CI path that runs `jacocoRootReport`, and the compile-task-output class dirs run truly cold there for the first time.

## Not fixed here (separate pre-existing bug, surfaced while doing this)
The **`benchmark` build type does not compile** — `MainActivity.kt` (src/main) references `DebugDrawerHost`, which only the debug/release source sets provide, not `src/benchmark`. Filing separately; likely also breaks `make benchmark-macro`.