### PR TITLE
Restore the macrobenchmark benchmark signing config (lost in #105 merge)

### DIFF
--- a/benchmark/macrobenchmark/build.gradle.kts
+++ b/benchmark/macrobenchmark/build.gradle.kts
@@ -26,6 +26,10 @@ android.apply {
             // Library modules publish only debug/release, so the benchmark consumer must fall back
             // to release when resolving :app's transitive deps - mirroring :app's own benchmark type.
             matchingFallbacks += "release"
+            // Only the default `debug` build type is auto-signed; a custom type ships unsigned and
+            // fails to install (INSTALL_PARSE_FAILED_NO_CERTIFICATES). Debug-sign it, matching :app's
+            // benchmark type so the test and target APKs install together.
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
 


### PR DESCRIPTION
## What happened
#105 was validated on an emulator with a `signingConfig = signingConfigs.getByName("debug")` line on the macrobenchmark `benchmark` build type — but it merged from the **pre-amend** commit (`6f76206`), which predates that line. So master's macrobenchmark ships an **unsigned** benchmark test APK, and `make benchmark-macro` / `benchmark-check` fail at install with `INSTALL_PARSE_FAILED_NO_CERTIFICATES`.

## Fix
Re-adds the one line #105's emulator run proved necessary: a custom build type isn't auto-signed like the default `debug` type, so it needs an explicit debug `signingConfig` to install alongside the self-instrumenting test APK.

## Verification
Re-ran on the emulator against current master + this fix: `connectedBenchmarkAndroidTest` installs both APKs, runs, and measures `startup` — **1 test, 0 failed**. `spotlessCheck` green.