### PR TITLE
fix: surface server errors on paged beer fetches instead of truncating the list

### DIFF
--- a/app/src/test/java/com/simtop/billionbeers/TestMockWebService.kt
+++ b/app/src/test/java/com/simtop/billionbeers/TestMockWebService.kt
@@ -1,14 +1,10 @@
 package com.simtop.billionbeers
 
 import com.simtop.beer_network.network.BeersService
+import com.simtop.core.network.NetworkJson
 import java.io.File
-import java.io.IOException
-import java.net.HttpURLConnection
-import kotlinx.serialization.json.Json
-import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
-import okhttp3.Response
 import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -59,45 +55,18 @@ abstract class TestMockWebService {
   }
 
   private fun generateFakeApiService() {
-    val json = Json { ignoreUnknownKeys = true }
     apiService =
       Retrofit.Builder()
         .baseUrl(mockServer.url("/"))
         .client(generateOkHttpClient())
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .addConverterFactory(NetworkJson.asConverterFactory("application/json".toMediaType()))
         .build()
         .create(BeersService::class.java)
   }
 
+  // Deliberately no error-translating interceptor: this stack must fail exactly the way production
+  // does. An earlier test-only ErrorInterceptor turned non-2xx into thrown exceptions, which hid
+  // that getListOfBeers' Response<> signature was swallowing server errors into an empty page.
   private fun generateOkHttpClient() =
-    OkHttpClient()
-      .newBuilder()
-      .addInterceptor(HttpLoggingInterceptor())
-      .addInterceptor(ErrorInterceptor())
-      .build()
-}
-
-class ErrorInterceptor : Interceptor {
-
-  override fun intercept(chain: Interceptor.Chain): Response {
-    val response =
-      try {
-        chain.proceed(chain.request())
-      } catch (error: IOException) {
-        // TODO add exceptions sealed class
-        throw Exception("No internet connection")
-      }
-    if (!response.isSuccessful) {
-      when (response.code) {
-        HttpURLConnection.HTTP_UNAVAILABLE -> throw Exception("ServerException.ServiceUnavailable")
-        HttpURLConnection.HTTP_NOT_FOUND -> throw Exception("ClientException.NotFound")
-        HttpURLConnection.HTTP_CLIENT_TIMEOUT -> throw Exception("ClientException.RequestTimeout")
-        else ->
-          throw Exception(
-            IllegalStateException("The status code ${response.code} was received but not handled!")
-          )
-      }
-    }
-    return response
-  }
+    OkHttpClient().newBuilder().addInterceptor(HttpLoggingInterceptor()).build()
 }

--- a/app/src/test/java/com/simtop/billionbeers/data/BeersRemoteSourceTest.kt
+++ b/app/src/test/java/com/simtop/billionbeers/data/BeersRemoteSourceTest.kt
@@ -9,7 +9,9 @@ import com.simtop.core.core.LanguageProvider
 import java.net.HttpURLConnection
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Assert.assertThrows
 import org.junit.Test
+import retrofit2.HttpException
 
 class BeersRemoteSourceTest : TestMockWebService() {
 
@@ -43,11 +45,27 @@ class BeersRemoteSourceTest : TestMockWebService() {
     page.totalCount shouldBeEqualTo null
   }
 
-  @Test(expected = Exception::class)
-  fun `throws when the service fails`() {
+  @Test
+  fun `throws HttpException carrying the status code when the service fails`() {
     mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_UNAVAILABLE)
 
-    runBlocking { remoteSource.getListOfBeers(1) }
+    val thrown =
+      assertThrows(HttpException::class.java) { runBlocking { remoteSource.getListOfBeers(1) } }
+
+    thrown.code() shouldBeEqualTo HttpURLConnection.HTTP_UNAVAILABLE
+  }
+
+  /**
+   * The regression that matters: getListOfBeers returns Response<>, so Retrofit does not throw on
+   * non-2xx and a failed body is null. If that leaked through as an empty page, PagingMediator's
+   * empty-page probe would read it as end-of-pagination and silently truncate the list instead of
+   * surfacing an error the user can retry.
+   */
+  @Test
+  fun `a server error never surfaces as an empty page`() {
+    mockHttpResponse(FAKE_JSON, HttpURLConnection.HTTP_INTERNAL_ERROR)
+
+    assertThrows(HttpException::class.java) { runBlocking { remoteSource.getListOfBeers(1) } }
   }
 
   @Test

--- a/beer_network/src/main/java/com/simtop/beer_network/remotesources/BeersRemoteSource.kt
+++ b/beer_network/src/main/java/com/simtop/beer_network/remotesources/BeersRemoteSource.kt
@@ -6,6 +6,7 @@ import com.simtop.beer_network.models.TypologyApiResponseItem
 import com.simtop.beer_network.network.BeersService
 import com.simtop.core.core.LanguageProvider
 import dev.zacsweers.metro.Inject
+import retrofit2.HttpException
 
 interface BeersRemoteSource {
   /**
@@ -45,6 +46,12 @@ constructor(private val service: BeersService, private val languageProvider: Lan
         typologyId = typologyId,
         breweryId = breweryId,
       )
+    // Response<> means Retrofit hands back non-2xx instead of throwing, and a failed body is null.
+    // Without this guard a 5xx would become an empty page - which PagingMediator's empty-page probe
+    // reads as end-of-pagination, silently truncating the list with no error and no retry. Throwing
+    // matches the unpaged endpoints (no Response<> wrapper, so Retrofit throws) and lands in
+    // toFetchBeersError() like any other HTTP failure.
+    if (!response.isSuccessful) throw HttpException(response)
     // Malformed or absent header → null; the pager falls back to the empty-page probe.
     val totalCount = response.headers()[HEADER_TOTAL_COUNT]?.toIntOrNull()
     return BeersPage(items = response.body().orEmpty(), totalCount = totalCount)

--- a/core/src/main/java/com/simtop/core/di/NetworkingModule.kt
+++ b/core/src/main/java/com/simtop/core/di/NetworkingModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.simtop.core.BuildConfig
 import com.simtop.core.core.NetworkFaultController
 import com.simtop.core.network.NetworkFaultInterceptor
+import com.simtop.core.network.NetworkJson
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesTo
 import dev.zacsweers.metro.Named
@@ -30,13 +31,7 @@ interface NetworkingModule {
     private const val HTTP_CACHE_SIZE_BYTES = 5L * 1024 * 1024
   }
 
-  @Provides
-  @SingleIn(AppScope::class)
-  fun provideJson(): Json = Json {
-    ignoreUnknownKeys = true
-    coerceInputValues = true
-    isLenient = true
-  }
+  @Provides @SingleIn(AppScope::class) fun provideJson(): Json = NetworkJson
 
   @Provides
   @SingleIn(AppScope::class)

--- a/core/src/main/java/com/simtop/core/network/NetworkJson.kt
+++ b/core/src/main/java/com/simtop/core/network/NetworkJson.kt
@@ -1,0 +1,14 @@
+package com.simtop.core.network
+
+import kotlinx.serialization.json.Json
+
+/**
+ * The one JSON config for every API response. Lives here rather than inline in `NetworkingModule`
+ * so tests parse with the exact same leniency production does - a test-local `Json { … }` drifts,
+ * and a stricter test deserializer fails on payloads production would happily coerce.
+ */
+val NetworkJson: Json = Json {
+  ignoreUnknownKeys = true
+  coerceInputValues = true
+  isLenient = true
+}


### PR DESCRIPTION
`getListOfBeers` returns `Response<List<…>>`, so Retrofit hands back non-2xx instead of throwing and the failed body is `null`. That flowed through `body().orEmpty()` into `PagingMediator`, whose empty-page probe reads an empty page as end-of-pagination:

```kotlin
if (items.isEmpty()) { endPagination(result.totalCount); return }
```

So a 5xx mid-scroll silently truncated the list — no error state, no retry, the user just sees fewer beers and assumes that's all of them.

The suite never caught it because `TestMockWebService` installed a test-only `ErrorInterceptor` that converted non-2xx into thrown exceptions. Production has no such interceptor, so `throws when the service fails` was asserting behaviour that only existed in tests.

## Changes

- **`BeersRemoteSourceImpl`** — throw `HttpException(response)` on `!isSuccessful`. `toFetchBeersError()` already maps `HttpException`, and this makes all three endpoints fail identically (the unpaged two have no `Response<>` wrapper, so Retrofit already threw).
- **Dropped `ErrorInterceptor`** so the test stack fails the way production does. This also settles its `TODO add exceptions sealed class` — `FetchBeersError` already is that sealed class.
- **Extracted `NetworkJson`** into `:core`; production and tests now share one config instead of the test's stricter `Json { ignoreUnknownKeys = true }` drifting from it.
- **Tightened the error tests** — `@Test(expected = Exception::class)` would have kept passing after the fix for the wrong reason, since `HttpException` is an `Exception`. Now asserts the type and `code()`, plus a regression test for the truncation.

## Verification

Both new tests were falsified: with the guard commented out they fail, with it restored they pass.

Every production caller of the throwing path is inside a catch — `getBeersPageFromApi`'s only production caller is `BeersPagerFactoryImpl`'s `fetchPage` lambda, wired to `fetchRemote` on both `create()` and `create(query)`, so catalog, search and browse all route through `loadPage`'s try/catch → `classifyError` → `PagingState.Error`. `PagingMediatorTest` already covers throw → `Error`, so no new mediator test was needed.

`make test`, `make konsist`, `make lint` green; `:konsist:test` and `:core-common:test` run with `--rerun-tasks` since their first pass was UP-TO-DATE rather than executed.

Behaviour change worth noting on review: a 5xx mid-scroll now surfaces a retryable error instead of quietly ending the list.

## Not included

Moving these tests into `beer_network/src/test/` is a fair cleanup but needs new test deps and relocating `src/test/resources/json/` (`getJson` uses a cwd-relative `File(…)`), so it stays a separate follow-up.
