### PR TITLE
ci: re-baseline dependency-guard in the verification-metadata regen

### DIFF
--- a/.github/workflows/regen-verification-metadata.yml
+++ b/.github/workflows/regen-verification-metadata.yml
@@ -82,6 +82,50 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         run: chmod +x gradlew
 
+      # A version bump almost always shifts :app's release runtime classpath, so
+      # dependency-guard's committed baseline goes stale on the very commit that makes the ledger
+      # stale. `make verification-metadata` runs :app:dependencyGuard, which *fails* on any
+      # baseline drift - so without re-baselining first the regen step dies, the push step is
+      # skipped, and neither file is ever updated. That deadlocked #123, #124 and #127: the one
+      # workflow built to unblock Dependabot could not run to completion on any of them.
+      #
+      # --write-verification-metadata is what makes this step possible at all: in write mode
+      # Gradle records checksums instead of enforcing them, so the bump's not-yet-listed
+      # artifacts don't block the very resolution needed to list them.
+      - name: Re-baseline dependency guard
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          cp app/dependencies/releaseRuntimeClasspath.txt "$RUNNER_TEMP/guard-before.txt"
+          ./gradlew --write-verification-metadata sha256 --no-configuration-cache \
+            "-Dorg.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8" \
+            :app:dependencyGuardBaseline
+
+      # dependency-guard exists to make any change to the shipped dependency graph a *reviewed*
+      # decision, and patch/minor Dependabot PRs auto-merge unread - so re-baselining
+      # unconditionally would silently disable the control for exactly the PRs it guards.
+      # Version-only drift (same coordinates, new versions) is what a bump legitimately does and
+      # is already under review as the bump itself. A coordinate appearing or disappearing is a
+      # new or dropped transitive dependency - the signal the guard is actually for - so that
+      # stops here, red, and the auto-merge never resolves.
+      - name: Fail if the bump added or removed a coordinate
+        if: steps.guard.outputs.skip != 'true'
+        run: |
+          coords() { sed 's/:[^:]*$//' "$1" | sort -u; }
+          if ! delta=$(diff <(coords "$RUNNER_TEMP/guard-before.txt") \
+                            <(coords app/dependencies/releaseRuntimeClasspath.txt)); then
+            echo "::error::This bump adds or removes dependency coordinates, not just versions."
+            echo "$delta"
+            echo
+            echo "Review that transitive-graph change by hand. To accept it, re-baseline on the"
+            echo "branch and push - note that plain 'make dependency-guard-baseline' will NOT work"
+            echo "here, because the bump's artifacts aren't in the ledger yet and verification"
+            echo "blocks every Gradle invocation until they are:"
+            echo "  ./gradlew --dependency-verification off :app:dependencyGuardBaseline"
+            echo "Once the coordinate sets match again, this workflow re-runs and finishes the job."
+            exit 1
+          fi
+          echo "Release classpath drift is version-only - safe to re-baseline automatically."
+
       # Strict on purpose (no continue-on-error): if the task graph fails, the bump needs a
       # human anyway, and committing a partially-resolved ledger would only mask that.
       - name: Regenerate verification metadata
@@ -93,7 +137,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add gradle/verification-metadata.xml
+          git add gradle/verification-metadata.xml app/dependencies/releaseRuntimeClasspath.txt
           if git diff --cached --quiet; then
             echo "Ledger already current - nothing to commit."
           else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ Not yet mechanically enforced (candidates — see `rod/July_Improvements.md` §4
 | Dev-apps can't host dynamic features | `docs/adr/0004` |
 | Dependabot over Renovate | `docs/adr/0005` |
 | CI supply-chain hardening: Actions SHA-pinned, gitleaks on PR ranges | `docs/adr/0006` |
-| Dependency verification enforced; `make verification-metadata` regenerates the ledger, and a CI workflow does it on Dependabot branches so auto-merge survives | `docs/adr/0007` |
+| Dependency verification enforced; `make verification-metadata` regenerates the ledger, and a CI workflow does it on Dependabot branches so auto-merge survives — it re-baselines dependency-guard first (else the regen aborts on stale-baseline drift), but only when the drift is version-only | `docs/adr/0007` |
 | Per-lane CI test selection: a lane runs if the push could affect it or it was red last time, else it adopts the green verdict. Rules live in one function in `.github/scripts/detect-change-scope.sh` | `docs/adr/0008` |
 
 Also settled, without an ADR:

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,9 @@ dependency-guard-baseline: ## Re-baseline the dependency graph after an intentio
 # never runs). Don't add broader tasks (e.g. root assembleDebugAndroidTest) for the same reason.
 # The jvmargs override is needed because these are no-configuration-cache builds of the whole
 # graph; the default 2g heap GC-thrashes.
+# ORDER MATTERS after a dependency bump: :app:dependencyGuard below fails on a stale baseline and
+# aborts the regen before the ledger is written. Run `make dependency-guard-baseline` first (the
+# regen workflow does this automatically on Dependabot branches - ADR 0007).
 VERIFICATION_WRITE_FLAGS := --write-verification-metadata sha256 --no-configuration-cache --continue \
 	"-Dorg.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
 verification-metadata: ## Regenerate gradle/verification-metadata.xml over the full CI task graph (ADR 0007).

--- a/docs/adr/0007-gradle-dependency-verification.md
+++ b/docs/adr/0007-gradle-dependency-verification.md
@@ -33,6 +33,8 @@ that are easy to get wrong.
    (`.github/workflows/regen-verification-metadata.yml`). On Dependabot PRs it regenerates the
    ledger and pushes the diff back to the branch; CI re-runs on the new head and the existing
    `--auto` merge gate resolves normally.
+4. **The workflow re-baselines dependency-guard first, and only for version-only drift.** See
+   below — this is what makes (3) actually complete on a real bump.
 
 ## The two load-bearing choices in the workflow
 
@@ -53,6 +55,39 @@ The obvious pattern for pushing to a PR branch is `pull_request_target` (base-br
 write token). We don't need it: the deploy key provides the push, so the workflow runs in the
 ordinary least-privilege `pull_request` context with a read-only token, and never mixes
 base-context privileges with PR-head code execution.
+
+### Re-baseline dependency-guard before regenerating, and only when drift is version-only
+
+The ledger is not the only file a bump invalidates. `:app`'s release runtime classpath usually
+shifts too, so dependency-guard's committed baseline (`app/dependencies/releaseRuntimeClasspath.txt`)
+goes stale on the same commit. Because `make verification-metadata` runs `:app:dependencyGuard` —
+which *fails* on baseline drift — the regen step exited non-zero, its commit-and-push step was
+skipped, and **neither** file was ever written. The workflow built to unblock Dependabot could not
+complete on any bump that moved the shipped graph. Observed as a hard deadlock on PRs #123, #124
+and #127 (Kotlin 2.4.0→2.4.10, the Metro group, Material 1.13.0→1.14.0), each stuck red with no
+path forward: every manual fix a human could reach for — `spotlessApply`, a re-dispatched regen —
+was itself a Gradle invocation, and so failed on the same unlisted checksums.
+
+So the workflow runs `:app:dependencyGuardBaseline` **before** the regen, under
+`--write-verification-metadata` so the bump's unlisted artifacts don't block the resolution needed
+to list them. `make verification-metadata` afterwards remains the authority on ledger content —
+it still runs the full CI task graph, with `:app:dependencyGuard` now passing.
+
+Doing that unconditionally would quietly disable dependency-guard for exactly the PRs it guards,
+since patch/minor Dependabot PRs auto-merge unread. The workflow therefore compares the
+**version-stripped coordinate sets** either side of the re-baseline:
+
+- **version-only drift** (same coordinates, new versions) is what a bump legitimately is, and is
+  already under review as the bump itself → re-baseline and continue;
+- **a coordinate added or removed** is a new or dropped transitive dependency — the runtime-binary-
+  incompatibility signal the guard exists for → fail red, auto-merge never resolves, a human
+  reviews the delta and re-baselines by hand.
+
+  That hand re-baseline needs the escape hatch, not the Makefile target: on an un-regenerated
+  branch the bump's artifacts aren't in the ledger, so `make dependency-guard-baseline` fails on
+  verification like everything else. Use
+  `./gradlew --dependency-verification off :app:dependencyGuardBaseline`, commit, push — the
+  coordinate sets then match and the workflow finishes the ledger itself.
 
 ### Loop termination
 


### PR DESCRIPTION
PRs #123, #124 and #127 are all deadlocked, and none of them can be rescued by hand.

## What breaks

A Dependabot bump that moves `:app`'s release runtime classpath invalidates two committed files at once: `gradle/verification-metadata.xml` and dependency-guard's `app/dependencies/releaseRuntimeClasspath.txt`. The regen workflow only ever knew about the first.

`make verification-metadata` runs `:app:dependencyGuard`, which **fails** on baseline drift. So the regen step exited non-zero, its commit-and-push step was skipped, and neither file was written. Nothing could then unstick the PR by hand either — every available fix (`spotlessApply`, a re-dispatched regen) is itself a Gradle invocation, and dependency verification fails those during plugin resolution on the same unlisted checksums.

#125 and #126 merged cleanly through the same workflow, because their bumps didn't move the shipped graph. That's the tell: the deadlock is specific to bumps that shift `releaseRuntimeClasspath`.

## The fix

Run `:app:dependencyGuardBaseline` before the regen, under `--write-verification-metadata` so the bump's unlisted artifacts don't block the very resolution needed to list them. `make verification-metadata` stays the authority on ledger content and now completes.

Re-baselining unconditionally would have quietly disabled dependency-guard for exactly the PRs it guards, since patch/minor Dependabot PRs auto-merge unread. So the workflow compares version-stripped coordinate sets across the re-baseline:

- version-only drift (same coordinates, new versions) — what a bump legitimately is → continue;
- a coordinate added or removed — a new or dropped transitive dependency, the runtime-incompatibility signal the guard exists for → fail red, auto-merge never resolves, a human re-baselines by hand.

Reasoning recorded in ADR 0007, with the ordering trap noted in the Makefile where a local dev hits it.