### PR TITLE
fix: repair the two convention defects that block androidTest in any module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,23 @@ is re-run. Not an app bug.
 **Gotcha: `installDebug` is broken** by a duplicate PreviewProvider service entry — install the
 split APKs with `adb install-multiple` (the `billionbeers-android` skill handles this).
 
+**Adding `androidTest` to a module: two traps, both now fixed in build-logic.** Recorded because
+the symptoms point away from the cause. (1) The screenshot convention used to feed its generated
+Paparazzi runner into *every* compile task matching `"Test"`, including
+`compileDebugAndroidTestKotlin` — so the first screenshot-enabled module to gain an androidTest
+source set failed with `Unresolved reference 'Paparazzi'` in a file it never wrote. The filter now
+matches `"UnitTest"`. (2) `PROJECT_TEST_RUNNER` used to name `MockTestRunner`, which lives in
+`app/src/androidTest` — every other module built a test APK referencing a class it did not contain
+and died on device with `ClassNotFoundException`. The default is now the stock
+`AndroidJUnitRunner`; `:app` opts up in its own build script. A module that needs a custom runner
+sets it in its own `android { defaultConfig { … } }`, which overrides the convention.
+
+**Instrumented tests are opt-in per module.** A module needs
+`id("billionbeers.android.managed.device")` for `atdApi35DebugAndroidTest` to exist and for CI's
+`ciGroupDebugAndroidTest` to pick it up. Without it the tests compile and never run — the
+`:konsist:test` failure mode. Today `:app`, `:beer_database` and `:benchmark:microbenchmark` are
+opted in.
+
 ---
 
 ## 6. Build & development commands

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,11 @@ android {
   namespace = "com.simtop.billionbeers"
   dynamicFeatures += setOf(":feature:beerdetail", ":feature:beerbrowse")
 
+  // Opt up from the shared default (androidx.test.runner.AndroidJUnitRunner). MockTestRunner
+  // substitutes BillionBeersApplication so the instrumented tests can swap in the fake Metro graph
+  // - it lives in this module's androidTest source set, so only this module can name it.
+  defaultConfig { testInstrumentationRunner = "com.simtop.billionbeers.di.MockTestRunner" }
+
   packaging {
     resources {
       excludes += "META-INF/versions/9/module-info.class"

--- a/beer_database/build.gradle.kts
+++ b/beer_database/build.gradle.kts
@@ -5,13 +5,7 @@ plugins {
   id("billionbeers.android.managed.device")
 }
 
-android {
-  namespace = "com.simtop.beer_database"
-  // The shared convention points every module at the app's MockTestRunner (Metro/mockk graph),
-  // which doesn't exist here. This module's instrumented tests are plain Room migration checks, so
-  // use the stock runner.
-  defaultConfig { testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner" }
-}
+android { namespace = "com.simtop.beer_database" }
 
 dependencies {
   implementation(project(":core"))

--- a/build-logic/convention/src/main/kotlin/Versions.kt
+++ b/build-logic/convention/src/main/kotlin/Versions.kt
@@ -1,6 +1,10 @@
 import org.gradle.api.JavaVersion
 
-val PROJECT_TEST_RUNNER = "com.simtop.billionbeers.di.MockTestRunner"
+// The stock runner is the right default for every module: a custom runner exists to swap the Metro
+// application graph, and only :app has one. :app opts *up* to its own MockTestRunner in its build
+// script. Naming an :app-owned class here made every other module's test APK reference a class it
+// does not contain, failing on device with ClassNotFoundException.
+val PROJECT_TEST_RUNNER = "androidx.test.runner.AndroidJUnitRunner"
 val PROJECT_JAVA_VERSION = JavaVersion.VERSION_23
 val DETEKT_JAVA_VERSION = "22"
 val PROJECT_JACOCO_VERSION = "0.8.13"

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
@@ -153,8 +153,13 @@ tasks.matching {
         ?.exclude("META-INF/services/com.simtop.billionbeers.snapshot_testing.PreviewProvider")
 }
 
+// UnitTest, not Test: the generated runner is a Paparazzi (JVM-only) test and belongs solely to the
+// unit-test compilation. Matching "Test" also matched compileDebugAndroidTestKotlin, which fed the
+// generated file into the *instrumented* compile - where Paparazzi is not on the classpath. That was
+// latent only because no screenshot-enabled module had an androidTest source set; the first one to
+// add one failed with "Unresolved reference 'Paparazzi'" before this task had any chance to run.
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    if (name.contains("Test", ignoreCase = true)) {
+    if (name.contains("UnitTest", ignoreCase = true)) {
         source(generatePaparazziTest)
     }
 }


### PR DESCRIPTION
Two defects in the convention plugins make it impossible to add an `androidTest` source set to any module but `:app`. Both are latent — nothing in the repo triggers them today — and both fire immediately on the first module that grows one. I found them by adding a single Compose UI test to `:feature:beerslist` and running it on the ATD managed device; it failed twice before it passed.

### 1. The screenshot convention poisons instrumented compilation

`billionbeers.android.screenshot.gradle.kts` fed its generated Paparazzi runner into every Kotlin compile task whose name contains `"Test"` — which matches `compileDebugAndroidTestKotlin`. Paparazzi is JVM-only and is not on the instrumented classpath, so the module fails to compile with an unresolved reference in a file it never wrote:

```
e: .../Com_simtop_feature_beerslistScreenshotTest.kt:22:21 Unresolved reference 'Paparazzi'
e: .../Com_simtop_feature_beerslistScreenshotTest.kt:23:24 Unresolved reference 'DeviceConfig'
> Task :feature:beerslist:compileDebugAndroidTestKotlin FAILED
```

Matching `"UnitTest"` scopes the generated source to the compilation it actually belongs to.

### 2. Every module inherits a test runner only `:app` owns

`PROJECT_TEST_RUNNER` named `com.simtop.billionbeers.di.MockTestRunner`, which lives in `app/src/androidTest`. Every other module built a test APK naming a runner it does not contain:

```
java.lang.ClassNotFoundException: Didn't find class
  "com.simtop.billionbeers.di.MockTestRunner" on path: DexPathList[[zip file
  ".../com.simtop.feature.beerslist.test.../base.apk"]]
```

This had been hit before: `beer_database/build.gradle.kts` carried a private override back to the stock runner, fixing one module rather than the default.

The default was backwards. A custom runner exists to substitute the Metro application graph, and only `:app` has one — so the shared default is now `androidx.test.runner.AndroidJUnitRunner` and `:app` opts *up* in its own build script, where the class it names actually lives. `beer_database`'s override is deleted as redundant.

### Verification

- 20 instrumented tests green on `atdApi35` — 14 in `:app`, 6 in `:beer_database`
- Merged manifests confirm the runners resolve as intended: `:app` → `MockTestRunner`, `:beer_database` → `AndroidJUnitRunner` (so the `:app` tests are not passing by accident on the stock runner)
- `:feature:beersearch`, a screenshot-enabled module, now compiles an `androidTest` source set — the case that failed before
- `make screenshot-verify`, `make test`, `make konsist`, `make lint` all pass

### Also

AGENTS.md §5 gains both traps, plus a note that instrumented tests are opt-in per module via `billionbeers.android.managed.device` — a module without it compiles its tests and never runs them, which is the `:konsist:test` failure mode.

No behaviour changes to shipping code; this is build configuration only.
