### PR TITLE
docs: record ADR 0010 non-goals, and stop citing local-only notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,17 +115,19 @@ same change — a convention with no test is a convention that drifts.
 | Dependency verification enforced; `make verification-metadata` regenerates the ledger, and a CI workflow does it on Dependabot branches so auto-merge survives — it re-baselines dependency-guard first (else the regen aborts on stale-baseline drift), but only when the drift is version-only | `docs/adr/0007` |
 | Per-lane CI test selection: a lane runs if the push could affect it or it was red last time, else it adopts the green verdict. Rules live in one function in `.github/scripts/detect-change-scope.sh` | `docs/adr/0008` |
 | Instrumented UI tests live in the feature module that owns the screen; cross-feature and install-gate tests stay in `:app`. Cost is ~49s per *module* vs ~2s per *test*, so concentrate tests and add modules deliberately | `docs/adr/0009` |
+| **Non-goals** — auth, cert pinning, encrypted storage, integrity/anti-tamper, push, server-side `available` sync, a shipped analytics/crash SDK, consent flows, automatic retry, multi-process. All declined because the premise is absent (the backend isn't ours, is read-only, and is unauthenticated), each with its reopen trigger. Read it before "adding what a real app has" — and delete a row in the same PR that builds it | `docs/adr/0010` |
 
 Also settled, without an ADR:
 
 - **Typed errors reuse `Either<L, R>` parameterized with a sealed error type** — the problem was
   `Either<Exception, T>`'s untyped left, not `Either`. No new `Result`/`Outcome` type.
-- **`available` is local-only** even though the API has the field. The backend isn't ours, so a
-  sync could only ever one-way-overwrite user edits. The server value seeds a row on first insert.
+- **`available` is local-only** even though the API has the field. The server value seeds a row on
+  first insert; nothing writes back. Now has an ADR — the reasoning and its reopen trigger live in
+  `docs/adr/0010`.
 - **The N+1 image fetch is gone** — list responses embed `image.url`. Don't reintroduce
   `GET /images/{id}`.
 - **Paging is complete and plug-and-play** (5 phases, 8/8 criteria). A new filtered surface needs a
-  wider `BeersQuery` and a screen — **not** `core-common` changes. Reference: `rod/PAGING_2_0.md`.
+  wider `BeersQuery` and a screen — **not** `core-common` changes.
 - **Mappers are injected classes, not objects**, so they're testable and swappable.
 
 ---
@@ -236,7 +238,9 @@ is vendored (each carries a `.android-skill-source` marker): `android-cli`, `nav
 ## 8. Docs & planning
 
 - **`docs/`** — committed, load-bearing docs only. `docs/adr/` is the decision record.
-- **`rod/`** — local-only notes and plans, gitignored as one folder rule. **It has no git history,
-  so deleting a file there is permanent.** `rod/July_Improvements.md` is the current consolidation
-  of open work; `rod/MASTER_PLAN.md` is the plan of record.
-- A doc that becomes load-bearing gets promoted from `rod/` to `docs/` and committed.
+- **Planning notes are local-only and gitignored**, so nothing in a clone points at them and no
+  committed file should cite one. **They also have no git history, so deleting one is permanent** —
+  never delete or overwrite a file in an ignored notes directory without being asked to.
+- Work that is decided but not built is described in `docs/adr/0010` as planned future work, not as
+  a pointer to a plan the reader cannot open.
+- A note that becomes load-bearing gets rewritten into `docs/` and committed.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ diagram that only lives in a README rots; these rules fail the build. They run a
 | No module applies `java-test-fixtures` — fixtures live in sibling `:fakes` modules (ADR 0001) | `TestFixturesPluginBoundaryTest` |
 | ViewModels never use `MutableSharedFlow` — it drops one-shot events when nothing is collecting | `OneShotEventBoundaryTest` |
 | Domain models are immutable — no `var`, and no `val` holding a mutable collection | `DomainModelImmutabilityTest` |
+| A module with `src/androidTest/` opts into the managed device — otherwise its tests compile, read as coverage, and never run | `InstrumentedTestOptInBoundaryTest` |
 
 Reinforced by:
 
@@ -157,8 +158,11 @@ Reinforced by:
   [ADR 0007](docs/adr/0007-gradle-dependency-verification.md).
 - **Convention plugins** — module setup lives in `build-logic`, so a new feature module is a plugin
   id and a namespace, not a copied 80-line build script.
-- **Decision record** — eight [ADRs](docs/adr/) covering the choices that are easy to second-guess:
-  no Paging3, no `java-test-fixtures`, no use-case layer.
+- **Decision record** — eleven [ADRs](docs/adr/) covering the choices that are easy to second-guess:
+  no Paging3, no `java-test-fixtures`, no use-case layer — and
+  [ADR 0010](docs/adr/0010-non-goals.md), which records the capabilities this project deliberately
+  *doesn't* have (auth, pinning, push, background sync) and the premise each one is waiting on, so
+  a deliberate absence never has to be mistaken for an oversight.
 - **Dev-app sandboxes** — `app-dev-<feature>` modules build a single feature against fakes for fast
   iteration (`make new-dev-app`).
 - **CI that runs only what a change can break** — a push to a PR reruns the test lanes its diff can

--- a/docs/adr/0002-hand-rolled-paging.md
+++ b/docs/adr/0002-hand-rolled-paging.md
@@ -80,7 +80,7 @@ entirely.
   DB-backed implementation for SSOT (the beers one upserts and never deletes, so the local-only
   `availability` field survives pull-to-refresh). Screens get their own instance from a factory
   (`BeersPagerFactory`), keeping paging state screen-scoped instead of living on the AppScope
-  repository (improvements.md §12.3). Because such a cache outlives any single pager (warm
+  repository. Because such a cache outlives any single pager (warm
   launches) and survives refresh (upsert, no delete), a storage-derived key
   (`nextKeyFromStorage`, e.g. `rowCount / pageSize + 1`) keeps the pager's position reconciled
   with the data. Note the scoping boundary: the pager *position* is screen-scoped, but the beers

--- a/docs/adr/0003-use-case-policy.md
+++ b/docs/adr/0003-use-case-policy.md
@@ -93,7 +93,8 @@ instead of convention-enforced.
   mechanical, and rare compared to the per-method mirror tax.
 - **No universal seam:** policy 1 gives every operation a ready-made hook for cross-cutting
   behaviour (analytics, logging). Accepted: cross-cutting concerns belong in the observability
-  facade (`Logger`/`Analytics` seam, MASTER_PLAN Phase 3), not smeared across per-call wrappers.
+  facade (the `Logger`/`AnalyticsTracker` seam in `:core-common`), not smeared across per-call
+  wrappers.
 - **Onboarding nuance:** "always" is easier to teach than "iff". Accepted: the rule is one
   sentence, and Konsist turns violations of the underlying boundary into build failures rather
   than tribal knowledge.

--- a/docs/adr/0010-non-goals.md
+++ b/docs/adr/0010-non-goals.md
@@ -1,0 +1,108 @@
+# 0010: Non-goals — what this project deliberately does not do
+
+## Status
+
+Accepted.
+
+## Context
+
+The nine existing ADRs all settle the same *kind* of question: given something we are going to
+build, which implementation wins. Several of them decline an option outright and say so — Paging3
+(0002), a use-case layer (0003), Renovate (0005), keeping every instrumented test in `:app` (0009).
+That habit is healthy and this ADR does not disturb it.
+
+What none of them covers is the other kind of decision: **a capability the product does not have at
+all.** A reader — an interviewer, a future contributor, an agent — sees a production-shaped app with
+ten mechanically-enforced invariants and a supply-chain ledger, and then notices there is no
+authentication, no certificate pinning, no encrypted storage, no push, no background sync. Every one
+of those absences is correct. None of them is written down anywhere, so all of them read as
+oversights. "There is no credential to protect" is a good answer that currently lives only in one
+person's head, which is exactly the failure mode the ADR habit exists to prevent.
+
+The root fact almost all of these follow from: **`brewbuddy.dev` is not ours, it is read-only, and
+it is unauthenticated.** Repeating that reasoning per capability is how it gets forgotten; recording
+it once is how it survives.
+
+## The deciding rule
+
+**A capability is a non-goal when the premise it serves is absent — not when it is merely unbuilt.**
+
+Auth is a non-goal because there is no credential anywhere in the system. An offline write queue is
+*deferred*, not declined, because its premise already exists: `available` is a real local write with
+optimistic UI, and the queue simply hasn't been built. The distinction matters because it makes the
+revisit trigger fall out for free — for a non-goal, the trigger is always "the premise arrives."
+
+The two lists below are therefore kept separate on purpose. Mistaking a deferral for a decline is
+how a plan quietly loses items.
+
+## Decision — non-goals
+
+| Not doing | Why — the missing premise | Reopens when |
+|---|---|---|
+| **Auth, sessions, token refresh**, OkHttp `Authenticator` | The API takes no credential. There is no identity in the system to establish, store, or refresh | Any endpoint we call requires a token |
+| **Certificate pinning** | Nothing confidential is in flight — public catalog data, no credential. Pinning carries a real operational cost (rotation bricks old clients; it needs a backup pin *and* a remote kill switch, which is itself deferred below) | Auth lands — but only *after* remote config, never before |
+| **Encrypted storage** (SQLCipher, `EncryptedSharedPreferences`) | Room holds the public catalog plus one local boolean. There is no secret at rest | Any user-supplied or personal data is persisted |
+| **Play Integrity / SafetyNet, root or tamper detection** | No entitlement, no revenue, no server trust decision. Nothing is gated on the client being honest | A paid or licensed artifact ships |
+| **Push notifications (FCM)** | No server we control, so nothing to send | A backend of ours exists |
+| **Server-side sync of `available`** | The backend isn't ours, so a sync could only ever one-way-overwrite the user's edit. The server value seeds a row on first insert and is local-only thereafter | We own the write path |
+| **A shipped analytics or crash SDK** | The *seam* is built and deliberate — `AnalyticsTracker` / `CrashReporter` / `Logger` with no-op bindings in `ObservabilityModule`, swappable one binding at a time. Declining the *dependency* is the separate call: no `google-services.json` exists anywhere, so this repo clones and builds with zero external account setup. That property is worth more to a public template than a wired-up dashboard | A real distribution needs the data, or one integration lands behind a flag to prove the seam |
+| **Consent, GDPR, and ad-ID flows** | Falls out of the row above: no SDK ships, no personal data is collected, no advertising ID is read. Play's Data Safety declaration is trivially satisfied because the honest answer is "nothing" | The row above changes |
+| **Automatic network retry and backoff** | Failure is surfaced to the user and retried explicitly (`PagedListFooter.Retry`, `LoadMoreRetryFooter`) rather than silently re-attempted. On a read-only catalog a silent retry buys little and hides the failure the paging tests are written against. OkHttp's connection-level `retryOnConnectionFailure` default is left on; nothing sits above it | A write path exists, where transparent retry is load-bearing rather than cosmetic |
+| **Multi-process** | Nothing declares `android:process`. No component needs isolation, and the second process would cost a second graph | A component needs its own lifetime or crash domain |
+
+## Deferred, not declined
+
+Planned for the future and simply not built yet. Recorded here only so nothing in this file is
+mistaken for a closed question — none of these is waiting on a missing premise, so none of them
+belongs in the table above.
+
+| Deferred | Why it is a deferral, not a decline |
+|---|---|
+| Offline write queue (WorkManager, conflict resolution, idempotency) | The local write it would queue already exists — `available`, with optimistic UI |
+| Remote config, kill switch, staged rollout, force-update | The premise is present, unlike push: `FeatureFlagProvider` already exists with a local implementation, and a remote source needs no backend of ours. Only the remote half is unbuilt — and the certificate-pinning row above is blocked behind it |
+| Release-build health in CI, APK size budget, diffuse-on-PR | `make bundle-release` already runs R8 and regenerates the baseline profile locally; only the CI gate is missing |
+| Adaptive two-pane layout; favorites + Glance widget | Ordinary feature work. The `adaptive` and `navigation-3` skills are already vendored |
+| Kotlin Multiplatform | The domain and `:core-common` are already pure-JVM and Metro is KMP-capable, so the groundwork is in place |
+
+The implementation choices named in the Context above — plus dev-apps for dynamic features (0004) —
+keep their own ADRs and are not reopened here.
+
+## Cost accepted
+
+**This project cannot be read as a demonstration of any capability in the first table.** Someone
+evaluating it for auth, sync, or push fluency finds nothing, and that is a real loss for a portfolio
+artifact.
+
+Accepted, because the alternative is worse. Building auth against a backend we don't own means
+inventing a fake server to authenticate against, and a fake premise produces fake architecture —
+code shaped by a scenario nobody has to live with. The value of this repository is that its shape is
+honest: every structure in it answers a constraint that actually exists. One well-argued page of
+declines is a better signal than a token-refresh interceptor with no token behind it.
+
+## Consequences
+
+- **`ACCESS_NETWORK_STATE` is declared and unread by our code.** `app/src/main/AndroidManifest.xml:4`
+  requests it; no file under any `src/` touches `ConnectivityManager` or `NetworkCapabilities`. It is
+  a leftover from the connectivity-aware retry this ADR declines. Drop the explicit declaration —
+  if Play Core still needs it, its own manifest merges it in and the line was redundant; if not, the
+  app was asking for a permission it does not use, which is exactly the drift this repo otherwise
+  refuses to tolerate.
+- **No `google-services.json` is a property to protect, not an accident.** Adding Firebase would
+  make a public template require a private file to build. Any future integration must survive its
+  absence.
+- **Adding one of these means deleting its row, in the same PR.** A non-goal list that outlives its
+  premise is worse than no list — it becomes a reason not to look.
+
+## When to revisit
+
+Concrete triggers, in the order the rows actually unlock:
+
+1. **A write path to a server we own.** This does not reopen one row, it reopens five — auth,
+   encrypted storage, server-side `available` sync, automatic retry, and (only afterwards)
+   certificate pinning. Pinning is last on purpose: shipping a pin without a remote kill switch is
+   how a fleet gets bricked by a certificate rotation, so it depends on the remote-config work in
+   the deferred table.
+2. **A paid or licensed artifact ships** — planned, but not scheduled. Integrity/anti-tamper and a
+   real observability backend both acquire a premise the day one does.
+3. **The app collects anything about a person** — consent and Data Safety stop being trivial the
+   day the honest answer stops being "nothing."


### PR DESCRIPTION
The nine existing ADRs all settle the same kind of question: given something we are going to build, which implementation wins. Several decline an option outright and say so — Paging3, a use-case layer, Renovate, keeping every instrumented test in `:app`.

None of them covers the other kind of decision: **a capability the product does not have at all.** There is no auth, no certificate pinning, no encrypted storage, no push, no background sync. Every one of those absences is correct and none was written down, so all of them read as oversights.

## ADR 0010

The spine is a deciding rule rather than a list: **a capability is a non-goal when the premise it serves is absent — not when it is merely unbuilt.** Auth is declined because no credential exists anywhere in the system; an offline write queue is deferred because its premise (a real local write on `available`) already exists. That distinction makes every reopen trigger fall out for free, and it keeps two separate tables honest:

- **Ten non-goals**, each with its missing premise and its reopen trigger. Almost all trace to one root fact stated once — `brewbuddy.dev` is not ours, is read-only, and is unauthenticated.
- **Five deferrals**, each with why it is a deferral rather than a decline.

Two rows worth calling out. Certificate pinning is deliberately ordered *after* remote config, never before — shipping a pin with no kill switch is how a certificate rotation bricks a fleet. And the analytics row separates the seam from the dependency: the no-op bindings are good design, while declining the SDK is its own call, because no `google-services.json` exists and this repo builds with zero external account setup.

One live finding surfaced while writing it and is recorded as a consequence: `app/src/main/AndroidManifest.xml:4` declares `ACCESS_NETWORK_STATE` and nothing under any `src/` touches `ConnectivityManager` — a leftover from the connectivity-aware retry the ADR declines.

## Dropped pointers to local-only notes

AGENTS.md, ADR 0002 and ADR 0003 cited gitignored planning notes, which resolve to nothing in a clone. AGENTS.md §8 keeps the two load-bearing facts (notes are gitignored; they have no git history, so deletion is permanent) without naming a file. ADR 0003 now cites the `Logger`/`AnalyticsTracker` seam it was actually describing — code a reader can open.

## README drift found on the way

The Konsist table listed nine rules against ten test files; `InstrumentedTestOptInBoundaryTest` was missing. The ADR count was stale at eight.

Docs only — no gates apply.
