### PR TITLE
ci: warn on a renamed job, not on one still running

### DIFF
--- a/.github/scripts/detect-change-scope.sh
+++ b/.github/scripts/detect-change-scope.sh
@@ -34,7 +34,12 @@
 #   runs exclude com.simtop.billionbeers.screenshot.*, Paparazzi runs include only it, and the
 #   package lives in a `screenshot/` source folder. If that filter changes, this map changes with
 #   it. Test *compilation* is still shared - but a compile break fails whichever lane reruns, so
-#   the gate catches it even when the other lane adopted green.
+#   the gate catches it even when the other lane adopted green. What is NOT covered is *behavioural*
+#   sharing: a helper under `src/test/` outside a `screenshot/` folder that a hand-written screenshot
+#   test depends on would let the screenshot lane adopt a stale green. No such helper exists today
+#   (:catalog is the only module with hand-written screenshot tests and it has no other test
+#   sources). If that changes, a plain `src/test/` edit in a module that also holds screenshot tests
+#   has to set a_screenshot too.
 set -euo pipefail
 
 emit() {
@@ -144,11 +149,18 @@ concl() { echo "$JOBS" | jq -r --arg n "$1" 'map(select(.name == $n))[0].conclus
 
 # Every name below is matched against the previous run's job list as a literal string, so renaming
 # a job silently turns its lookup into "missing" -> nothing is ever adopted -> CI just quietly gets
-# slower, with no failure to notice. Warn loudly instead. (A PR that *adds* a lane also trips this
-# once, because the previous run predates the job - harmless and self-clearing.)
+# slower, with no failure to notice. Warn loudly instead.
+#
+# Warn on an absent *name*, not on a "missing" conclusion. The two are different and only the first
+# means a rename: a job that is still running is listed by name with a null conclusion, which
+# `concl` also reports as "missing". That happens whenever the previous run was superseded by this
+# push (concurrency cancels it mid-flight), so keying the warning off `concl` would cry wolf on
+# every rapid second push. The *decision* still fails open in both cases, which is what matters.
+# (A PR that adds a lane trips this once, because the previous run predates the job - self-clearing.)
+has_job() { echo "$JOBS" | jq -e --arg n "$1" 'any(.[]; .name == $n)' >/dev/null 2>&1; }
 for n in "Detect change scope" "Unit Tests" "Screenshot Tests (Paparazzi)" \
   "Instrumented Tests (Gradle Managed Device)"; do
-  [ "$(concl "$n")" = "missing" ] &&
+  has_job "$n" ||
     echo "::warning::Job '$n' not found in previous run $PREV_RUN - verdict adoption is disabled for it. If this job was renamed, update .github/scripts/detect-change-scope.sh to match."
 done
 


### PR DESCRIPTION
Fixes a false-positive in the warning added by #120, plus documents one assumption the map now rests on.

## The bug

#120 keyed its "job not found" warning off `concl()`, which returns `"missing"` for two different situations:

- the job name is genuinely absent (a rename — what the warning is for)
- the job is **listed but still running**, so its `conclusion` is `null`

The second happens on every rapid second push, because concurrency cancels the in-flight run and the lookup then sees unfinished jobs. So the warning would have cried wolf exactly when someone pushes twice in a row. The *decision* was always correct — both cases fail open — only the warning was wrong.

Now it keys off name presence instead. Verified against the live in-progress run 30168207663:

| job | `concl()` | old warn | new warn |
|---|---|---|---|
| Unit Tests (finished) | `success` | no | no |
| Instrumented Tests (still running) | `missing` | **yes** | no |
| a genuinely renamed lane | `missing` | yes | yes |

## Documented assumption

The map treats a plain `src/test/` file as screenshot-neutral. Shared *compilation* is safe — a compile break fails whichever lane reruns — but shared *behaviour* is not: a helper outside a `screenshot/` folder that a hand-written screenshot test depends on would let the screenshot lane adopt a stale green. Nothing like that exists today (`:catalog` is the only module with hand-written screenshot tests and has no other test sources), so this is a comment rather than code, with a note on what to change if that stops being true.

Full matrix re-verified against real API data, unchanged: docs-only → none; plain `src/test/` → unit; `src/androidTest/` → instrumented; `screenshot/` test → screenshot; goldens → screenshot; production code → all three.