### PR TITLE
feat: add the feature-module UI test tier, with its first two tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ when they get in the way. (`:konsist`'s build-script rules skip `bin/` for this 
 
 ## 3. Invariants — break these and the build (or an instrumented test) breaks
 
-All nine are enforced by `:konsist`; the wording here is from the tests themselves.
+All ten are enforced by `:konsist`; the wording here is from the tests themselves.
 
 1. **Repository interfaces do not import data-layer types.** (`RepositoryBoundaryTest`)
 2. **Feature modules never depend on other feature modules** — `beerslist` ⊥ `beerdetail`, and so
@@ -88,6 +88,13 @@ All nine are enforced by `:konsist`; the wording here is from the tests themselv
 9. **Domain models are immutable** — no `var`, and no `val` holding a mutable collection
    (`MutableList`, `HashMap`, `Array`, …), which is the half that slips through review.
    (`DomainModelImmutabilityTest`.)
+
+10. **A module with `src/androidTest/` opts into the managed device** — via
+    `billionbeers.android.feature.uitest` (feature modules) or `billionbeers.android.managed.device`
+    directly. Without it the module has no `atdApi35DebugAndroidTest` task and is absent from
+    `ciGroupDebugAndroidTest`, so its tests compile, look like coverage, and never run.
+    `:benchmark:*` is exempt — benchmarks use their own runner and real hardware, not the ATD lane.
+    (`InstrumentedTestOptInBoundaryTest` — reads the build scripts.)
 
 Every invariant in this list is now mechanically enforced. If you add one, add its rule in the
 same change — a convention with no test is a convention that drifts.
@@ -165,11 +172,14 @@ and died on device with `ClassNotFoundException`. The default is now the stock
 `AndroidJUnitRunner`; `:app` opts up in its own build script. A module that needs a custom runner
 sets it in its own `android { defaultConfig { … } }`, which overrides the convention.
 
-**Instrumented tests are opt-in per module.** A module needs
-`id("billionbeers.android.managed.device")` for `atdApi35DebugAndroidTest` to exist and for CI's
-`ciGroupDebugAndroidTest` to pick it up. Without it the tests compile and never run — the
-`:konsist:test` failure mode. Today `:app`, `:beer_database` and `:benchmark:microbenchmark` are
-opted in.
+**Instrumented tests are opt-in per module.** A module needs `billionbeers.android.managed.device`
+— directly, or via `billionbeers.android.feature.uitest` — for `atdApi35DebugAndroidTest` to exist
+and for CI's `ciGroupDebugAndroidTest` to pick it up. Without it the tests compile and never run,
+the `:konsist:test` failure mode; invariant 10 now enforces this. Opted in today: `:app`,
+`:beer_database`, `:feature:beerslist`. `:benchmark:microbenchmark` has `androidTest` sources but is
+*deliberately* out — it declares `AndroidBenchmarkRunner`, builds against
+`testBuildType = "release"`, and suppresses the `EMULATOR` error class, because a measurement taken
+on a managed virtual device is meaningless. It runs via `make benchmark-check`.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,8 +73,8 @@ dependencies {
   testImplementation(libs.striktCore)
   androidTestImplementation(libs.striktCore)
 
-  androidTestImplementation("androidx.compose.ui:ui-test-junit4")
-  debugImplementation("androidx.compose.ui:ui-test-manifest")
+  androidTestImplementation(libs.androidx.ui.test.junit4)
+  debugImplementation(libs.androidx.ui.test.manifest)
 
   androidTestImplementation(libs.roomRuntime)
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.feature.uitest.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.feature.uitest.gradle.kts
@@ -1,0 +1,39 @@
+import org.gradle.accessors.dm.LibrariesForLibs
+
+/**
+ * Opts a feature module into the instrumented UI-test tier: one plugin id instead of the six
+ * declarations each module would otherwise repeat.
+ *
+ * Applied on top of `billionbeers.android.feature`, which already supplies the Compose BOM (on the
+ * androidTest configuration too) and the Espresso / test-runner baseline from
+ * `billionbeers.android.library`. What is left is the managed device, the Compose test rules, and
+ * the domain fakes every screen test drives its state with.
+ *
+ * **This tier is for behaviour that only a real device can show** - fling and layout-driven paging,
+ * a real IME, accessibility traversal, state restoration. Anything a JVM test can already prove
+ * belongs in `src/test/`, and anything about a static rendering belongs in Paparazzi; both are
+ * faster and neither needs an emulator. `:feature:beerslist`'s `InfiniteListHandler` is the model
+ * case: its signal logic has seven unit tests in `:presentation_utils`, so the instrumented test
+ * covers only the part those cannot reach - the real `LazyColumn` layout feeding the handler.
+ *
+ * Applying this plugin adds the module to `ciGroupDebugAndroidTest`, so its tests run on every push
+ * (AGENTS.md §5). Dynamic-feature modules cannot use this tier - resources declared inside them
+ * crash instrumented tests, which is invariant 5.
+ */
+apply(plugin = "billionbeers.android.managed.device")
+
+val libs = the<LibrariesForLibs>()
+
+dependencies {
+    // Fakes for the domain interfaces, so a screen test drives state without the data layer.
+    "androidTestImplementation"(project(":beerdomain:fakes"))
+
+    // Versionless: the Compose BOM is already on androidTestImplementation via
+    // billionbeers.android.compose, which billionbeers.android.feature applies.
+    "androidTestImplementation"(libs.androidx.ui.test.junit4)
+
+    // Provides the empty ComponentActivity that createComposeRule() hosts the content in. It is a
+    // debug-only manifest contribution, hence debugImplementation rather than an androidTest
+    // configuration - the test APK reads it from the module under test.
+    "debugImplementation"(libs.androidx.ui.test.manifest)
+}

--- a/feature/beerslist/build.gradle.kts
+++ b/feature/beerslist/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
   id("billionbeers.android.feature")
   id("billionbeers.android.screenshot")
+  id("billionbeers.android.feature.uitest")
 }
 
 android { namespace = "com.simtop.feature.beerslist" }

--- a/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListPagingUiTest.kt
+++ b/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListPagingUiTest.kt
@@ -1,0 +1,131 @@
+package com.simtop.feature.beerslist
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollToIndex
+import androidx.test.platform.app.InstrumentationRegistry
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.fakes.fakeBeerModel
+import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
+import com.simtop.core.core.CommonUiState
+import com.simtop.core.core.PagedListFooter
+import com.simtop.core.core.PagedListUiModel
+import com.simtop.presentation_utils.R as PresentationUtilsR
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The half of load-more that a JVM test cannot reach: a real `LazyColumn` laying itself out and
+ * feeding [com.simtop.presentation_utils.core.InfiniteListHandler] through `snapshotFlow`.
+ *
+ * The signal logic itself is *not* retested here - `InfiniteListHandlerTest` in
+ * `:presentation_utils` already covers it with seven cases over synthetic `ListPosition` values,
+ * including the count-based dedup that PR #70 fixed. What those cannot see is whether the handler
+ * is wired to the list at all, whether it is wired to the *same* `LazyListState` the `LazyColumn`
+ * uses, and whether the screen's own suppression rule holds. Those need real layout, so they live
+ * here.
+ */
+class BeersListPagingUiTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  /**
+   * Long enough that the bottom is well off-screen on first layout - the tests assert the callback
+   * has *not* fired before scrolling, which is what proves they are testing the scroll rather than
+   * a list that was already at its end.
+   */
+  private val beers: List<Beer> =
+    List(40) { index -> fakeBeerModel.copy(id = "$index", name = "Beer $index") }
+
+  private val lastBeerIndex = beers.lastIndex
+
+  private fun string(resId: Int): String =
+    InstrumentationRegistry.getInstrumentation().targetContext.getString(resId)
+
+  private fun setContent(footer: PagedListFooter, onScrollToBottom: () -> Unit) {
+    composeTestRule.setContent { Content(footer = footer, onScrollToBottom = onScrollToBottom) }
+  }
+
+  @Composable
+  private fun Content(footer: PagedListFooter, onScrollToBottom: () -> Unit) {
+    BillionBeersTheme {
+      BeersListContent(
+        viewState =
+          CommonUiState.Success(
+            PagedListUiModel(items = beers, footer = footer, totalCount = beers.size)
+          ),
+        onBeerClick = {},
+        onSearchClick = {},
+        onBrowseClick = {},
+        onScrollToBottom = onScrollToBottom,
+        onRefresh = {},
+        onRetry = {},
+        onRetryLoadMore = {},
+      )
+    }
+  }
+
+  @Test
+  fun scrollingToTheBottomRequestsTheNextPage() {
+    var loadMoreCount = 0
+    setContent(PagedListFooter.Hidden) { loadMoreCount++ }
+
+    composeTestRule.waitForIdle()
+    assertEquals(
+      "load-more fired before any scroll - the list was already at its end",
+      0,
+      loadMoreCount,
+    )
+
+    composeTestRule.onNodeWithTag(BEER_LIST_TAG).performScrollToIndex(lastBeerIndex)
+
+    // The callback runs from a LaunchedEffect collecting a snapshotFlow, so it can land after the
+    // scroll returns. Waiting on the condition rather than asserting straight away is what keeps
+    // this from passing on a warm local device and flaking on a CI runner.
+    composeTestRule.waitUntil(WAIT_TIMEOUT_MS) { loadMoreCount > 0 }
+
+    assertEquals(1, loadMoreCount)
+  }
+
+  /**
+   * The rule at `BeersListScreen`'s `footer !is PagedListFooter.Retry` guard: after a failed load
+   * the user is parked at the bottom, so auto-load has to stand down and let the Retry button be
+   * the only way forward. Otherwise scrolling away and back silently re-fires the request the user
+   * was just told had failed.
+   *
+   * Structured so it cannot pass vacuously: it asserts the retry footer is on screen after the
+   * scroll, which proves the gesture actually reached the bottom. A negative assertion alone would
+   * also "pass" if the scroll had done nothing at all.
+   */
+  @Test
+  fun theRetryFooterSuspendsAutoLoad() {
+    var loadMoreCount = 0
+    setContent(PagedListFooter.Retry) { loadMoreCount++ }
+
+    composeTestRule.waitForIdle()
+    assertEquals(0, loadMoreCount)
+
+    // One past the last beer: the retry footer is its own item in the lazy list.
+    composeTestRule.onNodeWithTag(BEER_LIST_TAG).performScrollToIndex(lastBeerIndex + 1)
+    composeTestRule.waitForIdle()
+
+    composeTestRule
+      .onNodeWithText(string(PresentationUtilsR.string.paged_list_load_more_failed))
+      .assertIsDisplayed()
+
+    assertEquals(
+      "auto-load fired while the retry footer was up - the user must drive this with Retry",
+      0,
+      loadMoreCount,
+    )
+  }
+
+  private companion object {
+    const val BEER_LIST_TAG = "beer_list"
+    const val WAIT_TIMEOUT_MS = 5_000L
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,6 +82,9 @@ roomGradlePlugin = { module = "androidx.room:room-gradle-plugin", version.ref = 
 
 # Compose (managed by BOM)
 androidxComposeBom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+# Versionless on purpose - both come from the Compose BOM above.
+androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidxActivityCompose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-foundation-android = { group = "androidx.compose.foundation", name = "foundation-android" }
 androidx-runtime-retain = { group = "androidx.compose.runtime", name = "runtime-retain" }

--- a/konsist/src/test/kotlin/com/simtop/konsist/InstrumentedTestOptInBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/InstrumentedTestOptInBoundaryTest.kt
@@ -1,0 +1,60 @@
+package com.simtop.konsist
+
+import java.io.File
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Instrumented tests are opt-in per module: without `billionbeers.android.managed.device` a module
+ * has no `atdApi35DebugAndroidTest` task and is not part of `ciGroupDebugAndroidTest`, so its
+ * `androidTest` sources compile and are never executed. That is the `:konsist:test` failure mode
+ * (AGENTS.md §5) - tests that exist, look like coverage in review, and silently assert nothing for
+ * months.
+ *
+ * The invariant lives in build.gradle.kts, not in Kotlin source, and Konsist's project scope does
+ * not surface build scripts, so this rule reads them directly - the same approach as
+ * [DevAppDependencyBoundaryTest].
+ *
+ * `:benchmark:*` is exempt, and deliberately so: benchmark modules declare their own
+ * `AndroidBenchmarkRunner`, build against `testBuildType = "release"`, and suppress the EMULATOR
+ * error class because a measurement taken on a managed virtual device is meaningless. They run
+ * through `make benchmark-check` on real hardware, not the ATD lane.
+ */
+class InstrumentedTestOptInBoundaryTest {
+
+  /**
+   * Plugin ids that put a module on the managed device: the device plugin itself, and the wrappers
+   * that apply it. Listed rather than resolved, because this rule reads build scripts as text and
+   * cannot follow a plugin into build-logic. A new wrapper must be added here - the cost of
+   * forgetting is a loud failure on the next module that uses it, not a silent gap.
+   */
+  private val optInPluginIds =
+    listOf("billionbeers.android.managed.device", "billionbeers.android.feature.uitest")
+
+  @Test
+  fun `modules with instrumented tests opt into the managed device`() {
+    val root = repoRoot()
+
+    val modulesWithInstrumentedTests =
+      buildScripts(root)
+        .filter { File(it.parentFile, "src/androidTest").isDirectory }
+        .filterNot { it.parentFile.relativeTo(root).invariantSeparatorsPath.startsWith("benchmark/") }
+
+    assertTrue(modulesWithInstrumentedTests.isNotEmpty()) {
+      "No module with a src/androidTest directory found under $root - the layout changed and this " +
+        "rule would pass vacuously"
+    }
+
+    val violations =
+      modulesWithInstrumentedTests
+        .filterNot { script -> optInPluginIds.any { script.uncommentedText().contains(it) } }
+        .map { it.parentFile.relativeTo(root).invariantSeparatorsPath }
+
+    assertTrue(violations.isEmpty()) {
+      "Module(s) $violations have src/androidTest but apply none of $optInPluginIds - their " +
+        "instrumented tests would never run, locally or in CI. Apply " +
+        "'billionbeers.android.feature.uitest' (feature modules) or " +
+        "'billionbeers.android.managed.device' directly."
+    }
+  }
+}


### PR DESCRIPTION
Instrumented tests only existed in `:app`, where running one means assembling the whole app plus both dynamic-feature splits before a single assertion executes. This adds the tier a feature module can use instead, and proves it with the two tests that motivated it.

### The opt-in

`billionbeers.android.feature.uitest` — one plugin id in place of the managed device, the Compose test rules and `:beerdomain:fakes`. `:feature:beerslist` is the first consumer.

### The tests cover only what a JVM test cannot reach

`loadMoreSignals` already has seven unit tests in `:presentation_utils` over synthetic `ListPosition` values, including the count-based dedup from #70. Neither new test re-checks that logic — they check the wiring only real layout produces:

- **`scrollingToTheBottomRequestsTheNextPage`** — a real `LazyColumn` laying itself out and feeding `InfiniteListHandler` through `snapshotFlow`. Catches the handler being detached, or bound to a different `LazyListState` than the list uses.
- **`theRetryFooterSuspendsAutoLoad`** — `BeersListScreen`'s `footer !is PagedListFooter.Retry` guard. After a failed load the user is parked at the bottom, so auto-load must stand down and let Retry be the only way forward. That rule was documented in a comment and tested nowhere.

**Both were mutation-checked, not merely run.** Removing the Retry guard fails the second test and only that one; detaching `InfiniteListHandler` fails the first and only that one. Each test also asserts the callback has *not* fired before scrolling, so neither can pass on a list that was already at its end — and the negative test asserts the retry footer is on screen afterwards, so it cannot pass because the scroll silently did nothing.

Run twice on `atdApi35` back to back, both green.

### Invariant 10

`InstrumentedTestOptInBoundaryTest`: a module with `src/androidTest/` must opt into the managed device. Without it the module has no `atdApi35DebugAndroidTest` task and is absent from `ciGroupDebugAndroidTest` — its tests compile, read as coverage in review, and never run. Verified to actually fail on a real violation rather than only to pass.

`:benchmark:*` is exempt, deliberately: benchmark modules declare `AndroidBenchmarkRunner`, build against `testBuildType = "release"` and suppress the `EMULATOR` error class, because a measurement on a managed virtual device is meaningless. They run through `make benchmark-check`.

### Two things worth flagging

**This makes the instrumented lane slower, not faster.** CI runs `ciGroupDebugAndroidTest` across all opted-in modules, so `:feature:beerslist` adds a third APK build and install. The tier buys correct test placement, fast local iteration, isolation from app assembly, and shardability — per-module test APKs shard across matrix runners, a monolithic `:app` test does not. It does not buy a shorter CI run.

**No `:testing-utils-android` robots module yet — deliberate.** These tests have one consumer and use `ComposeTestRule` directly. Extracting a shared robots module now would also churn `:app`'s existing test sources for no current benefit; the right moment is when a second module needs them.

### Also

- Corrects an error in the AGENTS.md note added by #137: it listed `:benchmark:microbenchmark` as opted into the managed device, which it is not.
- `:app`'s two raw Compose test coordinates move to catalog aliases. Both resolve to already-verified artifacts, so the dependency ledger is unchanged.

`make test`, `make konsist`, `make screenshot-verify`, `make lint`, `make format` all pass.
