### PR TITLE
Restore JUnit XML reports, and assert screen-reader labels in the UI tier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,13 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: unit-test-reports
-          path: '**/build/reports/tests/'
+          # test-results holds the JUnit XML, reports/tests the HTML. Screenshot-enabled modules
+          # emit only the former - billionbeers.android.screenshot has to disable the HTML report,
+          # because Paparazzi replaces the HTML reporter with one that calls a Gradle 8 internal.
+          # With the HTML path alone this artifact was empty for most of the app.
+          path: |
+            **/build/test-results/
+            **/build/reports/tests/
 
   screenshot-tests:
     name: Screenshot Tests (Paparazzi)

--- a/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
@@ -66,12 +66,17 @@ class MainActivityComposeTest {
       homeScreen {
         waitUntilNodeWithTextIsDisplayed(fakeBeer.name)
         assertBeerNameIsDisplayed(fakeBeer.name)
+        // Both real screens, checked where they are already composed - the catalog list and the
+        // detail screen behind it. Cheaper here than a dedicated test per feature module, which
+        // ADR 0009 prices at ~49s of module overhead against ~2s of test.
+        assertEveryClickableIsLabelled()
         clickOnBeer(fakeBeer.name)
       }
 
       detailScreen {
         waitUntilNodeWithTextIsDisplayed(fakeBeer.description)
         assertBeerDetailIsDisplayed(fakeBeer.name, fakeBeer.description)
+        assertEveryClickableIsLabelled()
       }
     }
 
@@ -114,6 +119,9 @@ class MainActivityComposeTest {
         waitUntilNodeWithTextIsDisplayed(fakeStyle.name)
         assertBrowseTitleIsDisplayed()
         assertStyleIsDisplayed(fakeStyle.name)
+        // The only a11y coverage the browse dynamic feature gets - and its tabs are exactly the
+        // kind of icon-adjacent control where an unlabelled clickable hides.
+        assertEveryClickableIsLabelled()
 
         clickOnBreweriesTab()
         waitUntilNodeWithTextIsDisplayed(fakeBrewery.name)

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
@@ -16,15 +16,20 @@ dependencies {
     add("ksp", project(":snapshot-processor"))
 }
 
-// Paparazzi 2.0.0-alpha04's PaparazziTestReporter is wired into the Test
-// task's HTML/Junit report generators and calls a Gradle 8.x internal method
-// (TestResultProvider.hasOutput) that no longer exists in Gradle 9.4.
-// This makes the build fail at report-generation even when the test itself passed and
-// Images were recorded successfully. Disabling both reports because anyway we usually check
-// the reports in build/reports/paparazzi.
+// Paparazzi's plugin calls Test.setTestReporter(PaparazziTestReporter) on every Test task in the
+// module - not just during record/verify - and that reporter's ClassPageRenderer calls the Gradle 8
+// internal TestResultsProvider.hasOutput, gone in Gradle 9.4. Report generation then fails a build
+// whose tests passed, so the HTML report stays off; the Paparazzi one in build/reports/paparazzi is
+// the one worth reading anyway.
+//
+// JUnit XML is NOT affected and must stay on. Gradle generates it through Binary2JUnitXmlReport-
+// Generator, a path setTestReporter does not touch - the reporter it replaces is the HTML one only.
+// Disabling it here was collateral damage, and it cost more than the bug: it is the only
+// machine-readable record a test run leaves, so CI's unit-test-reports artifact was empty for the
+// seven screenshot-enabled modules and "the tests passed" could not be verified from CI output.
 tasks.withType<Test>().configureEach {
     reports.html.required.set(false)
-    reports.junitXml.required.set(false)
+    reports.junitXml.required.set(true)
 }
 
 val namespaceProvider = provider {
@@ -177,8 +182,25 @@ tasks.withType<Test>().configureEach {
         it.contains("Paparazzi", ignoreCase = true) 
     }
     
+    // A `--tests` filter that matches nothing must fail, or a typo'd filter reads as a green run -
+    // the bug that forced a mutation-probe to prove a test had executed at all. Restoring it
+    // unconditionally is not an option: with the excludeTestsMatching below and no `--tests`, a
+    // module holding only screenshot tests (:core:designsystem) legitimately runs zero tests, and
+    // Gradle fails exactly that with "No tests found for given includes:" (empty list and all).
+    // So it tracks `--tests`, which is stock Gradle behaviour for the filter the developer typed.
+    // The per-task filter's commandLineIncludePatterns would be more precise, but it lives on the
+    // internal DefaultTestFilter - and an internal-API dependency is what broke the reports above.
+    //
+    // Consequence, and it is the correct one: a project-wide `./gradlew testDebugUnitTest --tests
+    // "*Foo*"` now fails these modules when they hold no match. Every module that does not apply
+    // this plugin already did - :app, :beer_data, :beer_network and :navigation all fail that way -
+    // so this ends a silent exemption rather than creating a new sharp edge. Scope the filter to a
+    // module (`make test MODULE=:feature:beerslist`) as before.
+    val hasCommandLineTestFilter = project.gradle.startParameter.taskRequests
+        .any { request -> request.args.any { it == "--tests" } }
+
     filter {
-        isFailOnNoMatchingTests = false
+        isFailOnNoMatchingTests = hasCommandLineTestFilter
         if (isPaparazziRun) {
             // Paparazzi task strictly executes the auto-generated Screenshot runner
             includeTestsMatching("com.simtop.billionbeers.screenshot.*")

--- a/feature/beersearch/src/androidTest/java/com/simtop/feature/beersearch/BeersSearchInputUiTest.kt
+++ b/feature/beersearch/src/androidTest/java/com/simtop/feature/beersearch/BeersSearchInputUiTest.kt
@@ -60,6 +60,24 @@ class BeersSearchInputUiTest {
     searchScreen(composeTestRule) { assertSearchFieldIsFocused() }
   }
 
+  /**
+   * The screen's controls are icon-only - a back arrow and a clear affordance - so a dropped
+   * `contentDescription` leaves them silent to TalkBack while looking untouched in a screenshot.
+   * Asserted with text present, because the clear action only composes once the field is non-empty.
+   */
+  @Test
+  fun everyControlIsReachableByAScreenReader() {
+    setContent()
+
+    searchScreen(composeTestRule) {
+      assertEveryClickableIsLabelled()
+
+      typeQuery("stout")
+      assertClearActionIsPresent()
+      assertEveryClickableIsLabelled()
+    }
+  }
+
   @Test
   fun typingThroughTheImeReachesTheQueryCallback() {
     val typed = mutableListOf<String>()

--- a/testing-utils-android/src/main/java/com/simtop/testing_utils_android/BaseTestRobot.kt
+++ b/testing-utils-android/src/main/java/com/simtop/testing_utils_android/BaseTestRobot.kt
@@ -1,11 +1,15 @@
 package com.simtop.testing_utils_android
 
 import androidx.annotation.StringRes
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -16,6 +20,64 @@ import androidx.test.espresso.Espresso
 import androidx.test.platform.app.InstrumentationRegistry
 
 open class BaseTestRobot(private val composeTestRule: ComposeTestRule) {
+
+  /**
+   * Fails if any node a user can activate reaches a screen reader unlabelled - no
+   * `contentDescription`, no text, no editable text. That is the single most common Compose
+   * accessibility defect, and it is invisible to every other rung of the ladder: an
+   * `Icon(contentDescription = null)` inside an `IconButton` renders identically and passes
+   * screenshot verification.
+   *
+   * Read against the *merged* semantics tree on purpose. A clickable `Row` holding a `Text` owns no
+   * label of its own but merges its children's, which is exactly what TalkBack announces - checking
+   * the unmerged tree would flag every such row as a false positive.
+   *
+   * Why this and not the Accessibility Test Framework, which is the usual recipe (Espresso's
+   * `AccessibilityChecks.enable()`, or ATF behind Compose's `composeAccessibilityValidator`):
+   * **measured, ATF is blind to Compose here.** It builds its hierarchy by walking `View` children,
+   * and a Compose screen is one `AndroidComposeView` whose content lives in virtual
+   * `AccessibilityNodeInfo` nodes it never descends into. Wired up against espresso-accessibility
+   * 3.7.0 (ATF 3.1.2) it returned exactly one finding on every screen - `SpeakableTextPresentCheck`
+   * against `AndroidComposeView` itself, id -1 - and a deliberately unlabelled back button added to
+   * the search screen did **not** change that result. One guaranteed false positive, zero true
+   * positives. Revisit only with an ATF that accepts an `AccessibilityNodeInfo` root.
+   */
+  fun assertEveryClickableIsLabelled() {
+    val candidates =
+      composeTestRule.onAllNodes(
+        SemanticsMatcher("clickable node with no screen-reader label") { node ->
+          node.config.contains(SemanticsActions.OnClick) &&
+            node.config.getOrNull(SemanticsProperties.ContentDescription).isNullOrEmpty() &&
+            node.config.getOrNull(SemanticsProperties.Text).isNullOrEmpty() &&
+            node.config.getOrNull(SemanticsProperties.EditableText) == null
+        }
+      )
+
+    // Displayed only. The semantics tree also holds what is composed but off-screen - a closed
+    // drawer, a lazy list's prefetched rows - and a screen reader cannot reach those either, so
+    // flagging them would report defects no user can hit. Filtered here rather than in the matcher
+    // because isDisplayed() is defined on the interaction, not on the node.
+    val unlabelled =
+      (0 until candidates.fetchSemanticsNodes().size)
+        .map { candidates[it] }
+        .filter {
+          it.isDisplayed()
+        }
+
+    if (unlabelled.isNotEmpty()) {
+      val detail =
+        unlabelled.joinToString("\n") { interaction ->
+          val node = interaction.fetchSemanticsNode()
+          "  - node ${node.id}, testTag=" +
+            "${node.config.getOrNull(SemanticsProperties.TestTag) ?: "(none)"}, " +
+            "role=${node.config.getOrNull(SemanticsProperties.Role)}, " +
+            "bounds=${node.boundsInRoot}"
+        }
+      throw AssertionError(
+        "${unlabelled.size} clickable node(s) reach a screen reader with no label:\n$detail"
+      )
+    }
+  }
 
   fun clickOnNodeWithTag(testTag: String) {
     composeTestRule.onNodeWithTag(testTag).performClick()


### PR DESCRIPTION
Two independent gaps found while auditing what the test tiers actually prove.

## Restoring the reports screenshot modules lost

`billionbeers.android.screenshot` disabled both the HTML and JUnit XML reports to work around Paparazzi's `setTestReporter`, which installs a reporter calling a Gradle 8 internal that no longer exists in 9.4.

Only the HTML report was ever affected. JUnit XML is generated by `Binary2JUnitXmlReportGenerator`, a path `setTestReporter` does not touch — verified both ways, including `verifyPaparazziDebug`, where the broken reporter actually runs. Disabling XML was collateral damage, and it cost more than the bug: XML is the only machine-readable record a run leaves, so CI's `unit-test-reports` artifact was empty for the seven screenshot-enabled modules. That artifact also pointed only at the HTML path, which stays disabled, so re-enabling XML alone would have shipped nothing — it now uploads `**/build/test-results/` too.

`isFailOnNoMatchingTests` could not simply be enabled: with the screenshot exclude and no `--tests`, a module holding only screenshot tests (`:core:designsystem`, `:catalog`) legitimately runs zero tests, and Gradle fails exactly that with `No tests found for given includes:`. It now tracks whether a `--tests` filter was typed, which is the capability that was actually lost — a typo'd filter matched nothing and read as a green run. A project-wide `--tests` now fails these modules when they hold no match, which is what every non-screenshot module already did; this ends a silent exemption rather than adding a sharp edge.

## Screen-reader labels

The UI tier had 20 `contentDescription` uses and zero assertions on any of them. A dropped label is invisible to every other rung — an `Icon(contentDescription = null)` renders identically and passes screenshot verification.

The usual recipe does not work here, and that is worth recording. Espresso's `AccessibilityChecks.enable()` hooks `ViewActions`, which these Compose tests never touch. ATF behind Compose's own `composeAccessibilityValidator` is no better: it builds its hierarchy by walking `View` children, and a Compose screen is a single `AndroidComposeView` whose content lives in virtual `AccessibilityNodeInfo` nodes it never descends into. Wired to espresso-accessibility 3.7.0 it returned exactly one finding on every screen — `SpeakableTextPresentCheck` against `AndroidComposeView` itself, id -1 — and a **deliberately unlabelled back button did not change that result**. One guaranteed false positive, zero true positives, so the dependency was dropped again; this PR adds none.

`BaseTestRobot.assertEveryClickableIsLabelled()` reads the merged semantics tree instead, so a clickable `Row` that merges its children's text is not a false positive, and is restricted to displayed nodes, since a screen reader cannot reach a closed drawer or a lazy list's prefetched rows either. Mutation-probed the same way as the ATF attempt: with the search screen's back button set to `null` it reports the unlabelled node; restored, the tier is green.

Covers search, the catalog list, detail, and the browse dynamic feature.

## Verification

`make test`, `konsist`, `lint`, `screenshot-verify` green. Instrumented: `:app` 14/14, `:feature:beersearch` 4/4. The three `--tests` cases checked individually — no-match fails, matching passes, plain zero-unit-test module passes.

## Known follow-ups, not in this PR

- `:feature:beerslist`'s UI tests drive `composeTestRule` directly and construct no robot, so they are not covered.
- The debug drawer's fault-injection radios expose `Role`+`OnClick` on the child with the `Text` on the parent — an independently-clickable unlabelled radio. Debug-only and off-screen, so the displayed-only filter excludes it; the fix is `onClick = null` on the `RadioButton`.