### PR TITLE
docs: add agent onboarding map, keep settings local

### DIFF
--- a/.claude/skills/billionbeers-android/SKILL.md
+++ b/.claude/skills/billionbeers-android/SKILL.md
@@ -93,9 +93,15 @@ the main app (no split-APK dance needed — just `installDebug`):
 
 ```bash
 "$ADB" shell am start -n "$APP/.presentation.MainActivity"   # launch
-"$ADB" shell pm clear "$APP"                                  # reset app data
+"$ADB" shell pm clear "$APP"                                  # reset app data — SEE WARNING
 "$ADB" logcat --pid=$("$ADB" shell pidof "$APP")             # app logs only
 ```
+
+> ⚠️ **`pm clear` breaks on-demand dynamic-feature installs.** It wipes bundletool
+> local-testing's staged split APKs, so installing `beerdetail` or `beerbrowse` afterwards
+> fails with SplitInstall **error −5**. That is not an app bug and not worth debugging —
+> re-run `scripts/install-local-testing.sh` to re-stage the splits. If you only need to reset
+> app state, prefer relaunching or clearing via the app rather than `pm clear`.
 
 ### Screenshots — prefer the `android` CLI
 

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ rod/
 # Claude Code local state. Vendored Android skills (github.com/android/skills)
 # are synced locally via `make update-android-skills`, not committed — only the
 # sync opt-out list and the project-authored billionbeers-android skill live in git.
+# settings.json is NOT committed — permissions (read-only allowlist and machine-specific
+# rules alike) stay local to each clone.
 .claude/*
 !.claude/skills/
 .claude/skills/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,63 +1,186 @@
-# BillionBeers AI Developer & Token Optimization Guidelines
+# BillionBeers — agent onboarding
 
-This guide details how AI coding agents and developers can optimize token usage, run common tasks, and interact with the BillionBeers project tooling.
+Read this first. It exists so an agent doesn't have to re-derive the same facts by grepping every
+session: what the modules are, what the rules are, and what's already been decided.
 
----
-
-## 🪙 AI Token Optimization Tools
-
-To reduce token consumption by 60–90%, BillionBeers integrates support for three tools. You should use them locally and in CI:
-
-1. **`rtk` (Rust Token Killer)**: Compresses stdout logs from tools like `git status`, test runners, etc.
-   - Usage: Prepended to command, e.g. `rtk git status`.
-2. **`snip`**: YAML-driven CLI proxy that filters LLM context inputs.
-   - Usage: Prepended to command, e.g. `snip git diff`.
-3. **`build-brief` (`bb`)**: Filters verbose Gradle outputs down to core summaries and failures while saving raw logs to `/tmp`.
-   - Usage: Prepended to `gradlew`, e.g. `bb ./gradlew assembleDebug`.
+**Ground truth beats this file.** Where it names an ADR or a Konsist test, that file is
+authoritative — this is the map, not the territory. If you find a contradiction, the code wins and
+this file needs a fix.
 
 ---
 
-## 🛠️ Build & Development Commands
+## 1. What this project is
 
-Always use the `Makefile` wrappers which automatically detect if `bb` or `rtk` is installed and route commands through them.
+A production-shaped multi-module Android app (beer catalog) over `brewbuddy.dev`, a read-only
+json-server-style REST API. Compose UI, Metro DI, Room SSOT, hand-rolled paging, two on-demand
+dynamic feature modules, architecture rules enforced by Konsist in CI.
 
-- **Clean project**: `make clean`
-- **Deep Cache Clean**: `make deep-clean`
-- **Build APK**: `make build`
-- **Install debug APK**: `make install`
-- **Run Unit Tests**: `make test [MODULE=:feature:beerslist]`
-- **Run Linting**: `make lint`
-- **Auto-Format Code**: `make format`
-- **Verify Screenshots**: `make screenshot-verify`
-- **Record Screenshots**: `make screenshot-record`
+It is a portfolio and template base, so the *shape* is the product: conventions are enforced by
+tooling rather than by memory, and deviations need a written reason.
 
 ---
 
-## 📱 Android Skills
+## 2. Module map
 
-Skills live in `.claude/skills/` and Claude Code agents should reach for them
-whenever a task matches their domain.
+| Module | What lives there |
+|---|---|
+| `:app` | The shipping app: Metro graph assembly, `MainActivity`, nav host, `dynamicFeatures` declaration |
+| `:app-dev-beerslist` | Standalone dev-app for fast feature iteration (see `scripts/new-dev-app.sh`, `new-dev-app` skill) |
+| `:core` | Android-side core: DI modules (networking, observability), production `Logger` binding |
+| `:core:designsystem` | Theme, tokens, `@LightDarkPreviews` multipreview, `PreviewTheme` |
+| `:core-common` | **Pure JVM.** `PagingMediator`, `PagedListReducer`, `CachePolicy`, `Either`, `CommonUiState`, dispatchers, `Logger`/`AnalyticsTracker`/`CrashReporter` interfaces + no-op impls, `FeatureFlagProvider`, `LanguageProvider`, `ThemeController`, `NetworkFaultController` |
+| `:beerdomain:api` | Domain models + repository *interfaces* + typed sealed errors + nav values |
+| `:beerdomain:fakes` | Fakes for the domain interfaces, consumed by feature tests and dev-apps |
+| `:beer_network` | Retrofit service, DTOs (`@Serializable`), `BeersPage` header envelope |
+| `:beer_database` | Room database, DAOs, entities, migrations (currently v3) |
+| `:beer_data` | Repository impls, `BeersMapper`, `BeersPagerFactoryImpl`, error mapping at the data boundary |
+| `:feature:beerslist` | Catalog (paged) — regular feature module |
+| `:feature:beersearch` | Search-as-you-type (paged, in-memory) — regular feature module |
+| `:feature:beerdetail` | Detail — **on-demand dynamic feature** |
+| `:feature:beerbrowse` | Browse by style / brewery (tabs, paged) — **on-demand dynamic feature** |
+| `:presentation_utils` | Shared UI: paged-list scaffolding, `InfiniteListHandler`, dynamic-feature install (`InstallStatus`, `DynamicFeatureInstaller`, `DynamicFeatureLoader`), **and the strings dynamic features need** (see §3) |
+| `:navigation` | Nav keys / typed routes shared across features |
+| `:konsist` | The architecture rules. Pure JVM — see the gotcha in §5 |
+| `:testing-utils` | Pure-JVM shared test helpers |
+| `:snapshot-testing`, `:snapshot-processor` | Paparazzi harness + KSP generation of screenshot tests from previews |
+| `:catalog`, `:catalog-annotations`, `:catalog-processor` | Demo/component catalog app + its KSP generator |
+| `:benchmark:{macrobenchmark,microbenchmark,baselineprofile}` | Perf budgets and baseline profile generation |
+| `build-logic` | Convention plugins (`billionbeers.android.feature`, `…dynamic.feature`, `…screenshot`, unused-deps, duplicate-classes). A separate composite build |
 
-**Project skill — `billionbeers-android`** (`.claude/skills/billionbeers-android/SKILL.md`):
-**Always use it whenever a task touches a real device or emulator** — starting/stopping
-emulators, checking devices/SDK status, installing/launching the app, screenshots, logcat,
-or running instrumented (`androidTest`) tests. It handles the correct `adb` path
-(`$ANDROID_HOME/platform-tools/adb`) and the known `installDebug` bundle workaround. For
-device-free work (unit tests, builds, lint, screenshots) keep using the `Makefile` targets above.
+Modules are **auto-discovered** by `settings.gradle.kts` — any directory with a build script is
+included. Adding a module needs no `settings.gradle.kts` edit.
 
-**Official Android skills** — a curated subset from
-[github.com/android/skills](https://github.com/android/skills) is vendored into
-`.claude/skills/` (each carries a `.android-skill-source` marker). Agents should use the
-relevant one for its domain, e.g. `android-cli` (Google's `android` tool), `navigation-3`,
+**Two stale directories will mislead a grep** (both harmless, both worth deleting):
+`beerdomain/impl/` is empty (no build script, so not even a module), and `core-common/bin/` is a
+leftover IDE output tree holding *deleted* sources — including `BaseUseCase.kt`, which was removed
+from the project. If a search hits `bin/`, you're reading a ghost; search `src/`.
+
+---
+
+## 3. Invariants — break these and the build (or an instrumented test) breaks
+
+The first four are enforced by `:konsist`; the wording here is from the tests themselves.
+
+1. **Repository interfaces do not import data-layer types.** (`RepositoryBoundaryTest`)
+2. **Feature modules never depend on other feature modules** — `beerslist` ⊥ `beerdetail`, and so
+   on. Cross-feature navigation goes through `:navigation`. (`FeatureModuleBoundaryTest`)
+3. **The `beerdomain` domain layer has no Android imports.** (`DomainLayerPurityTest`)
+4. **ViewModels depend only on domain-layer types.** This is the load-bearing precondition for the
+   use-case policy in ADR 0003 — without it, "inject the repository directly" becomes "inject
+   whatever you like". (`ViewModelBoundaryTest`)
+
+Not yet mechanically enforced (candidates — see `rod/July_Improvements.md` §4.3):
+
+5. **User-facing strings for dynamic-feature modules live in `:presentation_utils`.** Resources
+   declared inside a dynamic feature module crash instrumented tests. This has bitten twice.
+6. **Dev-apps depend only on `api` + `fakes` modules** — that's what keeps their build fast.
+7. **Test fixtures live in sibling `:module:fakes` / `:module:fixtures` modules**, never Gradle's
+   `java-test-fixtures` plugin (ADR 0001 — measured build-time cost).
+8. **Domain models are immutable; one-shot UI events use `Channel(BUFFERED).receiveAsFlow()`**, not
+   `SharedFlow` (which drops events with no active collector).
+
+---
+
+## 4. Settled decisions — don't re-litigate, read the ADR
+
+| Decision | Where |
+|---|---|
+| Test fixtures via sibling modules, not `java-test-fixtures` | `docs/adr/0001` |
+| Hand-rolled paging, no Paging3 (`PagingData` leaks through every layer) | `docs/adr/0002` |
+| A use case exists iff it does something a repository call doesn't — in practice **none survive today**; ViewModels inject `BeersRepository` directly, which is only safe because invariant 4 is enforced | `docs/adr/0003` |
+| Dev-apps can't host dynamic features | `docs/adr/0004` |
+| Dependabot over Renovate | `docs/adr/0005` |
+
+Also settled, without an ADR:
+
+- **Typed errors reuse `Either<L, R>` parameterized with a sealed error type** — the problem was
+  `Either<Exception, T>`'s untyped left, not `Either`. No new `Result`/`Outcome` type.
+- **`available` is local-only** even though the API has the field. The backend isn't ours, so a
+  sync could only ever one-way-overwrite user edits. The server value seeds a row on first insert.
+- **The N+1 image fetch is gone** — list responses embed `image.url`. Don't reintroduce
+  `GET /images/{id}`.
+- **Paging is complete and plug-and-play** (5 phases, 8/8 criteria). A new filtered surface needs a
+  wider `BeersQuery` and a screen — **not** `core-common` changes. Reference: `rod/PAGING_2_0.md`.
+- **Mappers are injected classes, not objects**, so they're testable and swappable.
+
+---
+
+## 5. Verification ladder
+
+Cheapest first. Run the narrowest rung that can falsify your change, then the ones above it before
+declaring done.
+
+1. **Compile** — `./gradlew :module:compileDebugKotlin --console=plain`
+2. **Unit tests** — `make test [MODULE=:feature:beerslist]`
+3. **Architecture** — `make konsist`
+4. **Screenshots** — `make screenshot-verify` (record with `make screenshot-record` and inspect the
+   PNGs; they are your eyes on the UI)
+5. **Lint / format** — `make lint`, `make format`
+6. **Device** — instrumented tests, install, logcat: use the `billionbeers-android` skill, not
+   ad-hoc `adb`
+
+**Gotcha: pure-JVM modules are invisible to `make test`.** It targets `testDebugUnitTest`, which
+plain `org.jetbrains.kotlin.jvm` modules (`:core-common`, `:konsist`, `:testing-utils`) don't have.
+Their tests need explicit invocation (`./gradlew :core-common:test`) or `make check`. `:konsist:test`
+silently never ran for a while because of exactly this.
+
+**Gotcha: `adb shell pm clear` breaks on-demand installs.** It wipes bundletool local-testing's
+staged splits; installs then fail with SplitInstall error −5 until `scripts/install-local-testing.sh`
+is re-run. Not an app bug.
+
+**Gotcha: `installDebug` is broken** by a duplicate PreviewProvider service entry — install the
+split APKs with `adb install-multiple` (the `billionbeers-android` skill handles this).
+
+---
+
+## 6. Build & development commands
+
+Use the `Makefile` wrappers — they auto-detect `bb`/`rtk` and route through them.
+
+`make clean` · `deep-clean` · `build` · `install` · `test [MODULE=…]` · `konsist` · `lint` ·
+`format` · `check` · `screenshot-record` · `screenshot-verify` · `ui-test` · `benchmark-check` ·
+`generate-baseline` · `new-feature-module` · `new-dev-app` · `update-android-skills`
+(`make help` lists them all.)
+
+### Token optimization tools
+
+Three optional tools cut stdout volume; the Makefile uses them when installed.
+
+- **`rtk`** — compresses stdout from `git status`, test runners, etc. `rtk git status`
+- **`snip`** — YAML-driven CLI proxy filtering LLM context inputs. `snip git diff`
+- **`bb` (build-brief)** — filters Gradle output to summaries + failures, raw log to `/tmp`.
+  `bb ./gradlew assembleDebug`
+
+---
+
+## 7. Skills
+
+Skills live in `.claude/skills/`. Reach for one whenever the task matches its domain.
+
+**Project skills:**
+- **`billionbeers-android`** — **always** for anything touching a device or emulator: emulators,
+  devices/SDK status, install/launch, screenshots, logcat, instrumented tests. It knows the correct
+  `adb` path (`$ANDROID_HOME/platform-tools/adb`) and the `installDebug` workaround.
+- **`new-dev-app`** — scaffold *and finish* a `app-dev-<feature>` sandbox module.
+- **`land`** — commit / push / PR with this repo's hygiene gates.
+
+**Official Android skills** — a curated subset of [android/skills](https://github.com/android/skills)
+is vendored (each carries a `.android-skill-source` marker): `android-cli`, `navigation-3`,
 `r8-analyzer`, `perfetto-trace-analysis`, `testing-setup`, `edge-to-edge`, `adaptive`,
 `android-intent-security`, and more.
 
-- **Update / pull new skills**: `make update-android-skills` (wraps
-  `scripts/update-android-skills.sh`). Re-run any time — it installs newly added upstream
-  skills, prunes ones removed upstream, and never touches locally-authored skills like
-  `billionbeers-android`.
-- **Opt out of a skill**: add its name to `.claude/skills/.android-skills-ignore`. Ignored
-  skills are skipped and removed on sync, so `make update-android-skills` won't resurrect
-  skills you deliberately dropped. Currently ignored: `agp-9-upgrade`, `camera1-to-camerax`,
-  `display-glasses-with-jetpack-compose-glimmer`, `migrate-xml-views-to-jetpack-compose`,
-  `wear-compose-m3`.
+- **Sync:** `make update-android-skills` — installs new upstream skills, prunes removed ones, never
+  touches locally-authored skills.
+- **Opt out:** add the name to `.claude/skills/.android-skills-ignore`. Currently ignored:
+  `agp-9-upgrade`, `camera1-to-camerax`, `display-glasses-with-jetpack-compose-glimmer`,
+  `migrate-xml-views-to-jetpack-compose`, `wear-compose-m3`.
+
+---
+
+## 8. Docs & planning
+
+- **`docs/`** — committed, load-bearing docs only. `docs/adr/` is the decision record.
+- **`rod/`** — local-only notes and plans, gitignored as one folder rule. **It has no git history,
+  so deleting a file there is permanent.** `rod/July_Improvements.md` is the current consolidation
+  of open work; `rod/MASTER_PLAN.md` is the plan of record.
+- A doc that becomes load-bearing gets promoted from `rod/` to `docs/` and committed.


### PR DESCRIPTION
Closes §4.2 of `rod/July_Improvements.md` (the "AI setup completion" item), the
highest-compounding-ROI item left on the board.

## AGENTS.md — the map agents didn't have
Replaces the 63-line command list with a real onboarding map (still tight): module
table, the Konsist-enforced invariants (quoted from the tests) plus the candidate
ones, settled decisions each pointing at their ADR, a cheapest-first verification
ladder, and the device gotchas (`pm clear`, `installDebug`, pure-JVM modules being
invisible to `make test`). Ground-truth-wins is stated up front — it's the map, not
the territory.

## Settings stay local
`.claude/settings.json` is kept per-clone (gitignored) rather than committed. The
read-only allowlist still works locally; the shared/reproducible benefit wasn't worth
committing tool permissions for a solo repo. Machine-specific rules already live in the
ignored `settings.local.json`.

## Device skill gotcha
`billionbeers-android` now warns, at the `pm clear` command itself, that it wipes
bundletool's staged splits and breaks on-demand `beerdetail`/`beerbrowse` installs
(SplitInstall error -5) — re-run `scripts/install-local-testing.sh`. Encodes a
twice-bitten trap at its point of use.

Docs/config only — no code paths touched.
