### PR TITLE
Make the benchmark build type compile (share the release source set)

### DIFF
--- a/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
@@ -71,6 +71,15 @@ android.apply {
         }
     }
 
+    // `benchmark` mirrors `release` via initWith, but initWith copies build-type settings, not
+    // source sets - so benchmark lacked src/release, which holds the no-op DebugDrawerHost stub that
+    // src/main references (the real drawer lives in src/debug). Without this the benchmark variant
+    // does not compile, breaking macrobenchmark. The baseline-profile variants (benchmarkRelease,
+    // nonMinifiedRelease) already extend release; this gives the hand-rolled build type the same.
+    // AGP 9's built-in kotlinc compiles from the source set's kotlin dirs, so the .kt stub must be
+    // added there (java.srcDir alone does not reach kotlin compilation).
+    sourceSets.getByName("benchmark").kotlin.srcDir("src/release/java")
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"


### PR DESCRIPTION
Follow-up finding from the jacoco work. The hand-created `benchmark` build type did not compile.

## The bug
`benchmark` is created with `initWith(getByName("release"))` — but `initWith` copies build-type *settings*, not *source sets*. So benchmark lacked `src/release`, which holds the **no-op `DebugDrawerHost` stub** that `src/main/MainActivity.kt` references (the real drawer lives in `src/debug`). `compileBenchmarkKotlin` failed with `Unresolved reference 'DebugDrawerHost'`.

## The fix
Share the release source set with benchmark:
```kotlin
sourceSets.getByName("benchmark").kotlin.srcDir("src/release/java")
```
It has to go on the **kotlin** source set — AGP 9's built-in kotlinc compiles from the source set's kotlin dirs, and `java.srcDir` alone doesn't reach it (verified: java.srcDir left it broken, kotlin.srcDir fixed it). The baseline-profile variants (`benchmarkRelease`, `nonMinifiedRelease`) already extend release; this gives the hand-rolled type the same.

## Accuracy correction to my earlier note
I'd flagged this as "likely breaks `make benchmark-macro`." **It doesn't** — the macrobenchmark module targets `:app`'s **debug** variant (no `testBuildType` set), so the benchmark build type is currently **orphaned**; nothing targets it. This was a *latent* broken build type (it only surfaced because the old jacoco setup dragged it into `jacocoRootReport`), not a live macrobenchmark break.

## Why fix it anyway
- A build type that doesn't compile is a real defect — `assembleBenchmark` hits a wall, and any future coverage/benchmark wiring re-trips it.
- It's the **prerequisite** for the real follow-up: point macrobenchmark at `testBuildType = "benchmark"` so benchmarks run against a non-debuggable build (accurate measurements) instead of debug-with-suppressed-errors.

## Verification
`:app:compileBenchmarkKotlin` ✅, `:app:assembleBenchmark` builds ✅, `make konsist` + `spotlessCheck` green. (macrobenchmark on-device is unchanged — it still targets debug.)