### PR TITLE
chore: set the startup budget from real-device data, and stop gating on emulators

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ All ten are enforced by `:konsist`; the wording here is from the tests themselve
     directly. Without it the module has no `atdApi35DebugAndroidTest` task and is absent from
     `ciGroupDebugAndroidTest`, so its tests compile, look like coverage, and never run.
     `:benchmark:*` is exempt — benchmarks use their own runner and real hardware, not the ATD lane.
+    `make benchmark-check`'s startup budget is 500ms, calibrated on a Pixel 8 (medians 202-282ms) and
+    **enforced only on physical devices**; an emulator run reports its number and never gates.
     (`InstrumentedTestOptInBoundaryTest` — reads the build scripts.)
 
 11. **A `src/` directory has a build script beside it.** Otherwise nothing compiles, tests or ships

--- a/scripts/check-benchmark-budget.sh
+++ b/scripts/check-benchmark-budget.sh
@@ -19,19 +19,60 @@ if [ -z "$JSON_FILE" ] || [ ! -f "$JSON_FILE" ]; then
   exit 1
 fi
 
-# Budget in milliseconds, keyed by "<@Test method name>:<metric name>". Deliberately generous -
-# these run on whatever device/emulator is available (including CI, if ever wired up), and
-# emulator timing is noisier than a physical device. The point is to catch a real regression
-# (a multi-hundred-ms/multi-x slowdown), not to enforce a tight physical-device number.
+# Budget in milliseconds, keyed by "<@Test method name>:<metric name>".
+#
+# Calibrated on a PHYSICAL device and enforced only there. Reference: Pixel 8 (shiba), API 37.
+#
+# Observed run medians across five separate `make benchmark-check` invocations (5 cold starts each):
+# 202, 208, 210, 211, 282 ms. The 282 ms run is the important one - an initial sample of ten cold
+# starts suggested a max of 238 ms, and a later run beat that by 44 ms with no code change. Real
+# devices drift with thermal state and background load in a way a short sample does not show, so the
+# budget is set against the worst observed median rather than the tidy one.
+#
+# 500 ms is ~2.4x the typical median and ~1.8x that worst run: it fails on a doubling of startup
+# while surviving a warm phone. A tighter number (400 ms was tried) sits only 1.4x above a run that
+# has already happened, and a gate that cries wolf gets deleted - which is the failure mode this is
+# trying to avoid, not a hypothetical.
+#
+# It used to be 3000 ms, set from emulator numbers (median ~1078 ms, and 160 ms swings between two
+# runs of identical code). Against a real 209 ms that gate could never have fired - it was 14x the
+# value it was guarding.
+#
+# Like config/build-time-budget.txt, this is a property of the reference hardware. A slower physical
+# device can exceed it with nothing wrong; re-calibrate rather than assume a regression.
 #
 # A case statement (not an associative array) on purpose: macOS ships bash 3.2 (no `declare -A`
 # support), while CI runners default to bash 5.x - this has to work on both.
 budget_ms_for() {
   case "$1" in
-    "startup:timeToInitialDisplayMs") echo "3000" ;;
+    "startup:timeToInitialDisplayMs") echo "500" ;;
     *) echo "" ;;
   esac
 }
+
+# Emulator runs are reported but never gated.
+#
+# This project already holds that a benchmark taken on a managed virtual device is meaningless -
+# it is why :benchmark:microbenchmark is deliberately outside the ATD lane (AGENTS.md §5) and why
+# androidx.benchmark.suppressErrors lists EMULATOR. Measured here: the same before/after comparison
+# swung 160 ms between two identical-code runs on an emulator versus 2.5 ms on a Pixel 8. Enforcing
+# a physical-device budget there would either fail constantly or, if loosened to fit, stop meaning
+# anything - which is exactly how the old 3000 ms number came about.
+IS_EMULATOR=$(python3 -c "
+import json
+c = json.load(open('$JSON_FILE')).get('context', {}).get('build', {})
+blob = (c.get('fingerprint','') + ' ' + c.get('model','') + ' ' + c.get('device','')).lower()
+print('yes' if any(m in blob for m in ('sdk_gphone', 'generic', 'emulator', 'goldfish', 'ranchu')) else 'no')
+")
+
+DEVICE_LABEL=$(python3 -c "
+import json
+c = json.load(open('$JSON_FILE')).get('context', {})
+b = c.get('build', {})
+print(f\"{b.get('model','?')} (API {b.get('version',{}).get('sdk','?')}), cpuLocked={c.get('cpuLocked')}\")
+")
+
+echo "Device: $DEVICE_LABEL"
 
 FAILED=0
 
@@ -44,6 +85,8 @@ while IFS=$'\t' read -r test_name metric_name median; do
   fi
   if python3 -c "import sys; sys.exit(0 if float('$median') <= float('$budget') else 1)"; then
     echo "OK   $key: ${median}ms <= ${budget}ms budget"
+  elif [ "$IS_EMULATOR" = "yes" ]; then
+    echo "SKIP $key: ${median}ms > ${budget}ms budget - reported, not gated (emulator)"
   else
     echo "FAIL $key: ${median}ms > ${budget}ms budget"
     FAILED=1
@@ -64,4 +107,8 @@ if [ "$FAILED" -eq 1 ]; then
   exit 1
 fi
 
-echo "All benchmarks within budget."
+if [ "$IS_EMULATOR" = "yes" ]; then
+  echo "All benchmarks reported (emulator - budgets are not enforced here)."
+else
+  echo "All benchmarks within budget."
+fi


### PR DESCRIPTION
The budget was **3000 ms**, set from emulator numbers. Measured on a Pixel 8 the app starts in **~209 ms**, so the gate sat 14× above the value it was guarding and could never have fired.

## Now 500 ms, enforced only on physical devices

Observed run medians across five separate `make benchmark-check` invocations (5 cold starts each):

```
202, 208, 210, 211, 282 ms
```

**The 282 ms run is the one that set the number.** An initial ten-cold-start sample suggested a max of 238 ms; a later run beat that by 44 ms with no code change. Real devices drift with thermal state and background load more than a short sample shows, so the budget is set against the worst observed median rather than the tidy one.

500 ms is ~2.4× the typical median and ~1.8× that worst run — it fails on a doubling of startup while surviving a warm phone. **400 ms was tried first** and sits only 1.4× above a run that has already happened. A gate that cries wolf gets deleted, which is the failure mode being avoided rather than a hypothetical.

## Emulator runs report, never gate

The project already holds that a benchmark on a virtual device is meaningless — it's why `:benchmark:microbenchmark` sits outside the ATD lane (AGENTS.md §5) and why `androidx.benchmark.suppressErrors` lists `EMULATOR`. Measured here: the same before/after comparison swung **160 ms between two identical-code runs** on an emulator versus **2.5 ms** on the Pixel.

Device class comes from `context.build.fingerprint` in the results JSON, which the script already parses.

## Proven both ways

| input | result |
|---|---|
| real Pixel data (208 ms) | `OK … <= 500ms budget`, exit 0 |
| same device context, synthetic 512 ms median | `FAIL`, exit 1 |
| emulator data (1143 ms) | `SKIP … reported, not gated`, exit 0 |
