### PR TITLE
feat: budget build time, and record why it is measured locally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ same change — a convention with no test is a convention that drifts.
 | Per-lane CI test selection: a lane runs if the push could affect it or it was red last time, else it adopts the green verdict. Rules live in one function in `.github/scripts/detect-change-scope.sh` | `docs/adr/0008` |
 | Instrumented UI tests live in the feature module that owns the screen; cross-feature and install-gate tests stay in `:app`. Cost is ~49s per *module* vs ~2s per *test*, so concentrate tests and add modules deliberately | `docs/adr/0009` |
 | **Non-goals** — auth, cert pinning, encrypted storage, integrity/anti-tamper, push, server-side `available` sync, a shipped analytics/crash SDK, consent flows, automatic retry, multi-process. All declined because the premise is absent (the backend isn't ours, is read-only, and is unauthenticated), each with its reopen trigger. Read it before "adding what a real app has" — and delete a row in the same PR that builds it | `docs/adr/0010` |
+| Build time is budgeted in `config/build-time-budget.txt` and measured **locally** by `make build-budget`, never in CI — a CI wall-clock number measures which runner the job drew. Clean build 37s cold / 4s warm; a deep ABI change costs only 1.11x a leaf one, so **per-build overhead dominates, not compilation** — do not justify a new module by build speed | `docs/adr/0011` |
 
 Also settled, without an ADR:
 
@@ -149,6 +150,12 @@ declaring done.
    fails CI with `MissingTranslation` — that is how PR #140 broke master.
 6. **Device** — instrumented tests, install, logcat: use the `billionbeers-android` skill, not
    ad-hoc `adb`
+
+**Off the ladder, on purpose: `make build-budget` and `make benchmark-check`.** Both measure
+wall-clock, so both are local-and-deliberate rather than per-change gates — CI cannot control for
+hardware (ADR 0009 §"Note on measuring any of this", ADR 0011). Run `build-budget` when you change
+the build itself: a convention plugin, an annotation processor, the module graph. It takes 15–20
+minutes and it measures *your* machine, so close anything heavy first.
 
 **CI note: heavy lanes skip per-lane on PR pushes.** A push to an open PR reruns only the test
 lanes its diff can affect (goldens and `screenshot/` test folders → screenshot; `src/androidTest/`

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 # Variables
 MODULE ?=
-SCENARIO ?= incremental_build
+SCENARIO ?= clean_build_warm
+# Warm-ups matter here: at 1 warm-up every scenario was still descending (ADR 0011).
+BUILD_BUDGET_WARMUPS ?= 6
+BUILD_BUDGET_ITERATIONS ?= 10
 NAME ?=
 PASCAL ?=
 FEATURE ?=
@@ -14,7 +17,7 @@ UI_TEST_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,:app:)
 # Wrapper for Gradle to support build-brief (bb) or rtk if available
 GRADLE_RUNNER := $(shell if command -v bb >/dev/null 2>&1; then echo "bb ./gradlew"; elif command -v build-brief >/dev/null 2>&1; then echo "build-brief --gradle ./gradlew"; elif command -v rtk >/dev/null 2>&1; then echo "rtk ./gradlew"; else echo "./gradlew"; fi)
 
-.PHONY: help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist compose-metrics ui-test screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline verification-metadata health benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark jacoco-report coverage-check install-profiler install-diffuse new-feature-module new-dev-app play-listing-check play-listing-capture play-listing-reset store-frames
+.PHONY: help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist compose-metrics ui-test screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline verification-metadata health benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark build-budget build-budget-check jacoco-report coverage-check install-profiler install-diffuse new-feature-module new-dev-app play-listing-check play-listing-capture play-listing-reset store-frames
 
 help: ## Show this help message.
 	@echo "\n📊 BillionBeers Makefile Help"
@@ -25,7 +28,7 @@ help: ## Show this help message.
 	@echo "  make setup"
 	@echo "  make test MODULE=:feature:beerslist"
 	@echo "  make screenshot-record MODULE=:core:designsystem"
-	@echo "  make gradle-benchmark SCENARIO=clean_build"
+	@echo "  make gradle-benchmark SCENARIO=clean_build_warm"
 
 setup: ## Setup local development environment (Git hooks, Git LFS, etc.).
 	@echo "🔧 Setting up local development environment..."
@@ -206,8 +209,21 @@ benchmark-check: ## Run macrobenchmarks and fail if results exceed the configure
 generate-baseline: ## Generate Baseline Profiles for the app (needs a booted device/emulator).
 	$(GRADLE_RUNNER) :app:generateBaselineProfile
 
-gradle-benchmark: ## Run Gradle Profiler with a specific scenario. Usage: make gradle-benchmark SCENARIO=clean_build
+gradle-benchmark: ## Run Gradle Profiler with a specific scenario. Usage: make gradle-benchmark SCENARIO=clean_build_warm
 	gradle-profiler --benchmark --scenario-file ./benchmark.scenarios $(SCENARIO)
+
+build-budget: ## Measure build times and check them against config/build-time-budget.txt. Local only - see ADR 0011.
+	@command -v gradle-profiler >/dev/null 2>&1 || \
+		{ echo "❌ gradle-profiler not found. Install it with 'brew install gradle-profiler'." >&2; exit 1; }
+	@echo "⏱  Measuring build times (~15-20 min). Close other heavy processes - this measures your machine."
+	@rm -rf profile-out/baseline
+	gradle-profiler --benchmark --scenario-file ./benchmark.scenarios \
+		--warmups $(BUILD_BUDGET_WARMUPS) --iterations $(BUILD_BUDGET_ITERATIONS) \
+		--output-dir profile-out/baseline
+	@bash scripts/check-build-budget.sh profile-out/baseline/benchmark.csv
+
+build-budget-check: ## Re-check the last build-budget measurement without re-measuring.
+	@bash scripts/check-build-budget.sh profile-out/baseline/benchmark.csv
 
 # Reporting
 jacoco-report: ## Generate the unified Jacoco coverage report.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ Reinforced by:
   a deliberate absence never has to be mistaken for an oversight.
 - **Dev-app sandboxes** — `app-dev-<feature>` modules build a single feature against fakes for fast
   iteration (`make new-dev-app`).
+- **A budget on the build itself, not just the app** — `make build-budget` measures clean,
+  incremental and test builds with gradle-profiler and checks them against
+  `config/build-time-budget.txt`. Clean build is 37s cold and 4s warm; a deep ABI change costs
+  1.11x a leaf one, which says per-build overhead dominates and further module splitting would not
+  make builds faster. It runs locally, never in CI, because a CI wall-clock number mostly measures
+  which runner the job drew. See [ADR 0011](docs/adr/0011-build-time-budget.md).
 - **CI that runs only what a change can break** — a push to a PR reruns the test lanes its diff can
   affect, plus any lane that was red on the previous head; unaffected green lanes adopt their
   previous verdict, and a docs-only PR skips the heavy lanes entirely. The rules live in one

--- a/benchmark.scenarios
+++ b/benchmark.scenarios
@@ -1,13 +1,57 @@
-clean_build {
+// Gradle Profiler scenarios — the build-time equivalent of the macrobenchmark budgets.
+//
+// Run one with `make gradle-benchmark SCENARIO=<name>`, or the whole committed set with
+// `make build-budget` (which also checks the results against config/build-time-budget.txt).
+//
+// Two things these scenarios are careful about, because the obvious version of each is wrong:
+//
+// 1. `clean` does NOT produce a cold build. It deletes the build directory; it leaves the build
+//    cache (~/.gradle/caches/build-cache-1, 1.4G here) and the configuration cache
+//    (.gradle/configuration-cache) fully warm. So "clean build" is two different measurements and
+//    they are split below. The cold one *disables* the caches rather than deleting them — deleting
+//    is slow, destructive, and unreproducible across machines, whereas the flags are neither.
+//
+// 2. An ABI change high in the graph is the cheapest possible incremental build, not a
+//    representative one. `MainActivity.kt` is in `:app`, which nothing depends on; `Beer` is in
+//    `:beerdomain:api`, which ten modules depend on. Both are measured, because the *ratio*
+//    between them is what the module split actually buys.
+
+// The fresh-clone / cold-CI number: no build cache, no configuration cache.
+// This is the pessimistic bound — nobody experiences it twice, but a regression here is a real
+// regression that the warm numbers can hide.
+clean_build_cold {
+    tasks = ["assembleDebug"]
+    cleanup-tasks = ["clean"]
+    gradle-args = ["--no-build-cache", "--no-configuration-cache"]
+}
+
+// What a developer actually gets after `make clean`: outputs gone, both caches warm.
+clean_build_warm {
     tasks = ["assembleDebug"]
     cleanup-tasks = ["clean"]
 }
 
-incremental_build {
+// ABI change at the top of the graph — `:app` has no dependents, so this recompiles almost
+// nothing. The best case, and the floor the deep number is compared against.
+incremental_leaf {
     tasks = ["assembleDebug"]
     apply-abi-change-to = "app/src/main/java/com/simtop/billionbeers/presentation/MainActivity.kt"
 }
 
+// ABI change at the bottom of the graph — `Beer` lives in `:beerdomain:api`, which ten modules
+// depend on. This is the number that answers "does the module split pay for itself": it should be
+// meaningfully worse than incremental_leaf, but far better than clean_build_warm. If it ever
+// approaches the clean number, incremental compilation has stopped working somewhere.
+incremental_deep {
+    tasks = ["assembleDebug"]
+    apply-abi-change-to = "beerdomain/api/src/main/java/com/simtop/beerdomain/domain/models/Beer.kt"
+}
+
+// Without a mutator this scenario measures nothing: `testDebugUnitTest` is up-to-date after the
+// warm-up, so every measured iteration would report Gradle's startup cost and no test execution.
+// A non-ABI change to a file that `BeersListViewModelTest` exercises forces the recompile-and-rerun
+// this is meant to time, without the full-graph recompile `--rerun-tasks` would drag in.
 unit_tests {
     tasks = ["testDebugUnitTest"]
+    apply-non-abi-change-to = "feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListViewModel.kt"
 }

--- a/config/build-time-budget.txt
+++ b/config/build-time-budget.txt
@@ -1,0 +1,44 @@
+# Build-time budgets, in seconds, keyed by gradle-profiler scenario id (see benchmark.scenarios).
+# Checked by scripts/check-build-budget.sh via `make build-budget`. Raising a number here is a
+# deliberate, reviewable edit, exactly like lowering config/coverage-floor.txt.
+#
+# READ THIS BEFORE TREATING A FAILURE AS A REGRESSION.
+#
+# These are wall-clock seconds, so they are a property of the machine that measured them. The
+# reference machine is an Apple M1 Pro, 8 cores, 16 GB, macOS 26.5, JDK 24. A slower machine can
+# fail these without anything being wrong with the build. That is why:
+#
+#   1. Every budget is deliberately generous - roughly 3-4x the measured median, and comfortably
+#      above the worst of ten measured iterations. This mirrors scripts/check-benchmark-budget.sh,
+#      which budgets 3000ms against an ~890ms measurement and says why in its own comment. The
+#      point is to catch a multi-x regression, not to defend a stopwatch.
+#   2. The `ratio` line below is the machine-independent half, and the one worth arguing from.
+#      Two scenarios measured on the same machine in the same run cancel out the hardware.
+#
+# Baseline measured 2026-08-07, 6 warm-ups + 10 iterations (ADR 0011 has the full table):
+#
+#   scenario            median    min     max   spread
+#   clean_build_cold      37.3   29.7    59.3      79%
+#   clean_build_warm       4.3    2.5    11.5     207%
+#   incremental_leaf       2.3    1.8     3.7      81%
+#   incremental_deep       2.5    2.0     3.4      58%
+#   unit_tests             5.6    4.9     6.6      32%
+
+clean_build_cold  120
+clean_build_warm   20
+incremental_leaf   10
+incremental_deep   10
+unit_tests         20
+
+# The modularization guard, and the only line here that survives a change of hardware.
+#
+# Measured at 1.11x: an ABI change to `Beer` in `:beerdomain:api` (ten dependent modules) costs
+# essentially the same as one to `MainActivity` in `:app` (no dependents). At ~2.4s per build, both
+# are dominated by Gradle's fixed per-build overhead rather than by compilation, so the fan-out is
+# not what you are paying for.
+#
+# The limit is 3x rather than something near 1.11x on purpose: the ratio of two small, noisy numbers
+# is itself noisy, and this is a guard against incremental compilation breaking across module
+# boundaries - the failure where a deep change starts recompiling the world. If it ever trips,
+# the question is "what stopped being incremental", not "which module got slower".
+ratio incremental_deep incremental_leaf 3.0

--- a/docs/adr/0011-build-time-budget.md
+++ b/docs/adr/0011-build-time-budget.md
@@ -1,0 +1,153 @@
+# 0011: Build time is budgeted, and measured locally rather than gated in CI
+
+## Status
+
+Accepted.
+
+## Context
+
+Every axis of this project's health is ratcheted against a committed number except the one that
+decides whether its structure was worth building.
+
+| Axis | Committed artifact |
+|---|---|
+| Line coverage | `config/coverage-floor.txt` |
+| Resolved dependency graph | `app/dependencies/releaseRuntimeClasspath.txt` |
+| Android Lint findings | `app/lint-baseline.xml` |
+| App startup time | budget in `scripts/check-benchmark-budget.sh` |
+| **Build time** | **nothing** |
+
+The instrument already existed — `benchmark.scenarios` and `make gradle-benchmark` have been in the
+repo for months — so this was never a tooling gap. The reading was simply never taken, never
+committed, and therefore never able to catch a regression.
+
+That matters more here than in most projects, because the repository's central claim is structural —
+a deliberately modular graph, convention plugins, ten enforced invariants. The question a reviewer is
+entitled to ask is whether the split pays for itself, and the only honest answer is a number.
+
+(Deliberately no module count here. ADR 0009 quotes 27 for `:app`'s build; `./gradlew projects`
+reports a different figure for the whole build. The two are probably measuring different things, but
+until someone confirms which, a third number in a third document helps nobody.)
+
+## Decision
+
+**Build time is budgeted in `config/build-time-budget.txt`, measured by `make build-budget`, and
+checked by `scripts/check-build-budget.sh`. It runs locally and deliberately. It is not a CI lane.**
+
+This mirrors `make benchmark-check`, which is also absent from every workflow for the same reason:
+a measurement taken in an environment that does not control for hardware is not a measurement.
+
+## Why this is not a CI lane
+
+Not primarily cost. A converged run is 15–20 minutes, which is affordable if it bought anything.
+
+It is validity. **ADR 0009 already measured this effect on this repository's own CI**: across 19
+master runs every lane correlated r = 0.93–0.99 with Detekt, a lane no test change can affect. Lane
+duration is mostly a function of which runner the job drew. A CI build-time gate would therefore be
+a runner-assignment detector with a build-time label on it, and the failure mode is worse than
+having no gate — it would go red for reasons no one can act on, and be disabled within a month.
+
+The local numbers below reinforce it independently: even on one quiet machine, `clean_build_cold`
+ranged 29.7s–59.3s across ten iterations. Adding shared-runner variance on top of that is not a
+signal anyone can threshold.
+
+A deterministic, machine-independent CI check was considered — executed-task count or task-graph
+size for a fixed change. Rejected for this ADR: it catches "a plugin added 200 tasks" and is blind
+to incremental compilation breaking, which is the actual risk. Graph-shape enforcement belongs in
+`:konsist`, not here.
+
+## The baseline
+
+Measured 2026-08-07 on an Apple M1 Pro (8 cores, 16 GB, macOS 26.5, JDK 24) with the settings
+`make build-budget` uses — 6 warm-ups and 10 measured iterations per scenario.
+
+| Scenario | median | min | max | spread | stdev |
+|---|---|---|---|---|---|
+| `clean_build_cold` | 37.3s | 29.7s | 59.3s | 79% | 9.6 |
+| `clean_build_warm` | 4.3s | 2.5s | 11.5s | 207% | 2.8 |
+| `incremental_leaf` | 2.3s | 1.8s | 3.7s | 81% | 0.6 |
+| `incremental_deep` | 2.5s | 2.0s | 3.4s | 58% | 0.5 |
+| `unit_tests` | 5.6s | 4.9s | 6.6s | 32% | 0.6 |
+
+**A clean build with no caches is 37s; with warm caches it is 4s.** That is the answer to the
+question this ADR exists to make answerable.
+
+### The finding that contradicts the scenario's own premise
+
+`incremental_deep` was added specifically because the pre-existing incremental scenario applied its
+ABI change to `MainActivity.kt` in `:app`, which nothing depends on — the cheapest possible
+incremental build, presented as the representative one. The replacement changes `Beer` in
+`:beerdomain:api`, which ten modules depend on.
+
+The expectation was that the deep change would be substantially more expensive, and that the gap
+would quantify what modularization buys. **It measured 1.11x — 2.5s against 2.3s.**
+
+The honest reading is not "incremental compilation is extraordinarily good." It is that at ~2.4s per
+build, **fixed per-build overhead dominates and compilation is not what you are paying for.**
+Configuration, task-graph construction and up-to-date checking swamp the difference between
+recompiling one module and recompiling eleven.
+
+Two consequences follow, and both cut against instinct:
+
+- **Further module splitting will not make incremental builds faster.** There is no compilation time
+  left to parallelise away at this scale. Modules must be justified by boundaries and enforced
+  invariants — which is exactly how ADR 0009 justifies the UI-test tier — never by build speed.
+- **The lever, if build time ever becomes a problem, is per-build overhead**: configuration cache
+  hit rate, plugin configuration cost, task count. Not the graph.
+
+## Why the scenarios changed
+
+The three pre-existing scenarios each measured something other than their name, and all three
+defects were the same class — a measurement that looks plausible and is inert.
+
+- **`clean_build` did not measure a clean build.** `clean` deletes the build directory. It leaves
+  the build cache (1.4 GB in a project-local Gradle home) and the configuration cache (50 MB in
+  `.gradle/`) fully warm. Split into `clean_build_cold`, which disables both by flag — deleting is
+  slow, destructive and unreproducible, whereas flags are none of those — and `clean_build_warm`,
+  which is what a developer actually experiences after `make clean`.
+- **`incremental_build` measured the cheapest possible case**, as described above.
+- **`unit_tests` measured Gradle startup.** With no mutator, `testDebugUnitTest` is up-to-date after
+  the warm-up, so every measured iteration was a no-op. Confirmed: it reported **545 ms**. It now
+  applies a non-ABI change to a file its tests exercise. `--rerun-tasks` was rejected as the fix —
+  it drags in a full recompile and would measure something different again.
+
+Recording these because the symptom in every case was a number that looked fine.
+
+## Cost accepted
+
+**The absolute budgets are machine-specific.** They are calibrated on one laptop and a slower
+machine can fail them with nothing wrong. Mitigated two ways, not solved: budgets sit at roughly
+3–4x the measured median and comfortably above the worst of ten iterations, following the precedent
+in `check-benchmark-budget.sh` (3000 ms against an ~890 ms measurement, with its reasoning in the
+comment); and the `ratio` check between two scenarios in the same run cancels the hardware out
+entirely, which is why it is the line worth arguing from.
+
+**A local gate depends on someone running it.** Unlike the coverage floor, nothing forces this
+before a merge. Accepted for the same reason `make benchmark-check` is accepted: a number that is
+occasionally checked and true beats a number that is continuously checked and meaningless.
+
+## Consequences
+
+- `make build-budget` measures and checks; `make build-budget-check` re-checks the last measurement
+  without re-measuring. Both are local-only.
+- `profile-out/` is gitignored, so the raw CSV does not survive. The table above is the record.
+- The check reports median, sample count and spread per scenario, and skips any scenario with no
+  budget line rather than failing. Adding a scenario therefore does not silently gate it.
+- **There is deliberately no "you have headroom, tighten this" nudge**, unlike `coverage-check.sh`.
+  Coverage should ratchet up; a build-time budget should not ratchet down, because headroom here is
+  policy rather than reclaimable slack.
+
+## When to revisit
+
+- **If `incremental_deep / incremental_leaf` ever trips 3x**, the question is what stopped being
+  incremental — an annotation processor without incremental support, a plugin forcing full
+  recompilation — not which module got slower.
+- **If per-build overhead becomes the complaint**, measure configuration time directly
+  (`gradle-profiler --measure-config-time`) before touching the module graph. This ADR's central
+  finding is that the graph is not where the time goes.
+- **After a major Gradle, AGP or Kotlin bump**, re-measure and update the table. Nothing forces this
+  — that is the acknowledged cost of a local gate — so it needs a trigger, and those bumps are the
+  right one: they move per-build overhead, which this ADR identifies as the dominant term.
+- **If a shared build cache or build scans are ever adopted**, re-measure `clean_build_warm` first:
+  it is the scenario a remote cache would change most, and its 207% spread today makes it the
+  weakest number in the table.

--- a/scripts/check-build-budget.sh
+++ b/scripts/check-build-budget.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Build-time budget check — the developer-perf counterpart to check-benchmark-budget.sh.
+#
+# Reads a gradle-profiler benchmark.csv and fails if a scenario's median exceeds its budget in
+# config/build-time-budget.txt. Raising a budget is a deliberate, reviewable edit to that file,
+# exactly like lowering the coverage floor.
+#
+# Why this is not a CI lane (see docs/adr/0011): a build-time number measured on a shared CI runner
+# is dominated by which runner the job drew, not by the build. ADR 0009 measured that effect on this
+# repo's own lanes - every lane correlates r = 0.93-0.99 with Detekt, which no test change can
+# affect. So this runs locally and deliberately, the same way `make benchmark-check` does.
+#
+# Usage:
+#   scripts/check-build-budget.sh [path-to-benchmark.csv]   (default: profile-out/baseline/benchmark.csv)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+CSV="${1:-profile-out/baseline/benchmark.csv}"
+BUDGET_FILE="config/build-time-budget.txt"
+
+if [[ ! -f "$CSV" ]]; then
+  echo "❌ No benchmark results at $CSV. Run 'make build-budget' to measure first." >&2
+  exit 1
+fi
+if [[ ! -f "$BUDGET_FILE" ]]; then
+  echo "❌ Missing $BUDGET_FILE." >&2
+  exit 1
+fi
+
+python3 - "$CSV" "$BUDGET_FILE" <<'PY'
+import csv, statistics, sys
+
+csv_path, budget_path = sys.argv[1], sys.argv[2]
+
+with open(csv_path, newline="", encoding="utf-8") as f:
+    rows = list(csv.reader(f))
+
+if not rows or rows[0][0] != "scenario":
+    sys.exit(f"❌ {csv_path} is not a gradle-profiler benchmark.csv (no 'scenario' header row).")
+
+# Header carries scenario ids, because benchmark.scenarios deliberately sets no `title`.
+scenarios = [name for name in rows[0][1:] if name]
+
+# Only measured builds count. Warm-ups are excluded by gradle-profiler's own labelling, and
+# including them is the classic way to bake daemon JIT warm-up into a "build time".
+samples = {name: [] for name in scenarios}
+for row in rows:
+    if not row or not row[0].startswith("measured build"):
+        continue
+    for i, name in enumerate(scenarios, start=1):
+        if i < len(row) and row[i].strip():
+            samples[name].append(float(row[i]) / 1000.0)
+
+absolute, ratios = {}, []
+with open(budget_path, encoding="utf-8") as f:
+    for lineno, raw in enumerate(f, 1):
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        if parts[0] == "ratio":
+            if len(parts) != 4:
+                sys.exit(f"❌ {budget_path}:{lineno}: expected 'ratio <slow> <fast> <max>'.")
+            ratios.append((parts[1], parts[2], float(parts[3])))
+        elif len(parts) == 2:
+            absolute[parts[0]] = float(parts[1])
+        else:
+            sys.exit(f"❌ {budget_path}:{lineno}: expected '<scenario> <seconds>'.")
+
+failed = False
+measured = {}
+
+for name in scenarios:
+    values = samples[name]
+    if not values:
+        print(f"warning: scenario '{name}' produced no measured builds - skipping", file=sys.stderr)
+        continue
+    median = statistics.median(values)
+    measured[name] = median
+    spread = (max(values) - min(values)) / median * 100 if median else 0.0
+
+    if name not in absolute:
+        print(f"warning: no budget configured for '{name}' (median {median:.1f}s) - skipping", file=sys.stderr)
+        continue
+
+    budget = absolute[name]
+    if median > budget:
+        print(f"FAIL {name}: median {median:.1f}s > {budget:.0f}s budget  (n={len(values)}, spread {spread:.0f}%)")
+        failed = True
+    else:
+        # Deliberately no "you have headroom, tighten this" nudge, unlike coverage-check.sh.
+        # Coverage should ratchet up; a build-time budget should not ratchet down. These scenarios
+        # measured 32-207% spread (ADR 0011) and the numbers are machine-specific, so headroom is
+        # the policy rather than slack to be reclaimed. Nudging here would argue against the
+        # reasoning written into config/build-time-budget.txt.
+        print(f"OK   {name}: median {median:.1f}s <= {budget:.0f}s budget  (n={len(values)}, spread {spread:.0f}%)")
+
+# The scale-invariant half. Absolute seconds are a property of the machine that measured them;
+# a ratio between two scenarios on the same machine in the same run is not, which is why the
+# modularization payoff is expressed this way.
+for slow, fast, limit in ratios:
+    if slow not in measured or fast not in measured:
+        print(f"warning: ratio {slow}/{fast} needs both scenarios in this run - skipping", file=sys.stderr)
+        continue
+    if measured[fast] == 0:
+        print(f"warning: ratio {slow}/{fast} has a zero denominator - skipping", file=sys.stderr)
+        continue
+    actual = measured[slow] / measured[fast]
+    if actual > limit:
+        print(f"FAIL {slow}/{fast}: {actual:.2f}x > {limit:.2f}x  "
+              f"({measured[slow]:.1f}s vs {measured[fast]:.1f}s)")
+        failed = True
+    else:
+        print(f"OK   {slow}/{fast}: {actual:.2f}x <= {limit:.2f}x  "
+              f"({measured[slow]:.1f}s vs {measured[fast]:.1f}s)")
+
+if failed:
+    print(f"\nOne or more build-time budgets were exceeded. Fix the regression, or raise the "
+          f"budget in {budget_path} as a reviewed decision.", file=sys.stderr)
+    sys.exit(1)
+
+print("\nAll build-time budgets met.")
+PY


### PR DESCRIPTION
Every axis of this project's health is ratcheted against a committed number except the one that decides whether its structure was worth building.

| Axis | Committed artifact |
|---|---|
| Line coverage | `config/coverage-floor.txt` |
| Resolved dependency graph | `app/dependencies/releaseRuntimeClasspath.txt` |
| Android Lint findings | `app/lint-baseline.xml` |
| App startup time | budget in `scripts/check-benchmark-budget.sh` |
| **Build time** | **nothing** |

The instrument already existed — `benchmark.scenarios` and `make gradle-benchmark` have been here for months. The reading was never taken.

Adds `config/build-time-budget.txt`, `scripts/check-build-budget.sh`, `make build-budget` / `build-budget-check`, and ADR 0011.

## The baseline

M1 Pro, 8 cores, 16 GB, 6 warm-ups + 10 measured iterations per scenario.

| Scenario | median | min | max | spread |
|---|---|---|---|---|
| `clean_build_cold` | 37.3s | 29.7s | 59.3s | 79% |
| `clean_build_warm` | 4.3s | 2.5s | 11.5s | 207% |
| `incremental_leaf` | 2.3s | 1.8s | 3.7s | 81% |
| `incremental_deep` | 2.5s | 2.0s | 3.4s | 58% |
| `unit_tests` | 5.6s | 4.9s | 6.6s | 32% |

## The finding contradicts the scenario's own premise

`incremental_deep` was added to quantify what modularization buys: an ABI change to `Beer` in `:beerdomain:api` (ten dependent modules) versus one to `MainActivity` in `:app` (none). Expected a large gap. **Measured 1.11x — 2.5s against 2.3s.**

The honest reading isn't "incremental compilation is extraordinary." At ~2.4s per build, fixed per-build overhead dominates and compilation isn't what we pay for. Two consequences, both against instinct: further module splitting will not make incremental builds faster, so modules need boundary justifications rather than build-speed ones; and if build time ever becomes a problem the lever is per-build overhead, not the graph.

## Why it's not a CI lane

Not cost — a converged run is 15-20 minutes. Validity. ADR 0009 already measured that this repo's CI lanes correlate r = 0.93-0.99 with Detekt, a lane no test change can affect, so lane duration is mostly which runner the job drew. A CI build-time gate would be a runner-assignment detector with a build-time label. The local numbers agree independently: `clean_build_cold` ranged 29.7-59.3s on one quiet machine.

A deterministic CI check (task-graph size) was considered and rejected in the ADR: it catches "a plugin added 200 tasks" and is blind to incremental compilation breaking, which is the actual risk.

## All three pre-existing scenarios measured something other than their name

Same defect class each time — a number that looks plausible and is inert.

- `clean_build` left the build cache (1.4G) and configuration cache (50M) warm, because `clean` deletes neither. Split into cold (caches disabled by flag, since deleting is slow and unreproducible) and warm.
- `incremental_build` applied its ABI change to `:app`, which has no dependents — the cheapest possible incremental build.
- `unit_tests` had no mutator, so every iteration after warm-up was an up-to-date no-op. It measured **545ms** of Gradle startup. Now applies a non-ABI change to a file its tests exercise; `--rerun-tasks` was rejected as the fix because it drags in a full recompile.

## Verification

`make build-budget` run end to end (exit 0, all five scenarios, check passes). The check script was proven non-vacuous in both directions — it exits 1 on an absolute breach and on a ratio breach. `make konsist` green.

Budgets sit at 3-4x the measured median, following `check-benchmark-budget.sh`'s precedent of 3000ms against an ~890ms measurement. They're machine-specific and say so; the `ratio` line is the machine-independent half.
