### PR TITLE
revert: drop the networking graph warm-up, which a trace shows does nothing

### DIFF
--- a/app/src/main/java/com/simtop/billionbeers/BillionBeersApplication.kt
+++ b/app/src/main/java/com/simtop/billionbeers/BillionBeersApplication.kt
@@ -7,8 +7,6 @@ import com.simtop.billionbeers.di.BaseAppGraph
 import com.simtop.core.di.GraphProvider
 import dev.zacsweers.metro.createGraphFactory
 import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 class BillionBeersApplication : SplitCompatApplication(), GraphProvider {
   lateinit var appGraph: BaseAppGraph
@@ -16,45 +14,15 @@ class BillionBeersApplication : SplitCompatApplication(), GraphProvider {
   override val metroViewModelFactory: MetroViewModelFactory
     get() = appGraph.metroViewModelFactory
 
+  // Deliberately does *not* pre-warm the networking branch of the graph on a background thread.
+  // That was built, measured and reverted: a Perfetto trace of a cold start on a Pixel 8 shows no
+  // SSL, Conscrypt or socket work on the main thread at all - the only OkHttp work anywhere is
+  // ~3ms of JIT on the JIT thread pool - so there was nothing to move. See docs/adr/0012.
   override fun onCreate() {
     super.onCreate()
     enableStrictMode()
     if (!::appGraph.isInitialized) {
       appGraph = createGraphFactory<AppGraph.Factory>().create(this)
-    }
-    warmNetworkingGraph()
-  }
-
-  /**
-   * Builds the networking branch of the graph off the main thread, before the first composition
-   * asks for it.
-   *
-   * Resolving [BaseAppGraph.beersRepository] pulls the remote source, Retrofit and finally the
-   * OkHttp client, and building that client creates an `SSLContext` - which StrictMode reported as
-   * a main-thread `CustomViolation: newSSLContext` on every launch. The work sits in the dependency
-   * graph rather than in any coroutine, so it happened during `MainActivity.onCreate`'s
-   * `setContent`, on the critical path to the first frame. (Its sibling, a main-thread disk read
-   * for the cache directory, was fixed separately in `NetworkingModule`.)
-   *
-   * **This is a race.** Metro memoises providers behind a double-checked lock, so if the first
-   * composition reaches the repository first, the main thread blocks on the same work.
-   *
-   * Measured on a Pixel 8, 10 cold starts per side of the minified benchmark variant: median 209.5
-   * ms -> 206.2 ms, mean 213.9 ms -> 206.4 ms. A small real win, 3-7 ms, against a same-code
-   * run-to-run swing of 2.5 ms. The debug-build StrictMode violation it removes is far larger
-   * (270-294 ms on main, every launch, now zero) - but that is a debug number and does not
-   * transfer: the shipped variant is minified and AOT-compiled from a baseline profile, so the same
-   * work costs a fraction of it. Treat StrictMode durations as "this is on the wrong thread", never
-   * as "this costs the user that much".
-   *
-   * An emulator cannot answer this at all: there the same comparison swung 160 ms between two runs
-   * of identical code, which is 30x the effect being measured.
-   */
-  private fun warmNetworkingGraph() {
-    CoroutineScope(appGraph.coroutineDispatcher.io).launch {
-      // A warm-up must never be what crashes the app. If resolution fails here, swallow it and let
-      // the real call site fail in its own context, where the error can be handled and reported.
-      runCatching { appGraph.beersRepository }
     }
   }
 }

--- a/docs/adr/0012-dispatcher-placement.md
+++ b/docs/adr/0012-dispatcher-placement.md
@@ -118,24 +118,34 @@ upstream of any coroutine. Fixed by resolving the path from `applicationInfo.dat
 no syscall) and letting OkHttp create the directory lazily on its own dispatcher; verified on an
 emulator as two violations per launch before and zero after, with the cache still written.
 
-Its sibling, a `newSSLContext` violation from building the OkHttp client, was removed by warming the
-networking branch of the graph on the injected IO dispatcher in `BillionBeersApplication`.
+Its sibling, a `newSSLContext` violation from building the OkHttp client, was **not** worth fixing -
+and establishing that took three measurements, two of which lied.
 
-**Measured on a Pixel 8, not an emulator**, 10 cold starts per side of the minified benchmark
-variant: median 209.5 ms to 206.2 ms, mean 213.9 ms to 206.4 ms. A small real win of 3-7 ms, against
-a same-code run-to-run swing of 2.5 ms. Debug-build StrictMode reported the violation at 270-294 ms
-on the main thread every launch, and zero after.
+A warm-up that resolved the networking branch on a background thread in `BillionBeersApplication`
+removed the violation, and was **built, merged and then reverted**. The record of why is worth more
+than the code was:
 
-Two lessons worth more than the change itself:
+1. **Emulator benchmark - wrong.** A single run showed -182 ms (-15.9%), which looked like a decisive
+   win. It was noise: two runs of *identical* code there differ by 160 ms, 30x the effect.
+2. **Physical benchmark - inconclusive, and I read it as a win.** Pixel 8, 10 cold starts per side:
+   median 209.5 -> 206.2 ms, mean 213.9 -> 206.4 ms. A 3-7 ms "improvement" sitting inside a 12-14 ms
+   standard deviation.
+3. **Perfetto trace - decisive.** A cold start on the Pixel contains *no* SSL, Conscrypt or socket
+   slice on the main thread. The only OkHttp work anywhere in the process is
+   `JIT compiling okhttp3.Dispatcher.<init>` on the JIT thread pool, ~3 ms, off the critical path.
+   There was nothing to move, so the 3-7 ms was noise too.
 
-- **A StrictMode duration is not a cost estimate.** 270-294 ms in a debug build bought ~5 ms in the
-  shipped variant, which is minified and AOT-compiled from a baseline profile. Read StrictMode as
-  "this is on the wrong thread", never as "this costs the user that much".
-- **The emulator could not answer this and quietly said it could.** The same comparison there swung
-  160 ms between two runs of *identical* code - 30x the effect - and a first single-run comparison
-  showed a convincing -182 ms (-15.9%) that was pure noise. The Pixel reproduces to 2.5 ms. This is
-  ADR 0009's measurement warning in a second setting, and why `androidx.benchmark.suppressErrors`
-  lists `EMULATOR`.
+**The lesson that generalises: a StrictMode duration is not a cost.** It reported 270-294 ms on the
+main thread in a *debug* build. The shipped build is minified and AOT-compiled from a baseline
+profile (the trace confirms `filter=speed-profile`), and there the same work does not measurably
+exist. Read StrictMode as "this is on the wrong thread", never as "this costs the user that much" -
+and reach for a trace before optimising, not a stopwatch and certainly not an emulator.
+
+Where startup time actually goes on a Pixel 8, from that trace: 103 ms in the first
+`Choreographer#doFrame` (22.8 ms of it Compose `measure`, 17.1 ms of *that* text measurement), 41 ms
+in `bindApplication` (~16 ms of it dex/OAT loading), and 24.7 ms before the process even starts. The
+largest addressable item is font I/O blocking the main thread during text layout - 12.3 ms of
+uninterruptible I/O sleep inside `TextStringSimpleNode::measure` - not anything in the DI graph.
 
 ## Worked example: a vendor SDK that does not handle threading
 


### PR DESCRIPTION
Reverts the mechanism from #148 and keeps the record, corrected.

## Why

A Perfetto trace of a cold start on a Pixel 8 contains **no SSL, Conscrypt or socket slice on the main thread**. The only OkHttp work anywhere in the process is `JIT compiling okhttp3.Dispatcher.<init>` on the JIT thread pool, ~3 ms, off the critical path.

There was nothing for the warm-up to move — so the 3–7 ms it appeared to buy was noise inside a 12–14 ms standard deviation.

## Three measurements, two of which lied

| | verdict | reality |
|---|---|---|
| Emulator benchmark, 1 run | −182 ms (−15.9%) | **noise** — two identical-code runs there differ by 160 ms, 30× the effect |
| Pixel benchmark, 10 runs/side | median −3.3 ms, mean −7.5 ms | **inconclusive** — inside the spread, and I read it as a win |
| Perfetto trace | nothing on the main thread | **decisive**, and free — macrobenchmark had already captured it |

## The lesson, now in ADR 0012

**A StrictMode duration is not a cost.** It reported 270–294 ms on the main thread in a *debug* build. The shipped build is minified and AOT-compiled from a baseline profile — the trace confirms `filter=speed-profile` — and there the same work does not measurably exist.

Read StrictMode as *"this is on the wrong thread"*, never as *"this costs the user that much"*. Reach for a trace before optimising, not a stopwatch and certainly not an emulator.

## What actually costs, from the trace

- **103 ms** — first `Choreographer#doFrame`; 22.8 ms Compose `measure`, **17.1 ms of that text measurement**
- **41 ms** — `bindApplication`, ~16 ms of it dex/OAT loading
- **24.7 ms** — before the process even starts

The largest addressable item is **font I/O blocking the main thread during text layout**: 12.3 ms of uninterruptible I/O sleep inside `TextStringSimpleNode::measure` across 35 events. Investigating that next.

`make konsist` green, `:app:assembleDebug` green.
