### PR TITLE
ci: collapse the lane rules into one function, paginate the jobs lookup, add ADR 0008

### DIFF
--- a/.github/scripts/detect-change-scope.sh
+++ b/.github/scripts/detect-change-scope.sh
@@ -62,11 +62,49 @@ emit() {
   fi
 }
 
-# Docs / skills / local-notes paths that no test lane can be affected by.
-# scripts/coverage-check.sh is carved out: the unit lane executes it (make coverage-check).
-is_safe() {
-  [ "$1" = "scripts/coverage-check.sh" ] && return 1
-  echo "$1" | grep -qE '^(docs/|rod/|imagesForReadme/|\.claude/skills/|scripts/|.*\.md$|LICENSE$)'
+# =============================================================================
+# THE RULE SET - the only block to edit when changing which lanes a change runs
+# =============================================================================
+# classify_path maps ONE changed file onto the lanes it can affect, by setting
+# a_unit / a_screenshot / a_instrumented. A file that sets none of them is inert:
+# no test lane can be affected by it.
+#
+# Both levels of the filter go through this one function - level 1 (is the whole
+# PR inert?) and level 2 (what did this push touch?) - so path knowledge lives in
+# exactly one place. Adding a rule here changes both.
+#
+# First match wins, so order matters. The final `else` is the safety net: an
+# unrecognised path runs everything, which is what stops a new kind of file from
+# being silently skipped. Only add a branch above it when you can say why the
+# lanes you are excluding cannot be affected - that claim is now the only thing
+# standing between a stale verdict and a green PR.
+INERT_RE='^(docs/|rod/|imagesForReadme/|\.claude/skills/|scripts/)'
+classify_path() {
+  local f="$1"
+  if [ "$f" = "scripts/coverage-check.sh" ]; then
+    a_unit=true # the unit lane executes it (make coverage-check)
+  elif [[ "$f" =~ $INERT_RE ]] || [[ "$f" == *.md ]] || [ "$f" = "LICENSE" ]; then
+    : # inert - docs, skills, local notes, every other script
+  elif [[ "$f" == */src/test/snapshots/* ]]; then
+    a_screenshot=true # recorded goldens
+  elif [[ "$f" == */src/test/* && "$f" == */screenshot/* ]]; then
+    a_screenshot=true # screenshot-test source, excluded from plain test runs
+  elif [[ "$f" == */src/androidTest/* ]]; then
+    a_instrumented=true
+  elif [[ "$f" == */src/test/* ]]; then
+    a_unit=true # plain unit-test source, excluded from Paparazzi runs
+  else
+    a_unit=true; a_screenshot=true; a_instrumented=true
+  fi
+}
+
+# Classify a newline-separated file list, leaving the three a_* flags set.
+classify_all() {
+  a_unit=false; a_screenshot=false; a_instrumented=false
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    classify_path "$f"
+  done <<< "$1"
 }
 
 if [ "$EVENT_NAME" != "pull_request" ]; then
@@ -76,12 +114,8 @@ fi
 
 CHANGED=$(git diff --name-only "$BASE_SHA...HEAD")
 echo "PR diff:"; echo "$CHANGED"
-all_safe=true
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  is_safe "$f" || { all_safe=false; break; }
-done <<< "$CHANGED"
-if $all_safe; then
+classify_all "$CHANGED"
+if ! $a_unit && ! $a_screenshot && ! $a_instrumented; then
   emit false false false "docs/skills/scripts-only PR"
   exit 0
 fi
@@ -99,27 +133,7 @@ fi
 PUSHED=$(git diff --name-only "$BEFORE" "$AFTER")
 echo "Pushed diff ($BEFORE -> $AFTER):"; echo "$PUSHED"
 
-# Path -> lane map. Keep it sound: when in doubt a path must fall through to
-# "affects everything".
-a_unit=false; a_screenshot=false; a_instrumented=false
-while IFS= read -r f; do
-  [ -z "$f" ] && continue
-  if [ "$f" = "scripts/coverage-check.sh" ]; then
-    a_unit=true # runs inside the unit lane
-  elif is_safe "$f"; then
-    : # affects no lane
-  elif [[ "$f" == */src/test/snapshots/* ]]; then
-    a_screenshot=true # recorded goldens
-  elif [[ "$f" == */src/test/* && "$f" == */screenshot/* ]]; then
-    a_screenshot=true # screenshot-test source, excluded from plain test runs
-  elif [[ "$f" == */src/androidTest/* ]]; then
-    a_instrumented=true
-  elif [[ "$f" == */src/test/* ]]; then
-    a_unit=true # plain unit-test source, excluded from Paparazzi runs
-  else
-    a_unit=true; a_screenshot=true; a_instrumented=true
-  fi
-done <<< "$PUSHED"
+classify_all "$PUSHED"
 
 if $a_unit && $a_screenshot && $a_instrumented; then
   emit true true true "push touches code paths"
@@ -137,9 +151,14 @@ if ! [[ "$PREV_RUN" =~ ^[0-9]+$ ]]; then
   emit true true true "no usable previous CI run for $BEFORE - failing open"
   exit 0
 fi
-JOBS=$(gh api "repos/$REPO/actions/runs/$PREV_RUN/jobs?per_page=100" \
-  --jq '[.jobs[] | {name, conclusion}]' || true)
-if [ -z "$JOBS" ]; then
+# --paginate, because a single page caps at 100 jobs: a workflow with a sharded matrix can exceed
+# that, and a lane whose job fell off page 1 would read as renamed - it still fails open, but you
+# would lose adoption with no obvious cause. `jq -s` reassembles the per-page streams into one array.
+JOBS=$(gh api --paginate "repos/$REPO/actions/runs/$PREV_RUN/jobs?per_page=100" \
+  --jq '.jobs[] | {name, conclusion}' | jq -s '.' || true)
+# An API failure yields no stdout, which `jq -s` turns into "[]" rather than the empty string - so
+# check both, or a failed fetch would fall through and warn about every job being "renamed".
+if [ -z "$JOBS" ] || [ "$JOBS" = "[]" ]; then
   emit true true true "could not read jobs of previous run $PREV_RUN - failing open"
   exit 0
 fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ Not yet mechanically enforced (candidates — see `rod/July_Improvements.md` §4
 | Dependabot over Renovate | `docs/adr/0005` |
 | CI supply-chain hardening: Actions SHA-pinned, gitleaks on PR ranges | `docs/adr/0006` |
 | Dependency verification enforced; `make verification-metadata` regenerates the ledger, and a CI workflow does it on Dependabot branches so auto-merge survives | `docs/adr/0007` |
+| Per-lane CI test selection: a lane runs if the push could affect it or it was red last time, else it adopts the green verdict. Rules live in one function in `.github/scripts/detect-change-scope.sh` | `docs/adr/0008` |
 
 Also settled, without an ADR:
 
@@ -131,7 +132,8 @@ declaring done.
 lanes its diff can affect (goldens and `screenshot/` test folders → screenshot; `src/androidTest/`
 → instrumented; other `src/test/` → unit; anything else → all) plus any lane that was red on the
 previous head; unaffected green lanes adopt their previous verdict. Docs/skills/scripts-only PRs
-still skip all heavy lanes. Logic and soundness rules live in `.github/scripts/detect-change-scope.sh`.
+still skip all heavy lanes. **To change what runs when, edit the single `classify_path` function**
+in `.github/scripts/detect-change-scope.sh`; the reasoning is in ADR 0008.
 
 **Gotcha: pure-JVM modules are invisible to `make test`.** It targets `testDebugUnitTest`, which
 plain `org.jetbrains.kotlin.jvm` modules (`:core-common`, `:konsist`, `:testing-utils`) don't have.

--- a/docs/adr/0008-per-lane-ci-test-selection.md
+++ b/docs/adr/0008-per-lane-ci-test-selection.md
@@ -1,0 +1,132 @@
+# 0008: Per-lane CI test selection with verdict adoption
+
+## Status
+
+Accepted. Extends the blanket path filter added in PR #110 (recorded in the `changes` job comment,
+never given an ADR); PRs #117, #119, #120, #121.
+
+## Context
+
+The three heavy CI lanes — unit, Paparazzi screenshot, and the Gradle Managed Device instrumented
+run — cost roughly 2.4, 2.4 and 4.5 minutes here. PR #110 already skipped all three when a PR's
+whole diff was docs/skills/scripts. What it could not do is anything finer: a PR that touches code
+*anywhere* ran the full suite on *every* push, including the push that only re-records a golden
+image or only edits an ADR.
+
+The interesting cases are the ones where a push cannot affect a lane that has already passed:
+re-recording screenshots after a Paparazzi failure, fixing a unit test, tweaking docs on a code PR.
+Re-running an unaffected lane proves nothing, and at scale it dominates: this mechanism was built
+here deliberately as a rehearsal for a work project whose lanes cost 20 minutes (unit), 30
+(screenshot) and 40 (UI on Firebase), where the same push pattern wastes ~90 minutes.
+
+The naive version of this is dangerous. Since the `CI Gate` treats `skipped` as pass (ADR-less, see
+its job comment), a lane that skips is *asserting* it would have passed. Get that assertion wrong
+and a red PR silently turns green.
+
+## Decision
+
+**A lane runs if the push could affect it, or if its verdict on the previous head was not green.
+Otherwise it adopts that green verdict and skips.** Red stays red; green stays green.
+
+The implementation is `.github/scripts/detect-change-scope.sh`, which emits one output per lane.
+
+### 1. The rules live in exactly one function
+
+`classify_path` maps one changed file onto the lanes it can affect. Both levels of the filter call
+it — "is this whole PR inert?" and "what did this push touch?" — so there is a single place to edit
+when the rules change, and no second copy to drift. Its final `else` runs everything, so an
+unrecognised path is never silently skipped.
+
+The current map: goldens and `screenshot/` test sources → screenshot; `src/androidTest/` →
+instrumented; other `src/test/` → unit; `scripts/coverage-check.sh` → unit (the unit lane executes
+it); docs, skills, local notes and other scripts → inert; everything else → all three.
+
+The unit/screenshot split is only sound because the build already partitions them the same way:
+`billionbeers.android.screenshot.gradle.kts` excludes `com.simtop.billionbeers.screenshot.*` from
+plain test runs and includes only it in Paparazzi runs. **If that filter changes, this map changes
+with it.**
+
+### 2. The script lives under `.github/`, not `scripts/`
+
+`scripts/` is inert. A filter that could classify an edit to itself as inert would be able to skip
+validating its own change.
+
+### 3. "Green" is anchored on the filter job, not the `CI Gate`
+
+A lane's previous conclusion of `skipped` counts as green only if the `Detect change scope` job
+succeeded in that run — because that skip was itself a sound adoption (induction).
+
+Anchoring on the aggregate `CI Gate` instead, as #117 originally did, was measurably wrong. The
+gate goes red when *any* job fails, including ones that say nothing about test freshness. On a PR
+being fixed over several pushes, the first fix push is cheap (the other lanes still hold
+`success`), but from the second push onward their conclusion is `skipped` under a red gate, so
+nothing is trusted and every unaffected lane re-runs — exactly the case the mechanism exists to
+speed up. Note `CI Gate` success implies filter success, so this rule skips in a strict superset of
+the old one's cases.
+
+The trade is explicit: the gate anchor was also the only thing periodically forcing a full
+re-execution. **The path map is now the sole safety net.**
+
+### 4. The pushed range is a direct tree diff, not a merge-base diff
+
+`git diff BEFORE AFTER`, never `BEFORE...AFTER`. A force-push that *drops* a commit makes the new
+head an ancestor of the old one, so the merge base **is** the new head and a three-dot diff reports
+zero files — measured. The filter would then adopt verdicts from a tree that still contained the
+reverted code. The two-dot form reports the revert as a change and runs everything.
+
+### 5. Everything uncertain fails open
+
+Non-PR events, a PR's first run, an unreachable `before` (the normal outcome of a force-push, since
+the orphaned commit is never fetched), no or unreadable previous run, a non-numeric run id, a
+renamed job, and a previous run still in flight all run the full suite. Skipping a real test is the
+costly mistake; an extra run is minutes.
+
+## Consequences
+
+Validated live rather than by argument. A docs-only push skipped all three lanes with the gate
+green; a push touching only a plain unit test ran unit alone, adopting from a run where all three
+had genuinely executed; and the safety property was tested directly by making the unit lane red and
+then pushing docs — **the red lane re-ran and failed again, and the gate stayed red.**
+
+Costs and sharp edges worth knowing:
+
+- **A force-push or rebase runs everything.** Correct — a rebase changes the code under test — but
+  at work, where strict branch protection makes "Update branch" frequent, this is a real recurring
+  cost.
+- **A rapid second push loses adoption for in-flight lanes.** Concurrency cancels the previous run;
+  lanes still running report a null conclusion and are not trusted. Lanes that had already finished
+  keep `success` and are still adopted, so the loss is partial.
+- **Job names are matched as literal strings.** A rename disables adoption for that lane and only
+  makes CI slower, with no failure to notice — so an absent name emits a `::warning::`. This is
+  keyed on the name being absent, not on the conclusion being unreadable, because a job that is
+  merely unfinished looks identical to a renamed one otherwise.
+- **The map is now the only thing standing between a stale verdict and a green PR.** Shared test
+  *compilation* is still covered (a compile break fails whichever lane re-runs); shared *behaviour*
+  is not.
+
+## Rejected: walking back more than one run
+
+When the previous run was cancelled or is still in flight, its lanes are untrusted and re-run. The
+obvious improvement is to walk further back to the last run where the lane actually executed.
+
+Rejected because it is not a lookup, it is the classification problem again — recursively. To trust
+a verdict from N runs ago you must prove that *every* intermediate diff was neutral for that lane,
+so a single wrong link in the chain silently invalidates the conclusion, and the chain is
+unbounded. The failure mode is the worst one available (a skipped lane that should have run) and
+the payoff is bounded by how often people push twice in quick succession. The one-run lookback
+fails open instead, which costs a few minutes and cannot be wrong.
+
+If bounded coasting is wanted later, the right lever is an explicit one — a scheduled full run on
+open PRs, or a `ci:full` label — not a longer inference chain.
+
+## Notes for reuse elsewhere
+
+- **Branch protection must require only the aggregate gate.** A skipped lane never reports a
+  status, so a *required* lane check would leave the PR permanently pending.
+- **No third-party action is used.** `git`, `gh` and `jq` only, consistent with ADR 0006's
+  preference for pinned binaries over marketplace actions. Where a repo already uses
+  `dorny/paths-filter`, keep it for classification and add only the adoption lookup — path
+  classification is the half dorny already does well, and verdict adoption is the half it has no
+  concept of.
+- **Paginate the jobs lookup.** A sharded matrix can exceed 100 jobs in one run; a lane whose job
+  falls off the first page reads as renamed and quietly stops being adopted.


### PR DESCRIPTION
Three things: a refactor for editability, the pagination fix, and the decision record.

## 1. The rules now live in exactly one place

The filter had path knowledge in **two** places — `is_safe()` for level 1 (is the whole PR inert?) and a separate `if/elif` chain for level 2 (what did this push touch?) — with `scripts/coverage-check.sh` spelled out in both. Changing a rule meant editing two spots correctly.

Both now go through one `classify_path` function that maps a file onto the lanes it can affect; "inert" is simply "sets no lane". Level 1 becomes "did anything in the PR diff set a lane?". One place to edit, no second copy to drift.

This is behaviour-preserving, verified case by case (below) rather than by inspection.

## 2. Paginated jobs lookup

`per_page=100` on a single page is fine at ten jobs, but a sharded matrix can exceed it, and a lane whose job fell off page one would read as renamed — it still fails open, but you would lose adoption with no visible cause. Now `--paginate` with `jq -s` reassembling the pages.

That surfaced a second, subtler thing: on an API failure `jq -s` turns empty stdout into `[]`, not the empty string, so the existing emptiness guard would have let a failed fetch through and warned that every job was renamed. Both are checked now.

## 3. ADR 0008

Records the decision and, per the repo convention in AGENTS.md §4, the reasoning that until now lived only in code comments: why the trust anchor is the filter job rather than the `CI Gate`, why the pushed range is a two-dot tree diff (a three-dot diff reports **zero files** for a force-push that drops a commit — measured), why the script sits under `.github/` rather than `scripts/`, and the fail-open ladder.

It also records **walking back more than one run as explicitly rejected**: it is not a lookup but the classification problem again, recursively — trusting a verdict from N runs back requires proving every intermediate diff was lane-neutral, one wrong link silently invalidates the conclusion, and the failure mode is the worst available. The one-run lookback fails open instead.

## Verification

Level 2, each case replayed against real API data — identical to pre-refactor:

| change | lanes |
|---|---|
| docs-only / root `.md` / `LICENSE` / skills / other `scripts/` | none |
| `scripts/coverage-check.sh` | unit |
| plain `src/test/` | unit |
| `src/androidTest/` | instrumented |
| `screenshot/` test source | screenshot |
| goldens | screenshot |
| workflow / production code | all three |

Level 1 and the entry paths separately: docs-only PR → none; PR containing code → all three; non-PR event → all three. The one inert rule that a git fixture could not exercise (`.claude/skills/` is gitignored) was checked directly against the predicate.