### PR TITLE
fix: stop reading the disk on the main thread to build the OkHttp cache

### DIFF
--- a/core/src/main/java/com/simtop/core/di/NetworkingModule.kt
+++ b/core/src/main/java/com/simtop/core/di/NetworkingModule.kt
@@ -29,6 +29,30 @@ interface NetworkingModule {
     private const val CONNECT_TIMEOUT_SECONDS = 10L
     private const val READ_TIMEOUT_SECONDS = 30L
     private const val HTTP_CACHE_SIZE_BYTES = 5L * 1024 * 1024
+
+    /**
+     * The OkHttp cache directory, resolved without touching the filesystem.
+     *
+     * `context.cacheDir` looks free and is not: it routes through `ContextImpl.getDataDir()`, which
+     * calls `File.exists()` and creates the directory if missing. StrictMode caught it on the main
+     * thread at ~500-790 ms per launch on an emulator (ADR 0012 added the detector; this was its
+     * first finding), because the first composition resolves a ViewModel, which pulls the
+     * repository, which builds this client - all before the first frame.
+     *
+     * `applicationInfo.dataDir` is a plain String field the package manager already populated, so
+     * it costs no syscall, and `<dataDir>/cache` is exactly what `getCacheDir()` returns. OkHttp
+     * does not touch the directory when the `Cache` is constructed either -
+     * `DiskLruCache.initialize()` creates it lazily on the first cache read or write, which happens
+     * on OkHttp's own dispatcher thread. So the disk work still happens, just not on the main
+     * thread.
+     *
+     * Deferring the whole client with Retrofit's `callFactory` was considered and does not work:
+     * Retrofit calls `newCall()` synchronously on the calling thread, which for a
+     * `viewModelScope.launch` is the main thread (ADR 0012). That relocates the violation instead
+     * of removing it.
+     */
+    private fun httpCacheDir(context: Context): File =
+      File(context.applicationInfo.dataDir, "cache/http")
   }
 
   @Provides @SingleIn(AppScope::class) fun provideJson(): Json = NetworkJson
@@ -49,7 +73,7 @@ interface NetworkingModule {
     return OkHttpClient.Builder()
       .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
       .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-      .cache(Cache(File(context.cacheDir, "http"), HTTP_CACHE_SIZE_BYTES))
+      .cache(Cache(httpCacheDir(context), HTTP_CACHE_SIZE_BYTES))
       .apply {
         if (BuildConfig.DEBUG) {
           addInterceptor(loggingInterceptor)

--- a/docs/adr/0012-dispatcher-placement.md
+++ b/docs/adr/0012-dispatcher-placement.md
@@ -109,6 +109,15 @@ This is the direct answer to "you can't tell from outside": you can, on the firs
 stack trace pointing at the exact call. Room and the platform already cover the two largest cases;
 StrictMode covers the remainder.
 
+**It earned its keep on the first launch**, and not in a repository. `NetworkingModule` built its
+OkHttp cache with `context.cacheDir`, which routes through `ContextImpl.getDataDir()` and calls
+`File.exists()` - a main-thread disk read of ~490-790 ms on every launch, before the first frame,
+because the first composition resolves a ViewModel that pulls the repository that builds the client.
+No amount of `launch(io)` in a ViewModel would ever have revealed it: the work was in the DI graph,
+upstream of any coroutine. Fixed by resolving the path from `applicationInfo.dataDir` (a String field,
+no syscall) and letting OkHttp create the directory lazily on its own dispatcher; verified on an
+emulator as two violations per launch before and zero after, with the cache still written.
+
 ## Worked example: a vendor SDK that does not handle threading
 
 The case the guidance has to survive. A third-party SDK exposes a blocking call and cannot be


### PR DESCRIPTION
StrictMode (added in #146 / ADR 0012) fired on its first emulator run, and the violation was not where the argument for it expected — not in a repository, but in the DI graph.

`NetworkingModule` built its OkHttp cache with `context.cacheDir`. That looks free and is not: it routes through `ContextImpl.getDataDir()`, which calls `File.exists()` and creates the directory if missing.

```
StrictMode policy violation; ~duration=788 ms: DiskReadViolation
  at java.io.File.exists
  at android.app.ContextImpl.getCacheDir
  at com.simtop.core.di.NetworkingModule.provideOkHttpClient(NetworkingModule.kt:52)
  … Metro BaseDoubleCheck → ProvideRetrofitMetroFactory …
  at com.simtop.billionbeers.presentation.MainActivity.onCreate(MainActivity.kt:43)
```

Two violations per launch, ~490–790 ms, **before the first frame**: `setContent` resolves a ViewModel, which pulls the repository, which builds the client. The work sat upstream of any coroutine, so no dispatcher choice in a ViewModel could ever have affected it — which is the point ADR 0012 makes about detectors versus defensive `launch(io)`.

## The fix

The path now comes from `applicationInfo.dataDir` — a plain `String` field the package manager already populated, so no syscall — and `<dataDir>/cache` is exactly what `getCacheDir()` returns. OkHttp doesn't touch the directory at `Cache` construction either: `DiskLruCache.initialize()` creates it lazily on the first cache read or write, on OkHttp's own dispatcher thread. The disk work still happens; it just isn't on the main thread.

## What I tried first and rejected

Deferring the whole client with Retrofit's `callFactory` — it doesn't work. Retrofit invokes `newCall()` **synchronously on the calling thread**, which after #146 is Main for a `viewModelScope.launch`. That relocates the violation instead of removing it. Recorded in the code comment so it isn't retried.

## Verified on the emulator

| | before | after |
|---|---|---|
| `DiskReadViolation` per launch | **2** (491–788 ms) | **0** |
| `CustomViolation: newSSLContext` | 1 (486–772 ms) | 1 (461–725 ms) — untouched |

Three launches each side. Then the correctness check that matters: deleted `cache/http` **and** the Room database to force a cold network fetch, and confirmed the directory is recreated from scratch —

```
cache/http/
  32cbaa9247e4eab6bb65821d113b6683.0   8383 bytes   (headers)
  32cbaa9247e4eab6bb65821d113b6683.1  99085 bytes   (body)
  journal                               125 bytes
```

— with still zero disk-read violations. So the cache genuinely works and only its creation moved off the main thread. (An earlier check was inconclusive because the directory pre-dated the change; and a launch with a warm Room cache creates nothing at all, since a fresh cache skips the fetch entirely.)

## Not fixed here

The `newSSLContext` violation (~460–725 ms per launch) is unchanged. Removing it means keeping the client off the first-frame path entirely, which is a real startup change and deserves `make benchmark-check` either side rather than a guess.

`make test` and `make konsist` green.
