### PR TITLE
ci: fail open on a bad run-id lookup and surface lane selection

### DIFF
--- a/.github/scripts/detect-change-scope.sh
+++ b/.github/scripts/detect-change-scope.sh
@@ -42,6 +42,19 @@ emit() {
   echo "screenshot=$2" >> "$GITHUB_OUTPUT"
   echo "instrumented=$3" >> "$GITHUB_OUTPUT"
   echo "Decision: unit=$1 screenshot=$2 instrumented=$3 ($4)"
+  # Also surface it on the run page: "why did that lane not run?" should not require opening a log.
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    { echo "### Test lane selection"
+      echo ""
+      echo "$4"
+      echo ""
+      echo "| lane | runs |"
+      echo "|---|---|"
+      echo "| Unit Tests | $1 |"
+      echo "| Screenshot Tests (Paparazzi) | $2 |"
+      echo "| Instrumented Tests | $3 |"
+    } >> "$GITHUB_STEP_SUMMARY"
+  fi
 }
 
 # Docs / skills / local-notes paths that no test lane can be affected by.
@@ -112,8 +125,11 @@ fi
 # head was green - look that up.
 PREV_RUN=$(gh api "repos/$REPO/actions/workflows/ci.yml/runs?head_sha=$BEFORE&event=pull_request&per_page=1" \
   --jq '.workflow_runs[0].id // empty' || true)
-if [ -z "$PREV_RUN" ]; then
-  emit true true true "no previous CI run for $BEFORE - failing open"
+# Must be a bare run id. On a transient API error (observed: HTTP 504) gh prints the error body to
+# *stdout*, so this lands here as JSON rather than as the empty string - an emptiness check alone
+# lets that text through into the next request URL. Anything that is not digits fails open.
+if ! [[ "$PREV_RUN" =~ ^[0-9]+$ ]]; then
+  emit true true true "no usable previous CI run for $BEFORE - failing open"
   exit 0
 fi
 JOBS=$(gh api "repos/$REPO/actions/runs/$PREV_RUN/jobs?per_page=100" \
@@ -125,8 +141,17 @@ fi
 echo "Previous run $PREV_RUN job conclusions: $JOBS"
 
 concl() { echo "$JOBS" | jq -r --arg n "$1" 'map(select(.name == $n))[0].conclusion // "missing"'; }
-# This job's own name - if it is ever renamed, the lookup returns "missing" and every skip stops
-# being trusted, so the mechanism degrades to running everything rather than to skipping wrongly.
+
+# Every name below is matched against the previous run's job list as a literal string, so renaming
+# a job silently turns its lookup into "missing" -> nothing is ever adopted -> CI just quietly gets
+# slower, with no failure to notice. Warn loudly instead. (A PR that *adds* a lane also trips this
+# once, because the previous run predates the job - harmless and self-clearing.)
+for n in "Detect change scope" "Unit Tests" "Screenshot Tests (Paparazzi)" \
+  "Instrumented Tests (Gradle Managed Device)"; do
+  [ "$(concl "$n")" = "missing" ] &&
+    echo "::warning::Job '$n' not found in previous run $PREV_RUN - verdict adoption is disabled for it. If this job was renamed, update .github/scripts/detect-change-scope.sh to match."
+done
+
 PREV_FILTER=$(concl "Detect change scope")
 
 was_green() {


### PR DESCRIPTION
Three small hardening changes to the lane filter, one of which fixes a real bug found live.

## 1. A failed run-id lookup could leak into the next request URL

`gh api --jq` prints the error body to **stdout** on a transient failure, so `PREV_RUN` ended up holding JSON rather than the empty string, and the emptiness check let it through into the next request URL. Hit for real during testing (HTTP 504):

```
parse "https://api.github.com/repos/.../runs/{"message": "We couldn't respond..."}/jobs": invalid control character in URL
```

It happened to fail open, but only because the *second* call then failed and its own guard caught it. Now the run id must match `^[0-9]+$` or the filter fails open directly.

## 2. A renamed job silently disabled adoption

Every job name is matched as a literal string against the previous run. Rename one and its lookup returns `missing`, nothing is ever adopted, and CI just quietly gets slower — no failure, nothing to notice. All four names are now checked and emit a `::warning::` naming the job and the file to update. A PR that *adds* a lane trips this once, harmlessly, since the previous run predates the job.

## 3. The decision is now on the run page

`### Test lane selection` in the step summary, with the reason and a per-lane table, so "why didn't screenshots run?" doesn't require opening a job log.

## Verification

Full matrix replayed against real API data from run 30166042122, unchanged by this PR: docs-only → none; plain `src/test/` → unit; `src/androidTest/` → instrumented; `screenshot/` test → screenshot; goldens → screenshot; `scripts/coverage-check.sh` → unit; production code → all three. The new guard was exercised by pointing the lookup at a nonexistent repo: `no usable previous CI run - failing open`.

Note this PR's own run takes the "first run of a code PR" branch, so as with #119 its green check does not exercise the changed lines.