### PR TITLE
feat: add pull-to-refresh to the browse-by-style/brewery list

### DIFF
--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersScreen.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -63,12 +64,15 @@ internal fun BrowseBeersScreen(
   val context = LocalContext.current
   val lifecycleOwner = LocalLifecycleOwner.current
   val loadMoreFailedMessage = stringResource(R.string.paged_list_load_more_failed)
+  val refreshFailedMessage = stringResource(R.string.paged_list_refresh_failed)
 
   LaunchedEffect(viewModel, lifecycleOwner) {
     lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
       viewModel.events.collect { event ->
         when (event) {
           BrowseBeersEvent.ShowLoadMoreError -> showToast(context, loadMoreFailedMessage)
+          // A failed refresh keeps the list; pulling again is the retry.
+          BrowseBeersEvent.ShowRefreshError -> showToast(context, refreshFailedMessage)
         }
       }
     }
@@ -94,6 +98,7 @@ internal fun BrowseBeersContent(
   onBeerClick: (Beer) -> Unit,
   onScrollToBottom: () -> Unit,
   onRetryLoadMore: () -> Unit,
+  // Serves both first-page reloads: the full-screen error retry and the pull-to-refresh gesture.
   onRetryFirstPage: () -> Unit,
 ) {
   Scaffold(
@@ -128,6 +133,7 @@ internal fun BrowseBeersContent(
               model = state.data,
               onBeerClick = onBeerClick,
               onScrollToBottom = onScrollToBottom,
+              onRefresh = onRetryFirstPage,
               onRetryLoadMore = onRetryLoadMore,
             )
           }
@@ -141,37 +147,41 @@ private fun BrowseBeersResults(
   model: PagedListUiModel<Beer>,
   onBeerClick: (Beer) -> Unit,
   onScrollToBottom: () -> Unit,
+  onRefresh: () -> Unit,
   onRetryLoadMore: () -> Unit,
 ) {
-  Column {
-    model.totalCount?.let { count ->
-      Text(
-        text = stringResource(R.string.browse_beers_count, count),
-        style = MaterialTheme.typography.labelLarge,
-        modifier =
-          Modifier.fillMaxWidth()
-            .padding(
-              horizontal = BillionBeersTheme.spacing.medium,
-              vertical = BillionBeersTheme.spacing.small,
-            ),
-      )
-    }
-
-    val listState = rememberLazyListState()
-    if (model.footer !is PagedListFooter.Retry) {
-      InfiniteListHandler(listState = listState, onLoadMore = onScrollToBottom)
-    }
-
-    val endOfListText = stringResource(R.string.browse_beers_end_of_list, model.items.size)
-    LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-      items(model.items.size) { index ->
-        ComposeBeersListItem(beer = model.items[index], onClick = onBeerClick)
+  // The count header sits inside the box so it travels with the pull, as on the catalog screen.
+  PullToRefreshBox(isRefreshing = model.isRefreshing, onRefresh = onRefresh) {
+    Column {
+      model.totalCount?.let { count ->
+        Text(
+          text = stringResource(R.string.browse_beers_count, count),
+          style = MaterialTheme.typography.labelLarge,
+          modifier =
+            Modifier.fillMaxWidth()
+              .padding(
+                horizontal = BillionBeersTheme.spacing.medium,
+                vertical = BillionBeersTheme.spacing.small,
+              ),
+        )
       }
-      pagedListFooter(
-        model = model,
-        endOfListText = endOfListText,
-        onRetryLoadMore = onRetryLoadMore,
-      )
+
+      val listState = rememberLazyListState()
+      if (model.footer !is PagedListFooter.Retry) {
+        InfiniteListHandler(listState = listState, onLoadMore = onScrollToBottom)
+      }
+
+      val endOfListText = stringResource(R.string.browse_beers_end_of_list, model.items.size)
+      LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+        items(model.items.size) { index ->
+          ComposeBeersListItem(beer = model.items[index], onClick = onBeerClick)
+        }
+        pagedListFooter(
+          model = model,
+          endOfListText = endOfListText,
+          onRetryLoadMore = onRetryLoadMore,
+        )
+      }
     }
   }
 }

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersViewModel.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersViewModel.kt
@@ -11,6 +11,7 @@ import com.simtop.core.core.CoroutineDispatcherProvider
 import com.simtop.core.core.PagedListReducer
 import com.simtop.core.core.PagedListUiModel
 import com.simtop.core.core.PagingEvent
+import com.simtop.core.core.PagingState
 import com.simtop.feature.beerbrowse.presentation.di.FeatureBrowseScope
 import com.simtop.presentation_utils.core.toErrorState
 import dev.zacsweers.metro.Assisted
@@ -81,6 +82,23 @@ constructor(
         }
       }
     }
+    observeRefreshFailures()
+  }
+
+  private fun observeRefreshFailures() {
+    viewModelScope.launch {
+      pager.pagingState.collect { pagingState ->
+        // A first-page failure with a list already on screen is a failed refresh: the reducer keeps
+        // the list, so the user's only feedback is this one-shot toast.
+        if (
+          pagingState is PagingState.Error &&
+            pagingState.isFirstPage &&
+            viewState.value is CommonUiState.Success
+        ) {
+          _events.trySend(BrowseBeersEvent.ShowRefreshError)
+        }
+      }
+    }
   }
 
   fun onScrollToBottom() {
@@ -91,7 +109,11 @@ constructor(
     viewModelScope.launch(coroutineDispatcher.io) { pager.loadNextPage() }
   }
 
-  /** Full-screen error retry: re-runs the first page of this selection. */
+  /**
+   * Re-runs the first page of this selection, for both callers that want one: the full-screen error
+   * retry, and pull-to-refresh. With a list already on screen the reducer turns this into the
+   * refresh spinner and keeps the items under it; a failure degrades to the one-shot toast.
+   */
   fun onRetryFirstPage() {
     viewModelScope.launch(coroutineDispatcher.io) { pager.loadFirstPage() }
   }
@@ -104,4 +126,6 @@ constructor(
 /** One-shot effects the browse beers screen consumes once. */
 sealed interface BrowseBeersEvent {
   data object ShowLoadMoreError : BrowseBeersEvent
+
+  data object ShowRefreshError : BrowseBeersEvent
 }

--- a/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/BrowseBeersViewModelTest.kt
+++ b/feature/beerbrowse/src/test/java/com/simtop/feature/beerbrowse/BrowseBeersViewModelTest.kt
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
 
 @ExperimentalCoroutinesApi
 class BrowseBeersViewModelTest {
@@ -143,6 +145,62 @@ class BrowseBeersViewModelTest {
           cancelAndIgnoreRemainingEvents()
         }
         expectThat(awaitItem()).isEqualTo(BrowseBeersEvent.ShowLoadMoreError)
+      }
+    }
+
+  @Test
+  fun `a first-page reload keeps the list under the refresh indicator`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.viewState.test {
+        runCurrent()
+        val pager = fakeFactory.searchPagers.last()
+        pager.setData(listOf(Beer.empty.copy(id = "1")))
+        pager.setPagingState(PagingState.Success())
+        runCurrent()
+
+        viewModel.onRetryFirstPage()
+        pager.setPagingState(PagingState.Loading)
+        runCurrent()
+
+        val refreshing = expectMostRecentItem()
+        val model = (refreshing as CommonUiState.Success).data
+        expectThat(model.isRefreshing).isTrue()
+        expectThat(model.items.map { it.id }).isEqualTo(listOf("1"))
+        // Two loads: the one from init, plus this refresh.
+        expectThat(pager.loadFirstPageCallCount).isEqualTo(2)
+        cancelAndIgnoreRemainingEvents()
+      }
+    }
+
+  // A failed refresh keeps the list on screen with no retry footer - the toast is the feedback and
+  // pulling again is the retry, matching the catalog screen.
+  @Test
+  fun `a failed refresh keeps the list, hides the footer and emits a one-shot refresh error`() =
+    runTest(testDispatcher) {
+      val viewModel = buildViewModel()
+
+      viewModel.events.test {
+        viewModel.viewState.test {
+          runCurrent()
+          val pager = fakeFactory.searchPagers.last()
+          pager.setData(listOf(Beer.empty.copy(id = "1")))
+          pager.setPagingState(PagingState.Success())
+          runCurrent()
+
+          viewModel.onRetryFirstPage()
+          pager.setPagingState(PagingState.Error(FetchBeersError.Network, isFirstPage = true))
+          runCurrent()
+
+          val state = expectMostRecentItem()
+          val model = (state as CommonUiState.Success).data
+          expectThat(model.items.map { it.id }).isEqualTo(listOf("1"))
+          expectThat(model.isRefreshing).isFalse()
+          expectThat(model.footer).isEqualTo(PagedListFooter.Hidden)
+          cancelAndIgnoreRemainingEvents()
+        }
+        expectThat(awaitItem()).isEqualTo(BrowseBeersEvent.ShowRefreshError)
       }
     }
 

--- a/presentation_utils/src/main/res/values/strings.xml
+++ b/presentation_utils/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="emergency_emergency_we_run_out_of_this_beer">EMERGENCY!!\nEMERGENCY!!\nWE RUN OUT OF THIS BEER</string>
     <string name="retry">Retry</string>
     <string name="paged_list_load_more_failed">Couldn\'t load more beers</string>
+    <string name="paged_list_refresh_failed">Couldn\'t refresh</string>
     <string name="empty_state">Empty State</string>
     <string name="abv_chip">ABV: %1$s%%</string>
     <string name="ibu_chip">IBU: %1$s</string>


### PR DESCRIPTION
The browse list already reduces through `PagedListReducer`, so `isRefreshing` was
already computed for it — it was simply never rendered. This closes the gap with the
catalog screen.

- `PullToRefreshBox` around the browse results (count header included, so it sits
  under the indicator with the list). The empty state stays outside it: a non-scrollable
  child would give a dead drag gesture.
- The missing refresh-failure path: `observeRefreshFailures()` + `ShowRefreshError`,
  mirroring `BeersListViewModel`. Previously a failed first-page reload with a list on
  screen produced no feedback at all.
- `onRetryFirstPage()` serves both first-page reloads — the full-screen retry and the
  pull gesture — instead of gaining an identical twin.
- The string goes in `:presentation_utils`: beerbrowse is a dynamic feature (invariant 5).

Two unit tests cover the reload keeping items under the indicator, and a failed reload
keeping the list, hiding the footer and emitting the one-shot event.

Verified on the emulator with the local-testing splits: the indicator appears mid-pull,
the list never flickers to a skeleton, and with the network off the pull leaves the 14
items in place and toasts "Couldn't refresh".