### PR TITLE
test(konsist): enforce that domain models are immutable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ when they get in the way. (`:konsist`'s build-script rules skip `bin/` for this 
 
 ## 3. Invariants — break these and the build (or an instrumented test) breaks
 
-The first eight are enforced by `:konsist`; the wording here is from the tests themselves.
+All nine are enforced by `:konsist`; the wording here is from the tests themselves.
 
 1. **Repository interfaces do not import data-layer types.** (`RepositoryBoundaryTest`)
 2. **Feature modules never depend on other feature modules** — `beerslist` ⊥ `beerdetail`, and so
@@ -85,10 +85,12 @@ The first eight are enforced by `:konsist`; the wording here is from the tests t
 8. **One-shot UI events use `Channel(BUFFERED).receiveAsFlow()`**, never `MutableSharedFlow`, which
    drops events when nothing is collecting. (`OneShotEventBoundaryTest`.)
 
-Still convention-only, with no rule behind it:
+9. **Domain models are immutable** — no `var`, and no `val` holding a mutable collection
+   (`MutableList`, `HashMap`, `Array`, …), which is the half that slips through review.
+   (`DomainModelImmutabilityTest`.)
 
-9. **Domain models are immutable.** Konsist can see `data class` properties, so this is enforceable;
-   nobody has written it.
+Every invariant in this list is now mechanically enforced. If you add one, add its rule in the
+same change — a convention with no test is a convention that drifts.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ diagram that only lives in a README rots; these rules fail the build. They run a
 | Dev-app sandboxes depend only on `api` + `fakes` modules, which is what keeps them fast | `DevAppDependencyBoundaryTest` |
 | No module applies `java-test-fixtures` — fixtures live in sibling `:fakes` modules (ADR 0001) | `TestFixturesPluginBoundaryTest` |
 | ViewModels never use `MutableSharedFlow` — it drops one-shot events when nothing is collecting | `OneShotEventBoundaryTest` |
+| Domain models are immutable — no `var`, and no `val` holding a mutable collection | `DomainModelImmutabilityTest` |
 
 Reinforced by:
 

--- a/konsist/src/test/kotlin/com/simtop/konsist/DomainModelImmutabilityTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/DomainModelImmutabilityTest.kt
@@ -1,0 +1,93 @@
+package com.simtop.konsist
+
+import com.lemonappdev.konsist.api.Konsist
+import com.lemonappdev.konsist.api.declaration.KoClassDeclaration
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Domain models are values: two `Beer`s with the same fields are the same beer, and nothing that
+ * receives one can change what the sender sees. The app leans on this. `PagedListReducer` folds
+ * pages into a list and hands it to Compose, which decides what to recompose by comparing old
+ * state to new - a model mutated in place is the same reference, so the comparison says
+ * "unchanged" and the UI silently keeps rendering stale data. The mappers and the pager pass the
+ * same instances around on the same assumption.
+ *
+ * Two ways to break it, so two rules:
+ *
+ * 1. A `var` property - the obvious one.
+ * 2. A `val` holding a **mutable collection**. `val items: MutableList<Beer>` reads as immutable
+ *    and is not: the reference is fixed, the contents are not, and `items.add(...)` mutates
+ *    something another layer is already holding. This is the half that slips through review, which
+ *    is why it is enforced rather than trusted.
+ *
+ * `Array` is in the same list for a second reason: it uses identity equality, so a data class with
+ * an `Array` property gets an `equals` that reports two identical models as different - breaking
+ * the same recomposition comparison from the opposite direction.
+ *
+ * Scoped to `com.simtop.beerdomain.domain`, matching [DomainLayerPurityTest]. Konsist's
+ * `properties()` includes primary-constructor properties, which is where every model here declares
+ * its state - verified by mutating a real model and watching this fail, not assumed.
+ */
+class DomainModelImmutabilityTest {
+
+  /** Bare type names, since a property's type is written unqualified in practice. */
+  private val mutableTypeNames =
+    setOf(
+      "MutableList",
+      "MutableSet",
+      "MutableMap",
+      "MutableCollection",
+      "MutableIterable",
+      "ArrayList",
+      "HashMap",
+      "HashSet",
+      "LinkedHashMap",
+      "LinkedHashSet",
+      "Array",
+    )
+
+  private fun domainClasses(): List<KoClassDeclaration> =
+    Konsist.scopeFromProject()
+      .files
+      .filter { it.packagee?.name?.startsWith("com.simtop.beerdomain.domain") == true }
+      .flatMap { it.classes(includeNested = true) }
+
+  @Test
+  fun `domain models expose no var properties`() {
+    val classes = domainClasses()
+
+    assertTrue(classes.isNotEmpty()) {
+      "No classes found under com.simtop.beerdomain.domain - the domain layout changed and this " +
+        "rule would pass vacuously"
+    }
+
+    val violations =
+      classes.flatMap { koClass ->
+        koClass.properties().filter { it.hasVarModifier }.map { "${koClass.name}.${it.name}" }
+      }
+
+    assertTrue(violations.isEmpty()) {
+      "Domain models must be immutable, but these are `var`: $violations. Model a change as a new " +
+        "value (`copy(...)`) instead - Compose compares old state to new to decide what to redraw, " +
+        "and an in-place mutation keeps the same reference, so the UI never updates."
+    }
+  }
+
+  @Test
+  fun `domain models hold no mutable collection types`() {
+    val violations =
+      domainClasses().flatMap { koClass ->
+        koClass.properties().mapNotNull { property ->
+          val typeName = property.type?.name?.substringBefore('<')?.substringAfterLast('.')
+          if (typeName in mutableTypeNames) "${koClass.name}.${property.name}: $typeName" else null
+        }
+      }
+
+    assertTrue(violations.isEmpty()) {
+      "These properties are `val` but hold mutable contents: $violations. Use the read-only " +
+        "interface (List/Set/Map) - a val MutableList is not an immutable model, and whoever " +
+        "received it can change what the sender is still holding."
+    }
+  }
+}


### PR DESCRIPTION
The last invariant in AGENTS.md §3 that had no rule behind it. All six domain models already comply, so this is a **ratchet, not a fix** — it stops the seventh from being written differently.

### Two rules, because there are two ways to break it

A `var` property is the obvious one. The other is a `val` holding a **mutable collection**:

```kotlin
data class BeerPage(val items: MutableList<Beer>, ...)   // reads immutable; isn't
```

The reference is fixed, the contents are not. Whoever receives the model can call `items.add(...)` and change what the sender is still holding. That's the half that slips through review, which is why it's worth enforcing rather than trusting.

`Array` is banned for a second reason: identity equality gives a data class an `equals` that reports two identical models as *different* — breaking the same Compose recomposition comparison from the opposite direction.

### Why this matters beyond tidiness

`PagedListReducer` folds pages into a list and hands it to Compose, which decides what to recompose by comparing old state to new. A model mutated in place is the same reference, so the comparison says "unchanged" and the UI silently keeps rendering stale data. The mappers and the pager pass the same instances around on the same assumption.

### Verified against real violations, not assumed

Both halves were checked by introducing a violation into a real model **in the primary constructor** and confirming the build fails:

- `data class BeerStyle(val id: String, var name: String)` → fails
- `data class BeerPage(val items: MutableList<Beer>, ...)` → fails

That specifically confirms Konsist's `properties()` sees primary-constructor properties. Had it not, the rule would have passed vacuously on every data class here — that's where all of them declare their state, so the check would have been decorative.

### Docs kept in step

AGENTS.md and the README rule table go from eight to nine in the same commit, and AGENTS.md §3 now states that every invariant it lists is mechanically enforced, with a note to add the rule alongside any new one.

`make konsist` · `spotlessCheck` · `make lint` — green.