### PR TITLE
ci: anchor verdict adoption on the filter job, not the aggregate gate

### DIFF
--- a/.github/scripts/detect-change-scope.sh
+++ b/.github/scripts/detect-change-scope.sh
@@ -19,8 +19,13 @@
 # - The pushed range is the direct tree diff BEFORE -> AFTER, NOT a merge-base diff: a force-push
 #   that *drops* a code commit changes the tree without adding commits and must still classify
 #   as code.
-# - "Green" means the job succeeded, or was skipped in a run whose CI Gate succeeded (that skip
-#   was itself a sound adoption - induction).
+# - "Green" means the job succeeded, or was skipped in a run where THIS filter job succeeded (that
+#   skip was itself a sound adoption - induction). The trust anchor is the filter job, not the
+#   aggregate CI Gate: the filter's decision that lane L could skip does not become unsound because
+#   some other lane M failed. Anchoring on the gate instead made adoption collapse on any red PR -
+#   from the second push onward every unaffected lane rerun, which is the exact case (a PR being
+#   fixed over several pushes) the mechanism exists to speed up. A cancelled run is still handled:
+#   its unstarted lanes are `cancelled`, not `skipped`, so they fail open.
 # - Every uncertainty fails open to running everything: non-PR events, first run of a PR,
 #   unreachable BEFORE, no or unreadable previous run, renamed jobs, a previous run still in
 #   flight. Skipping a real test is the costly mistake; an extra run is just minutes.
@@ -120,11 +125,13 @@ fi
 echo "Previous run $PREV_RUN job conclusions: $JOBS"
 
 concl() { echo "$JOBS" | jq -r --arg n "$1" 'map(select(.name == $n))[0].conclusion // "missing"'; }
-GATE=$(concl "CI Gate")
+# This job's own name - if it is ever renamed, the lookup returns "missing" and every skip stops
+# being trusted, so the mechanism degrades to running everything rather than to skipping wrongly.
+PREV_FILTER=$(concl "Detect change scope")
 
 was_green() {
   local c; c=$(concl "$1")
-  [ "$c" = "success" ] || { [ "$c" = "skipped" ] && [ "$GATE" = "success" ]; }
+  [ "$c" = "success" ] || { [ "$c" = "skipped" ] && [ "$PREV_FILTER" = "success" ]; }
 }
 
 decide() { # $1 = affected by this push (true/false), $2 = previous job name


### PR DESCRIPTION
Follow-up to #117, from a live red-stays-red test.

## The finding

Live probe on #118: unit lane deliberately made red (run C: `unit=failure`, screenshot/instrumented `skipped`, gate `failure`), then a docs-only push (run D).

Red stayed red — the red unit lane reran and the gate stayed red, which is the safety property. But screenshot and instrumented **also** reran despite being unaffected and having been green. Their last conclusion was `skipped`, and the old rule only trusted a skip when that run's **CI Gate** was green — and the gate was red because a *different* lane failed. So adoption collapsed and the run went full-suite.

That is the wrong trade in the exact case the mechanism exists for: a PR being fixed over several pushes. The first fix push is cheap (lanes still hold `success`), but from the second push onward every unaffected lane reruns.

## The change

Anchor the induction on the filter job's own conclusion instead of the aggregate gate. The filter's decision that lane L could skip does not become unsound because lane M failed.

Still sound: the filter job only runs when `format-check` passed, and it only skips a lane after verifying that lane was green. A cancelled run's unstarted lanes are `cancelled`, not `skipped`, so they still fail open — as does a rename of the job, which makes the lookup return `missing` and stops trusting every skip.

**Trade worth naming:** the gate anchor was also the only thing that periodically forced a full re-execution. A lane can now coast on adopted verdicts across arbitrarily many pushes as long as the path map says "unaffected" — which makes that map the sole remaining safety net rather than one of two. That is the right trade when lanes cost tens of minutes, and it raises the bar on keeping the map sound.

## Verification

**This PR's own CI does not exercise the change.** A `.github/scripts/**` edit makes it a code PR, so its run takes the "first run of a code PR" branch and never reaches the job lookup. Green here means the workflow still parses and the suite still passes — nothing more.

The actual evidence is an offline replay driving the real script against real API data:

| scenario | previous run | old rule | new rule |
|---|---|---|---|
| docs-only push onto red PR (run D, replayed) | 30166230689 — unit `failure`, others `skipped`, gate `failure`, filter `success` | `true true true` (reproduces what run D actually did) | `true false false` |
| docs-only push where the filter job itself was skipped (format-check failed) | 30163093465 — filter `skipped` | `true true true` | `true true true` (fails open) |

Regression matrix against a green previous run, where both rules must agree: docs-only → none; plain `src/test/` → unit; `src/androidTest/` → instrumented; `screenshot/` test → screenshot; production code → all three.