### PR TITLE
perf: warm the networking graph off the main thread at startup

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -37,10 +37,10 @@
       </SelectionState>
       <SelectionState runConfigName="main">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2026-03-08T19:58:18.270629Z">
+        <DropdownSelection timestamp="2026-08-08T13:08:00.257060Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/simontopchyan/.android/avd/Resizable_Experimental_API_35.avd" />
+              <DeviceId pluginId="Wireless" identifier="serviceName=adb-47311FDJH001LW-g5Kajr" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/simtop/billionbeers/BillionBeersApplication.kt
+++ b/app/src/main/java/com/simtop/billionbeers/BillionBeersApplication.kt
@@ -7,6 +7,8 @@ import com.simtop.billionbeers.di.BaseAppGraph
 import com.simtop.core.di.GraphProvider
 import dev.zacsweers.metro.createGraphFactory
 import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 class BillionBeersApplication : SplitCompatApplication(), GraphProvider {
   lateinit var appGraph: BaseAppGraph
@@ -19,6 +21,40 @@ class BillionBeersApplication : SplitCompatApplication(), GraphProvider {
     enableStrictMode()
     if (!::appGraph.isInitialized) {
       appGraph = createGraphFactory<AppGraph.Factory>().create(this)
+    }
+    warmNetworkingGraph()
+  }
+
+  /**
+   * Builds the networking branch of the graph off the main thread, before the first composition
+   * asks for it.
+   *
+   * Resolving [BaseAppGraph.beersRepository] pulls the remote source, Retrofit and finally the
+   * OkHttp client, and building that client creates an `SSLContext` - which StrictMode reported as
+   * a main-thread `CustomViolation: newSSLContext` on every launch. The work sits in the dependency
+   * graph rather than in any coroutine, so it happened during `MainActivity.onCreate`'s
+   * `setContent`, on the critical path to the first frame. (Its sibling, a main-thread disk read
+   * for the cache directory, was fixed separately in `NetworkingModule`.)
+   *
+   * **This is a race.** Metro memoises providers behind a double-checked lock, so if the first
+   * composition reaches the repository first, the main thread blocks on the same work.
+   *
+   * Measured on a Pixel 8, 10 cold starts per side of the minified benchmark variant: median 209.5
+   * ms -> 206.2 ms, mean 213.9 ms -> 206.4 ms. A small real win, 3-7 ms, against a same-code
+   * run-to-run swing of 2.5 ms. The debug-build StrictMode violation it removes is far larger
+   * (270-294 ms on main, every launch, now zero) - but that is a debug number and does not
+   * transfer: the shipped variant is minified and AOT-compiled from a baseline profile, so the same
+   * work costs a fraction of it. Treat StrictMode durations as "this is on the wrong thread", never
+   * as "this costs the user that much".
+   *
+   * An emulator cannot answer this at all: there the same comparison swung 160 ms between two runs
+   * of identical code, which is 30x the effect being measured.
+   */
+  private fun warmNetworkingGraph() {
+    CoroutineScope(appGraph.coroutineDispatcher.io).launch {
+      // A warm-up must never be what crashes the app. If resolution fails here, swallow it and let
+      // the real call site fail in its own context, where the error can be handled and reported.
+      runCatching { appGraph.beersRepository }
     }
   }
 }

--- a/docs/adr/0012-dispatcher-placement.md
+++ b/docs/adr/0012-dispatcher-placement.md
@@ -118,6 +118,25 @@ upstream of any coroutine. Fixed by resolving the path from `applicationInfo.dat
 no syscall) and letting OkHttp create the directory lazily on its own dispatcher; verified on an
 emulator as two violations per launch before and zero after, with the cache still written.
 
+Its sibling, a `newSSLContext` violation from building the OkHttp client, was removed by warming the
+networking branch of the graph on the injected IO dispatcher in `BillionBeersApplication`.
+
+**Measured on a Pixel 8, not an emulator**, 10 cold starts per side of the minified benchmark
+variant: median 209.5 ms to 206.2 ms, mean 213.9 ms to 206.4 ms. A small real win of 3-7 ms, against
+a same-code run-to-run swing of 2.5 ms. Debug-build StrictMode reported the violation at 270-294 ms
+on the main thread every launch, and zero after.
+
+Two lessons worth more than the change itself:
+
+- **A StrictMode duration is not a cost estimate.** 270-294 ms in a debug build bought ~5 ms in the
+  shipped variant, which is minified and AOT-compiled from a baseline profile. Read StrictMode as
+  "this is on the wrong thread", never as "this costs the user that much".
+- **The emulator could not answer this and quietly said it could.** The same comparison there swung
+  160 ms between two runs of *identical* code - 30x the effect - and a first single-run comparison
+  showed a convincing -182 ms (-15.9%) that was pure noise. The Pixel reproduces to 2.5 ms. This is
+  ADR 0009's measurement warning in a second setting, and why `androidx.benchmark.suppressErrors`
+  lists `EMULATOR`.
+
 ## Worked example: a vendor SDK that does not handle threading
 
 The case the guidance has to survive. A third-party SDK exposes a blocking call and cannot be


### PR DESCRIPTION
The second violation StrictMode found in #147. Building the OkHttp client creates an `SSLContext`, and because that work lives in the dependency graph rather than in a coroutine it ran during `MainActivity`'s `setContent` — on the critical path to the first frame.

Warming `appGraph.beersRepository` on the injected IO dispatcher in `Application.onCreate` pulls the remote source → Retrofit → OkHttp client off the main thread before the first composition asks for it.

## Measured on a Pixel 8, not an emulator

10 cold starts per side of the minified benchmark variant:

| | before | after |
|---|---|---|
| median | 209.5 ms | 206.2 ms (**−3.3 ms**) |
| mean | 213.9 ms | 206.4 ms (**−7.5 ms**) |
| stdev | 12.2 ms | 14.0 ms |
| same-code run-to-run swing | **2.5 ms** | |

A small but real win of 3–7 ms. Debug-build StrictMode went from a `newSSLContext` violation of **270–294 ms on the main thread every launch** to **zero**.

## Two findings worth more than the change

**A StrictMode duration is not a cost estimate.** 270–294 ms in a debug build bought about 5 ms in the shipped variant, which is minified and AOT-compiled from a baseline profile. Read StrictMode as *"this is on the wrong thread"*, never as *"this costs the user that much"*. I had implicitly assumed the former implied the latter.

**The emulator could not answer this, and gave no sign of it.** The same comparison there swung **160 ms between two runs of identical code** — 30× the effect being measured — and my first single-run comparison showed a convincing −182 ms (−15.9%) that was entirely noise. The Pixel reproduces to 2.5 ms. This is ADR 0009's measurement warning showing up in a second setting, and exactly why `androidx.benchmark.suppressErrors` lists `EMULATOR`.

## Caveats kept in the code

- **It is a race.** Metro memoises behind a double-checked lock, so if the first composition reaches the repository first, Main blocks on the same work. The measured win is consistent with the warm usually — not always — arriving first.
- `runCatching` around the resolution: a warm-up must never be what crashes the app.
- The dispatcher comes from the injected provider, not a hardcoded `Dispatchers.IO`, per ADR 0012.

`make test` and `make konsist` green. ADR 0012 records the measurement and both lessons.
