### PR TITLE
ci: rerun only affected or previously-red heavy lanes on PR pushes

### DIFF
--- a/.github/scripts/detect-change-scope.sh
+++ b/.github/scripts/detect-change-scope.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Change-scope detector with per-lane verdict adoption. Called by the `changes` job in
+# .github/workflows/ci.yml - the job comment there has the short version of the design.
+#
+# Inputs (env, set by the workflow step):
+#   EVENT_NAME    github.event_name
+#   EVENT_ACTION  github.event.action
+#   BASE_SHA      github.event.pull_request.base.sha
+#   BEFORE/AFTER  github.event.before / .after (previous and new PR head on synchronize)
+#   REPO          github.repository
+#   GH_TOKEN      token with actions:read (for the previous run's job conclusions)
+#   GITHUB_OUTPUT
+#
+# Outputs: unit / screenshot / instrumented - "true" means that lane runs.
+#
+# Soundness rules - keep these when editing:
+# - This file must live under .github/ (NOT scripts/): scripts/ is in the safe-list, and an edit
+#   to the filter itself has to run the full suite so it validates itself.
+# - The pushed range is the direct tree diff BEFORE -> AFTER, NOT a merge-base diff: a force-push
+#   that *drops* a code commit changes the tree without adding commits and must still classify
+#   as code.
+# - "Green" means the job succeeded, or was skipped in a run whose CI Gate succeeded (that skip
+#   was itself a sound adoption - induction).
+# - Every uncertainty fails open to running everything: non-PR events, first run of a PR,
+#   unreachable BEFORE, no or unreadable previous run, renamed jobs, a previous run still in
+#   flight. Skipping a real test is the costly mistake; an extra run is just minutes.
+# - The unit/screenshot split mirrors the test filter in
+#   build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts: plain test
+#   runs exclude com.simtop.billionbeers.screenshot.*, Paparazzi runs include only it, and the
+#   package lives in a `screenshot/` source folder. If that filter changes, this map changes with
+#   it. Test *compilation* is still shared - but a compile break fails whichever lane reruns, so
+#   the gate catches it even when the other lane adopted green.
+set -euo pipefail
+
+emit() {
+  echo "unit=$1" >> "$GITHUB_OUTPUT"
+  echo "screenshot=$2" >> "$GITHUB_OUTPUT"
+  echo "instrumented=$3" >> "$GITHUB_OUTPUT"
+  echo "Decision: unit=$1 screenshot=$2 instrumented=$3 ($4)"
+}
+
+# Docs / skills / local-notes paths that no test lane can be affected by.
+# scripts/coverage-check.sh is carved out: the unit lane executes it (make coverage-check).
+is_safe() {
+  [ "$1" = "scripts/coverage-check.sh" ] && return 1
+  echo "$1" | grep -qE '^(docs/|rod/|imagesForReadme/|\.claude/skills/|scripts/|.*\.md$|LICENSE$)'
+}
+
+if [ "$EVENT_NAME" != "pull_request" ]; then
+  emit true true true "not a PR - post-merge validation is always complete"
+  exit 0
+fi
+
+CHANGED=$(git diff --name-only "$BASE_SHA...HEAD")
+echo "PR diff:"; echo "$CHANGED"
+all_safe=true
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  is_safe "$f" || { all_safe=false; break; }
+done <<< "$CHANGED"
+if $all_safe; then
+  emit false false false "docs/skills/scripts-only PR"
+  exit 0
+fi
+
+if [ "$EVENT_ACTION" != "synchronize" ]; then
+  emit true true true "first run of a code PR"
+  exit 0
+fi
+
+if [ -z "${BEFORE:-}" ] || ! git cat-file -e "$BEFORE" 2>/dev/null; then
+  emit true true true "previous head unreachable (force-push) - failing open"
+  exit 0
+fi
+
+PUSHED=$(git diff --name-only "$BEFORE" "$AFTER")
+echo "Pushed diff ($BEFORE -> $AFTER):"; echo "$PUSHED"
+
+# Path -> lane map. Keep it sound: when in doubt a path must fall through to
+# "affects everything".
+a_unit=false; a_screenshot=false; a_instrumented=false
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  if [ "$f" = "scripts/coverage-check.sh" ]; then
+    a_unit=true # runs inside the unit lane
+  elif is_safe "$f"; then
+    : # affects no lane
+  elif [[ "$f" == */src/test/snapshots/* ]]; then
+    a_screenshot=true # recorded goldens
+  elif [[ "$f" == */src/test/* && "$f" == */screenshot/* ]]; then
+    a_screenshot=true # screenshot-test source, excluded from plain test runs
+  elif [[ "$f" == */src/androidTest/* ]]; then
+    a_instrumented=true
+  elif [[ "$f" == */src/test/* ]]; then
+    a_unit=true # plain unit-test source, excluded from Paparazzi runs
+  else
+    a_unit=true; a_screenshot=true; a_instrumented=true
+  fi
+done <<< "$PUSHED"
+
+if $a_unit && $a_screenshot && $a_instrumented; then
+  emit true true true "push touches code paths"
+  exit 0
+fi
+
+# At least one lane is unaffected by this push. It may skip IFF its verdict on the previous
+# head was green - look that up.
+PREV_RUN=$(gh api "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$BEFORE&event=pull_request&per_page=1" \
+  --jq '.workflow_runs[0].id // empty' || true)
+if [ -z "$PREV_RUN" ]; then
+  emit true true true "no previous CI run for $BEFORE - failing open"
+  exit 0
+fi
+JOBS=$(gh api "repos/$REPO/actions/runs/$PREV_RUN/jobs?per_page=100" \
+  --jq '[.jobs[] | {name, conclusion}]' || true)
+if [ -z "$JOBS" ]; then
+  emit true true true "could not read jobs of previous run $PREV_RUN - failing open"
+  exit 0
+fi
+echo "Previous run $PREV_RUN job conclusions: $JOBS"
+
+concl() { echo "$JOBS" | jq -r --arg n "$1" 'map(select(.name == $n))[0].conclusion // "missing"'; }
+GATE=$(concl "CI Gate")
+
+was_green() {
+  local c; c=$(concl "$1")
+  [ "$c" = "success" ] || { [ "$c" = "skipped" ] && [ "$GATE" = "success" ]; }
+}
+
+decide() { # $1 = affected by this push (true/false), $2 = previous job name
+  if [ "$1" = "true" ]; then echo true
+  elif was_green "$2"; then echo false
+  else echo true
+  fi
+}
+
+UNIT=$(decide "$a_unit" "Unit Tests")
+SCREENSHOT=$(decide "$a_screenshot" "Screenshot Tests (Paparazzi)")
+INSTRUMENTED=$(decide "$a_instrumented" "Instrumented Tests (Gradle Managed Device)")
+emit "$UNIT" "$SCREENSHOT" "$INSTRUMENTED" \
+  "per-lane: rerunning affected or previously-red lanes, adopting green verdicts from run $PREV_RUN"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,47 +54,150 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Or trigger it manually from the Actions tab (pick this branch in the \"Run workflow\" dropdown)." >> $GITHUB_STEP_SUMMARY
 
-  # Cheap change-scope detector. The heavy test lanes (unit / screenshot / instrumented) key their
-  # `if:` off this to skip work that a docs/skills/scripts-only change can't affect - saving a full
-  # emulator boot and a 29-module test pass. On anything other than a PR (i.e. the master
-  # post-merge push) it forces code=true so post-merge validation is always complete. On a PR it
-  # flags code=true unless every changed file is in the safe-list below - fail-open toward running,
-  # because skipping tests on a real code change is the costly mistake. Workflow edits are NOT in
-  # the safe-list on purpose: a `.github/**` change runs the full suite so it validates itself.
+  # Change-scope detector with per-lane verdict adoption. The heavy test lanes (unit / screenshot
+  # / instrumented) key their `if:` off one output each. Two levels:
+  #
+  # Level 1 (whole PR): if every file in the PR diff is in the docs/skills/scripts safe-list, all
+  # heavy lanes skip - a change that can't affect code can't break a test lane.
+  #
+  # Level 2 (per push): on a `synchronize` push to a code PR, a lane reruns only if (a) the pushed
+  # diff could affect it, or (b) its verdict on the previous head was not green. A lane skipped
+  # here is *adopting* its previous green verdict: the CI Gate treats `skipped` as pass, which is
+  # sound only because this job verified green-ness before deciding to skip. Concretely: push
+  # re-recorded goldens onto a PR where only screenshots were red -> only the screenshot lane
+  # reruns; push a unit-test fix -> unit + screenshot rerun (Paparazzi tests are unit-test
+  # source), instrumented adopts its green verdict.
+  #
+  # Soundness rules - keep these when touching the script:
+  # - The pushed range is the direct tree diff `before -> after`, NOT a merge-base diff: a
+  #   force-push that *drops* a code commit changes the tree without adding commits, and must
+  #   still classify as code.
+  # - "Green" means the job succeeded, or it was skipped in a run whose CI Gate succeeded (that
+  #   skip was itself a sound adoption - induction).
+  # - Every uncertainty fails open to running everything: non-PR events, first run of a PR,
+  #   unreachable `before` (force-push), no previous run, unreadable/renamed jobs, a previous run
+  #   still in flight. Skipping a real test is the costly mistake; an extra run is just minutes.
+  # - Workflow edits are NOT in the safe-list on purpose: a `.github/**` change runs the full
+  #   suite so it validates itself.
   changes:
     name: Detect change scope
     needs: format-check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # reads the previous head's job conclusions for verdict adoption
     outputs:
-      code: ${{ steps.filter.outputs.code }}
+      unit: ${{ steps.filter.outputs.unit }}
+      screenshot: ${{ steps.filter.outputs.screenshot }}
+      instrumented: ${{ steps.filter.outputs.instrumented }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0 # need the merge base for the diff below
+          fetch-depth: 0 # need the merge base and the previous head for the diffs below
 
       - name: Classify changed paths
         id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+
+          emit() {
+            echo "unit=$1" >> "$GITHUB_OUTPUT"
+            echo "screenshot=$2" >> "$GITHUB_OUTPUT"
+            echo "instrumented=$3" >> "$GITHUB_OUTPUT"
+            echo "Decision: unit=$1 screenshot=$2 instrumented=$3 ($4)"
+          }
+
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "Not a PR - running the full suite."
-            echo "code=true" >> "$GITHUB_OUTPUT"
+            emit true true true "not a PR - post-merge validation is always complete"
             exit 0
           fi
-          CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD")
-          echo "Changed files:"; echo "$CHANGED"
-          # A line is "safe" (docs / skills / scripts only) if it matches this. If ANY changed file
-          # is NOT safe - including any .github/** workflow edit - it's treated as code and the
-          # heavy lanes run.
+
+          # A line is "safe" (docs / skills / scripts only) if it matches this.
           SAFE='^(docs/|rod/|imagesForReadme/|\.claude/skills/|scripts/|.*\.md$|LICENSE$)'
-          if echo "$CHANGED" | grep -qvE "$SAFE"; then
-            echo "Code paths changed - heavy test lanes will run."
-            echo "code=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Docs/skills/scripts-only change - skipping heavy test lanes."
-            echo "code=false" >> "$GITHUB_OUTPUT"
+          CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD")
+          echo "PR diff:"; echo "$CHANGED"
+          if ! echo "$CHANGED" | grep -qvE "$SAFE"; then
+            emit false false false "docs/skills/scripts-only PR"
+            exit 0
           fi
+
+          if [ "${{ github.event.action }}" != "synchronize" ]; then
+            emit true true true "first run of a code PR"
+            exit 0
+          fi
+
+          BEFORE='${{ github.event.before }}'
+          AFTER='${{ github.event.after }}'
+          if [ -z "$BEFORE" ] || ! git cat-file -e "$BEFORE" 2>/dev/null; then
+            emit true true true "previous head unreachable (force-push) - failing open"
+            exit 0
+          fi
+
+          PUSHED=$(git diff --name-only "$BEFORE" "$AFTER")
+          echo "Pushed diff ($BEFORE -> $AFTER):"; echo "$PUSHED"
+
+          # Path -> lane map. Keep it sound: when in doubt a path must fall through to
+          # "affects everything".
+          a_unit=false; a_screenshot=false; a_instrumented=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            if echo "$f" | grep -qE "$SAFE"; then
+              : # docs/skills/scripts - affects no lane
+            elif [[ "$f" == */src/test/snapshots/* ]]; then
+              a_screenshot=true # recorded goldens
+            elif [[ "$f" == */src/androidTest/* ]]; then
+              a_instrumented=true
+            elif [[ "$f" == */src/test/* ]]; then
+              a_unit=true; a_screenshot=true # Paparazzi tests live in unit-test source sets
+            else
+              a_unit=true; a_screenshot=true; a_instrumented=true
+            fi
+          done <<< "$PUSHED"
+
+          if $a_unit && $a_screenshot && $a_instrumented; then
+            emit true true true "push touches code paths"
+            exit 0
+          fi
+
+          # At least one lane is unaffected by this push. It may skip IFF its verdict on the
+          # previous head was green - look that up.
+          PREV_RUN=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=$BEFORE&event=pull_request&per_page=1" \
+            --jq '.workflow_runs[0].id // empty' || true)
+          if [ -z "$PREV_RUN" ]; then
+            emit true true true "no previous CI run for $BEFORE - failing open"
+            exit 0
+          fi
+          JOBS=$(gh api "repos/${{ github.repository }}/actions/runs/$PREV_RUN/jobs?per_page=100" \
+            --jq '[.jobs[] | {name, conclusion}]' || true)
+          if [ -z "$JOBS" ]; then
+            emit true true true "could not read jobs of previous run $PREV_RUN - failing open"
+            exit 0
+          fi
+          echo "Previous run $PREV_RUN job conclusions: $JOBS"
+
+          concl() { echo "$JOBS" | jq -r --arg n "$1" 'map(select(.name == $n))[0].conclusion // "missing"'; }
+          GATE=$(concl "CI Gate")
+
+          was_green() {
+            local c; c=$(concl "$1")
+            [ "$c" = "success" ] || { [ "$c" = "skipped" ] && [ "$GATE" = "success" ]; }
+          }
+
+          decide() { # $1 = affected by this push (true/false), $2 = previous job name
+            if [ "$1" = "true" ]; then echo true
+            elif was_green "$2"; then echo false
+            else echo true
+            fi
+          }
+
+          UNIT=$(decide "$a_unit" "Unit Tests")
+          SCREENSHOT=$(decide "$a_screenshot" "Screenshot Tests (Paparazzi)")
+          INSTRUMENTED=$(decide "$a_instrumented" "Instrumented Tests (Gradle Managed Device)")
+          emit "$UNIT" "$SCREENSHOT" "$INSTRUMENTED" \
+            "per-lane: rerunning affected or previously-red lanes, adopting green verdicts from run $PREV_RUN"
 
   secret-scan:
     name: Secret Scan (gitleaks)
@@ -222,7 +325,7 @@ jobs:
   unit-tests:
     name: Unit Tests
     needs: [format-check, changes]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.unit == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -263,7 +366,7 @@ jobs:
   screenshot-tests:
     name: Screenshot Tests (Paparazzi)
     needs: [format-check, changes]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.screenshot == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -346,7 +449,7 @@ jobs:
   instrumented-tests:
     name: Instrumented Tests (Gradle Managed Device)
     needs: [format-check, changes]
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.instrumented == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,22 +63,11 @@ jobs:
   # Level 2 (per push): on a `synchronize` push to a code PR, a lane reruns only if (a) the pushed
   # diff could affect it, or (b) its verdict on the previous head was not green. A lane skipped
   # here is *adopting* its previous green verdict: the CI Gate treats `skipped` as pass, which is
-  # sound only because this job verified green-ness before deciding to skip. Concretely: push
-  # re-recorded goldens onto a PR where only screenshots were red -> only the screenshot lane
-  # reruns; push a unit-test fix -> unit + screenshot rerun (Paparazzi tests are unit-test
-  # source), instrumented adopts its green verdict.
+  # sound only because the filter verified green-ness before deciding to skip.
   #
-  # Soundness rules - keep these when touching the script:
-  # - The pushed range is the direct tree diff `before -> after`, NOT a merge-base diff: a
-  #   force-push that *drops* a code commit changes the tree without adding commits, and must
-  #   still classify as code.
-  # - "Green" means the job succeeded, or it was skipped in a run whose CI Gate succeeded (that
-  #   skip was itself a sound adoption - induction).
-  # - Every uncertainty fails open to running everything: non-PR events, first run of a PR,
-  #   unreachable `before` (force-push), no previous run, unreadable/renamed jobs, a previous run
-  #   still in flight. Skipping a real test is the costly mistake; an extra run is just minutes.
-  # - Workflow edits are NOT in the safe-list on purpose: a `.github/**` change runs the full
-  #   suite so it validates itself.
+  # The logic, path->lane map, and the soundness rules that must survive edits all live in
+  # .github/scripts/detect-change-scope.sh - deliberately under .github/ (NOT scripts/, which is
+  # in the safe-list) so an edit to the filter itself runs the full suite and validates itself.
   changes:
     name: Detect change scope
     needs: format-check
@@ -94,110 +83,19 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 0 # need the merge base and the previous head for the diffs below
+          fetch-depth: 0 # need the merge base and the previous head for the diffs
 
       - name: Classify changed paths
         id: filter
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          emit() {
-            echo "unit=$1" >> "$GITHUB_OUTPUT"
-            echo "screenshot=$2" >> "$GITHUB_OUTPUT"
-            echo "instrumented=$3" >> "$GITHUB_OUTPUT"
-            echo "Decision: unit=$1 screenshot=$2 instrumented=$3 ($4)"
-          }
-
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            emit true true true "not a PR - post-merge validation is always complete"
-            exit 0
-          fi
-
-          # A line is "safe" (docs / skills / scripts only) if it matches this.
-          SAFE='^(docs/|rod/|imagesForReadme/|\.claude/skills/|scripts/|.*\.md$|LICENSE$)'
-          CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD")
-          echo "PR diff:"; echo "$CHANGED"
-          if ! echo "$CHANGED" | grep -qvE "$SAFE"; then
-            emit false false false "docs/skills/scripts-only PR"
-            exit 0
-          fi
-
-          if [ "${{ github.event.action }}" != "synchronize" ]; then
-            emit true true true "first run of a code PR"
-            exit 0
-          fi
-
-          BEFORE='${{ github.event.before }}'
-          AFTER='${{ github.event.after }}'
-          if [ -z "$BEFORE" ] || ! git cat-file -e "$BEFORE" 2>/dev/null; then
-            emit true true true "previous head unreachable (force-push) - failing open"
-            exit 0
-          fi
-
-          PUSHED=$(git diff --name-only "$BEFORE" "$AFTER")
-          echo "Pushed diff ($BEFORE -> $AFTER):"; echo "$PUSHED"
-
-          # Path -> lane map. Keep it sound: when in doubt a path must fall through to
-          # "affects everything".
-          a_unit=false; a_screenshot=false; a_instrumented=false
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            if echo "$f" | grep -qE "$SAFE"; then
-              : # docs/skills/scripts - affects no lane
-            elif [[ "$f" == */src/test/snapshots/* ]]; then
-              a_screenshot=true # recorded goldens
-            elif [[ "$f" == */src/androidTest/* ]]; then
-              a_instrumented=true
-            elif [[ "$f" == */src/test/* ]]; then
-              a_unit=true; a_screenshot=true # Paparazzi tests live in unit-test source sets
-            else
-              a_unit=true; a_screenshot=true; a_instrumented=true
-            fi
-          done <<< "$PUSHED"
-
-          if $a_unit && $a_screenshot && $a_instrumented; then
-            emit true true true "push touches code paths"
-            exit 0
-          fi
-
-          # At least one lane is unaffected by this push. It may skip IFF its verdict on the
-          # previous head was green - look that up.
-          PREV_RUN=$(gh api "repos/${{ github.repository }}/actions/workflows/ci.yml/runs?head_sha=$BEFORE&event=pull_request&per_page=1" \
-            --jq '.workflow_runs[0].id // empty' || true)
-          if [ -z "$PREV_RUN" ]; then
-            emit true true true "no previous CI run for $BEFORE - failing open"
-            exit 0
-          fi
-          JOBS=$(gh api "repos/${{ github.repository }}/actions/runs/$PREV_RUN/jobs?per_page=100" \
-            --jq '[.jobs[] | {name, conclusion}]' || true)
-          if [ -z "$JOBS" ]; then
-            emit true true true "could not read jobs of previous run $PREV_RUN - failing open"
-            exit 0
-          fi
-          echo "Previous run $PREV_RUN job conclusions: $JOBS"
-
-          concl() { echo "$JOBS" | jq -r --arg n "$1" 'map(select(.name == $n))[0].conclusion // "missing"'; }
-          GATE=$(concl "CI Gate")
-
-          was_green() {
-            local c; c=$(concl "$1")
-            [ "$c" = "success" ] || { [ "$c" = "skipped" ] && [ "$GATE" = "success" ]; }
-          }
-
-          decide() { # $1 = affected by this push (true/false), $2 = previous job name
-            if [ "$1" = "true" ]; then echo true
-            elif was_green "$2"; then echo false
-            else echo true
-            fi
-          }
-
-          UNIT=$(decide "$a_unit" "Unit Tests")
-          SCREENSHOT=$(decide "$a_screenshot" "Screenshot Tests (Paparazzi)")
-          INSTRUMENTED=$(decide "$a_instrumented" "Instrumented Tests (Gradle Managed Device)")
-          emit "$UNIT" "$SCREENSHOT" "$INSTRUMENTED" \
-            "per-lane: rerunning affected or previously-red lanes, adopting green verdicts from run $PREV_RUN"
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+          REPO: ${{ github.repository }}
+        run: bash .github/scripts/detect-change-scope.sh
 
   secret-scan:
     name: Secret Scan (gitleaks)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,12 @@ declaring done.
 6. **Device** — instrumented tests, install, logcat: use the `billionbeers-android` skill, not
    ad-hoc `adb`
 
+**CI note: heavy lanes skip per-lane on PR pushes.** A push to an open PR reruns only the test
+lanes its diff can affect (goldens → screenshot; `src/androidTest/` → instrumented; other
+`src/test/` → unit + screenshot; anything else → all) plus any lane that was red on the previous
+head; unaffected green lanes adopt their previous verdict. Docs/skills/scripts-only PRs still skip
+all heavy lanes. Logic and soundness rules live in the `changes` job in `.github/workflows/ci.yml`.
+
 **Gotcha: pure-JVM modules are invisible to `make test`.** It targets `testDebugUnitTest`, which
 plain `org.jetbrains.kotlin.jvm` modules (`:core-common`, `:konsist`, `:testing-utils`) don't have.
 Their tests need explicit invocation (`./gradlew :core-common:test`) or `make check`. `:konsist:test`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,10 +128,10 @@ declaring done.
    ad-hoc `adb`
 
 **CI note: heavy lanes skip per-lane on PR pushes.** A push to an open PR reruns only the test
-lanes its diff can affect (goldens → screenshot; `src/androidTest/` → instrumented; other
-`src/test/` → unit + screenshot; anything else → all) plus any lane that was red on the previous
-head; unaffected green lanes adopt their previous verdict. Docs/skills/scripts-only PRs still skip
-all heavy lanes. Logic and soundness rules live in the `changes` job in `.github/workflows/ci.yml`.
+lanes its diff can affect (goldens and `screenshot/` test folders → screenshot; `src/androidTest/`
+→ instrumented; other `src/test/` → unit; anything else → all) plus any lane that was red on the
+previous head; unaffected green lanes adopt their previous verdict. Docs/skills/scripts-only PRs
+still skip all heavy lanes. Logic and soundness rules live in `.github/scripts/detect-change-scope.sh`.
 
 **Gotcha: pure-JVM modules are invisible to `make test`.** It targets `testDebugUnitTest`, which
 plain `org.jetbrains.kotlin.jvm` modules (`:core-common`, `:konsist`, `:testing-utils`) don't have.


### PR DESCRIPTION
Experiment: per-lane verdict adoption in the change-scope filter, as a testbed for porting to a larger project where the heavy lanes cost 20-90 min.

## What changed

The `changes` job now emits one output per heavy lane (`unit`, `screenshot`, `instrumented`) instead of a single `code` flag, and each lane's `if:` keys off its own output. Two levels:

- **Whole PR (unchanged):** a docs/skills/scripts-only PR skips all heavy lanes.
- **Per push (new):** on a `synchronize` push to a code PR, a lane reruns only if the pushed diff could affect it, or its verdict on the previous head was not green. Skipped lanes adopt their previous green verdict via the CI Gate's skipped=pass semantics.

Path→lane map: recorded goldens → screenshot only; `src/androidTest/` → instrumented only; other `src/test/` → unit + screenshot (Paparazzi tests are unit-test source); everything else → all lanes.

## Soundness

- Pushed range is the direct tree diff `before → after`, not a merge-base diff, so a force-push that drops a code commit still classifies as code.
- "Green" = job succeeded, or was skipped in a run whose CI Gate succeeded (that skip was itself a sound adoption — induction).
- Every uncertainty fails open to running everything: first run, unreachable `before`, no/unreadable previous run, renamed jobs, run still in flight. Workflow edits stay outside the safe-list so `.github/**` changes validate themselves — including this PR.

## Verification

Dry-ran the extracted filter script locally against real history and live API data: docs push onto PR #116 (all lanes adopt), androidTest-only probe (instrumented only), unit-test probe (unit + screenshot), goldens probe (screenshot only), and a docs push onto a red run (everything reruns). Live validation on this PR follows: probe pushes should show lanes skipping with the gate staying green.