### PR TITLE
Include JVM modules in the root coverage report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,12 +38,20 @@ tasks.register("clean", Delete::class) {
 }
 
 tasks.register<JacocoReport>("jacocoRootReport") {
-    // Debug unit tests only. Depending on every Test task (or the `test` lifecycle task, which on
-    // an Android module aggregates all variants) pulled in the benchmark variant - which does not
-    // compile (its source set lacks the debug-drawer stub `src/release` has) and broke this task.
-    // The class/exec data below already reads only Debug-named reports, so JVM modules' `test`
-    // never contributed here regardless.
-    dependsOn(subprojects.map { sp -> sp.tasks.matching { it.name == "testDebugUnitTest" } })
+    // Android debug unit tests + JVM-module `test`. The Android `test` *lifecycle* task aggregates
+    // every variant (incl. the non-compiling benchmark one), so it is excluded by only taking `test`
+    // from non-Android modules; Android modules contribute via testDebugUnitTest instead.
+    dependsOn(
+        subprojects.flatMap { sp ->
+            sp.tasks.matching { task ->
+                val isAndroid =
+                    sp.extensions.findByType(
+                        com.android.build.api.variant.AndroidComponentsExtension::class.java
+                    ) != null
+                task.name == "testDebugUnitTest" || (task.name == "test" && !isAndroid)
+            }
+        }
+    )
     dependsOn(subprojects.map { it.tasks.withType<JacocoReport>() })
 
     val subprojectsWithJacoco = subprojects.filter {
@@ -87,17 +95,21 @@ tasks.register<JacocoReport>("jacocoRootReport") {
             file("${it.projectDir}/src/main/kotlin")
         )
     })
+    // The report holding a module's data: jacocoDebugReport for Android modules, jacocoTestReport
+    // for JVM modules. (Android modules also have an unconfigured jacocoTestReport aggregator, which
+    // contributes empty class/exec data - harmless.)
+    fun org.gradle.api.Project.dataReports() =
+        tasks.withType<JacocoReport>().matching { it.name.contains("Debug") || it.name == "jacocoTestReport" }
+
     classDirectories.setFrom(subprojectsWithJacoco.flatMap {
-        it.tasks.withType<JacocoReport>().matching { task -> task.name.contains("Debug") }.map { reportTask ->
+        it.dataReports().map { reportTask ->
             reportTask.classDirectories.asFileTree.matching {
                 exclude(excludes)
             }
         }
     })
     executionData.setFrom(subprojectsWithJacoco.flatMap {
-        it.tasks.withType<JacocoReport>().matching { task -> task.name.contains("Debug") }.map { reportTask ->
-            reportTask.executionData
-        }
+        it.dataReports().map { reportTask -> reportTask.executionData }
     })
 
     reports {


### PR DESCRIPTION
Closes the caveat from #103: coverage was **Android-debug only**. The root `jacocoRootReport` filtered to `Debug`-named reports, and #101 had scoped the test dependency to `testDebugUnitTest` — so the JVM modules (`core-common`, `testing-utils`) were invisible to coverage.

## What changed (root report only)
- **Depends on the JVM modules' `test` task** too — carefully: it takes `test` only from *non-Android* modules, so the Android `test` *lifecycle* aggregate (which drags in the non-compiling benchmark variant — the #101 trap) stays excluded. Android modules still contribute via `testDebugUnitTest`.
- **Aggregates their `jacocoTestReport`** class/exec data alongside the Android `Debug` reports (a small `dataReports()` helper: `Debug`-named for Android, `jacocoTestReport` for JVM; the Android empty aggregator contributes nothing, harmless).

## Result
Coverage now spans the whole repo: **51.2% → 52.7% line** (1223 → 1445 lines counted; `core-common` classes like `PagingMediator` now appear in the report).

## Interplay with #103 (the ratchet)
Independent, no conflict. When both land, the floor (51.0) sits comfortably below the new 52.7% — so tightening `config/coverage-floor.txt` to the exact CI number is the natural next step (once a CI run confirms it), not done here.

## Verification
`jacocoRootReport --rerun-tasks` → 52.7% with JVM classes present; `spotlessCheck` + `make konsist` green. Rebased onto latest master (no-op — nothing merged since branch point).