### PR TITLE
test: document the two instrumentation-test entry points

### DIFF
--- a/app/src/androidTest/java/com/simtop/billionbeers/di/MockTestRunner.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/di/MockTestRunner.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.test.runner.AndroidJUnitRunner
 import com.simtop.billionbeers.BillionBeersApplication
 
+// Declared as the instrumentation runner in build-logic; instantiates the real Application class.
 class MockTestRunner : AndroidJUnitRunner() {
 
   override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -25,6 +25,9 @@ import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 
+// Covers the cache-resume rules the pager has to get right: the stored bookmark wins over the
+// row-count estimate, a language mismatch restarts from page 1, and a refresh neither wipes the
+// cache nor rewinds the bookmark.
 @ExperimentalCoroutinesApi
 class BeersPagerFactoryImplTest {
 

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -224,6 +224,13 @@ class BeersPagerFactoryImplTest {
         .isEqualTo(PagingState.Error(FetchBeersError.RateLimited, isFirstPage = true))
     }
 
+  // TEMPORARY - deliberate failure, pushed only to prove a red lane is never skipped by the
+  // per-lane CI filter. This commit is never merged; PR is closed after the observation.
+  @Test
+  fun `TEMPORARY deliberate failure`() {
+    expectThat(1).isEqualTo(2)
+  }
+
   @Test
   fun `a search pager fetches with the query term and keeps results in memory`() =
     runTest(testDispatcher) {

--- a/docs/TEMP-probe.md
+++ b/docs/TEMP-probe.md
@@ -1,0 +1,1 @@
+Temporary probe file - validates that a red lane is not skipped. Never merged.


### PR DESCRIPTION
Small comments on two test files, used as live probes for the per-lane CI selection merged in #117.

Sequence:
1. This commit touches `src/androidTest/` only. As the PR-opened run it takes the "first run of a code PR" branch and runs all three heavy lanes — establishing genuinely executed green verdicts.
2. A follow-up push will touch a plain `src/test/` file (not under a `screenshot/` folder). Expected: unit reruns, screenshot and instrumented adopt their green verdicts from run 1.

That second run is the case worth watching — it exercises partial rerun, adoption from executed (not skipped) verdicts, and the plain-`src/test/` → unit-only mapping in one shot.