### PR TITLE
docs: mark invariants 5 and 6 as konsist-enforced

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ from the project. If a search hits `bin/`, you're reading a ghost; search `src/`
 
 ## 3. Invariants — break these and the build (or an instrumented test) breaks
 
-The first four are enforced by `:konsist`; the wording here is from the tests themselves.
+The first six are enforced by `:konsist`; the wording here is from the tests themselves.
 
 1. **Repository interfaces do not import data-layer types.** (`RepositoryBoundaryTest`)
 2. **Feature modules never depend on other feature modules** — `beerslist` ⊥ `beerdetail`, and so
@@ -68,12 +68,18 @@ The first four are enforced by `:konsist`; the wording here is from the tests th
 4. **ViewModels depend only on domain-layer types.** This is the load-bearing precondition for the
    use-case policy in ADR 0003 — without it, "inject the repository directly" becomes "inject
    whatever you like". (`ViewModelBoundaryTest`)
+5. **User-facing strings for dynamic-feature modules live in `:presentation_utils`.** Resources
+   declared inside a dynamic feature module crash instrumented tests. This has bitten twice.
+   (`DynamicFeatureResourceBoundaryTest` — it catches the failure path, a dynamic-feature file
+   importing its *own* module `R`. Being Kotlin-only it can't see a stray `strings.xml` that
+   nothing references, which is harmless anyway.)
+6. **Dev-apps depend only on `api` + `fakes` modules** — that's what keeps their build fast.
+   (`DevAppDependencyBoundaryTest` enforces the load-bearing half: no `app-dev-*` build script may
+   declare `:beer_data`, `:beer_database` or `:beer_network`. It reads the build scripts directly,
+   since Konsist doesn't scan `.kts`.)
 
 Not yet mechanically enforced (candidates — see `rod/July_Improvements.md` §4.3):
 
-5. **User-facing strings for dynamic-feature modules live in `:presentation_utils`.** Resources
-   declared inside a dynamic feature module crash instrumented tests. This has bitten twice.
-6. **Dev-apps depend only on `api` + `fakes` modules** — that's what keeps their build fast.
 7. **Test fixtures live in sibling `:module:fakes` / `:module:fixtures` modules**, never Gradle's
    `java-test-fixtures` plugin (ADR 0001 — measured build-time cost).
 8. **Domain models are immutable; one-shot UI events use `Channel(BUFFERED).receiveAsFlow()`**, not


### PR DESCRIPTION
AGENTS.md §3 listed invariants 5 and 6 under "not yet mechanically enforced", but `:konsist` has been covering both — `DynamicFeatureResourceBoundaryTest` and `DevAppDependencyBoundaryTest`. The file's own rule is that ground truth wins and the map gets fixed, so: fixed.

Both moved into the enforced list, and the intro now says six rather than four.

Neither rule covers its invariant in full, so each carries a note on what it actually checks rather than implying blanket coverage:

- **Invariant 5** — the rule catches the *failure path*, a dynamic-feature file importing its own module `R`. Being Kotlin-only it can't see a stray `strings.xml` that nothing references, which is harmless anyway.
- **Invariant 6** — the rule enforces the load-bearing half, that no `app-dev-*` build script declares `:beer_data`, `:beer_database` or `:beer_network`. That's narrower than the stated "only `api` + `fakes`". It reads the build scripts directly, since Konsist doesn't scan `.kts`.

Invariants 7 and 8 stay in the unenforced list, still pointing at `rod/July_Improvements.md` §4.3.

Verified by running `./gradlew :konsist:test --rerun-tasks` and reading which suites executed — all 6 classes / 7 tests, including the two named here. Forced because `:konsist:test` reports UP-TO-DATE otherwise, which is the trap §5 of this same file documents.
