### PR TITLE
fix: translate paged_list_refresh_failed, unbreaking the lint gate on master

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,11 @@ declaring done.
 3. **Architecture** — `make konsist`
 4. **Screenshots** — `make screenshot-verify` (record with `make screenshot-record` and inspect the
    PNGs; they are your eyes on the UI)
-5. **Lint / format** — `make lint`, `make format`
+5. **Lint / format** — `make lint`, `make format`, and **`make android-lint` whenever resources
+   change**. `make lint` is Detekt only; the Android Lint gate CI runs is `make android-lint`
+   (`:app:lintDebug`, checkDependencies across the whole graph). A string added to
+   `values/strings.xml` without its `values-fr` / `values-es` siblings passes every other rung and
+   fails CI with `MissingTranslation` — that is how PR #140 broke master.
 6. **Device** — instrumented tests, install, logcat: use the `billionbeers-android` skill, not
    ad-hoc `adb`
 

--- a/presentation_utils/src/main/res/values-es/strings.xml
+++ b/presentation_utils/src/main/res/values-es/strings.xml
@@ -5,6 +5,7 @@
     <string name="emergency_emergency_we_run_out_of_this_beer">¡EMERGENCIA!!\n¡EMERGENCIA!!\nSE NOS ACABÓ ESTA CERVEZA</string>
     <string name="retry">Reintentar</string>
     <string name="paged_list_load_more_failed">No se pudieron cargar más cervezas</string>
+    <string name="paged_list_refresh_failed">No se pudo actualizar</string>
     <string name="empty_state">Sin resultados</string>
     <string name="abv_chip">ABV: %1$s%%</string>
     <string name="ibu_chip">IBU: %1$s</string>

--- a/presentation_utils/src/main/res/values-fr/strings.xml
+++ b/presentation_utils/src/main/res/values-fr/strings.xml
@@ -5,6 +5,7 @@
     <string name="emergency_emergency_we_run_out_of_this_beer">URGENCE!!\nURGENCE!!\nNOUS N\'AVONS PLUS CETTE BIÈRE</string>
     <string name="retry">Réessayer</string>
     <string name="paged_list_load_more_failed">Impossible de charger plus de bières</string>
+    <string name="paged_list_refresh_failed">Impossible d\'actualiser</string>
     <string name="empty_state">Aucun résultat</string>
     <string name="abv_chip">ABV : %1$s%%</string>
     <string name="ibu_chip">IBU : %1$s</string>


### PR DESCRIPTION
`59e213e` (PR #140) is red on master: `:app:lintDebug` fails with

```
presentation_utils/src/main/res/values/strings.xml:8: Error:
  "paged_list_refresh_failed" is not translated in "fr" (French) or "es" (Spanish) [MissingTranslation]
```

The string was added to `values/` only. This adds the two siblings, matching the register of the
neighbouring `paged_list_load_more_failed` entries.

Also fixes the gap that let it through: the verification ladder in AGENTS.md named `make lint`,
which is **Detekt only**. The Android Lint gate CI runs is `make android-lint` (`:app:lintDebug`
with checkDependencies over the whole graph), so a missing translation passes compile, unit tests,
konsist, screenshots, Detekt and format, then fails CI. Rung 5 now says so.

Verified: `:app:lintDebug --rerun-tasks` reports no new issues; `make test` and
`make screenshot-verify` green.