### PR TITLE
Fix the two a11y findings, and put beerslist on the shared robot

### DIFF
--- a/app/src/debug/java/com/simtop/billionbeers/debug/DebugDrawerContent.kt
+++ b/app/src/debug/java/com/simtop/billionbeers/debug/DebugDrawerContent.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
@@ -26,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.simtop.billionbeers.di.BaseAppGraph
 import com.simtop.core.core.FeatureFlag
@@ -68,16 +70,11 @@ fun DebugDrawerContent(appGraph: BaseAppGraph, modifier: Modifier = Modifier) {
     SectionTitle("Feature flags")
     val overrides by appGraph.featureFlagProvider.overrides.collectAsState()
     FeatureFlag.entries.forEach { flag ->
-      Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-      ) {
-        Text(text = flag.displayName, modifier = Modifier.weight(1f))
-        Switch(
-          checked = overrides[flag] ?: flag.defaultValue,
-          onCheckedChange = { enabled -> appGraph.featureFlagProvider.setOverride(flag, enabled) },
-        )
-      }
+      SwitchRow(
+        label = flag.displayName,
+        checked = overrides[flag] ?: flag.defaultValue,
+        onCheckedChange = { enabled -> appGraph.featureFlagProvider.setOverride(flag, enabled) },
+      )
     }
 
     Spacer(modifier = Modifier.padding(top = 12.dp))
@@ -121,13 +118,40 @@ private fun SectionTitle(text: String) {
   Text(text = text, style = MaterialTheme.typography.titleMedium)
 }
 
+/**
+ * The [RadioRow] reasoning, for a [Switch] whose label was likewise a sibling rather than merged.
+ */
+@Composable
+private fun SwitchRow(label: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .toggleable(value = checked, onValueChange = onCheckedChange, role = Role.Switch)
+        .padding(vertical = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(text = label, modifier = Modifier.weight(1f))
+    Switch(checked = checked, onCheckedChange = null)
+  }
+}
+
+/**
+ * `onClick = null` on the [RadioButton] is load-bearing, not a tidy-up. Given its own handler it
+ * becomes a separately focusable target carrying no label of its own - the row holds the [Text] -
+ * so a screen reader announces an unlabelled control next to the one it should read. Passing null
+ * leaves the button as decoration and lets the row's `selectable` own both the click and the merged
+ * semantics, which is what TalkBack should land on. `role` makes it announce as a radio rather than
+ * a generic button.
+ */
 @Composable
 private fun RadioRow(label: String, selected: Boolean, onClick: () -> Unit) {
   Row(
-    modifier = Modifier.fillMaxWidth().selectable(selected = selected, onClick = onClick),
+    modifier =
+      Modifier.fillMaxWidth()
+        .selectable(selected = selected, onClick = onClick, role = Role.RadioButton),
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    RadioButton(selected = selected, onClick = onClick)
+    RadioButton(selected = selected, onClick = null)
     Text(text = label)
   }
 }

--- a/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListPagingUiTest.kt
+++ b/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListPagingUiTest.kt
@@ -1,19 +1,13 @@
 package com.simtop.feature.beerslist
 
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performScrollToIndex
-import androidx.test.platform.app.InstrumentationRegistry
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.fakes.fakeBeerModel
 import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
 import com.simtop.core.core.CommonUiState
 import com.simtop.core.core.PagedListFooter
 import com.simtop.core.core.PagedListUiModel
-import com.simtop.presentation_utils.R as PresentationUtilsR
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
@@ -43,9 +37,6 @@ class BeersListPagingUiTest {
 
   private val lastBeerIndex = beers.lastIndex
 
-  private fun string(resId: Int): String =
-    InstrumentationRegistry.getInstrumentation().targetContext.getString(resId)
-
   private fun setContent(footer: PagedListFooter, onScrollToBottom: () -> Unit) {
     composeTestRule.setContent { Content(footer = footer, onScrollToBottom = onScrollToBottom) }
   }
@@ -74,19 +65,23 @@ class BeersListPagingUiTest {
     var loadMoreCount = 0
     setContent(PagedListFooter.Hidden) { loadMoreCount++ }
 
-    composeTestRule.waitForIdle()
-    assertEquals(
-      "load-more fired before any scroll - the list was already at its end",
-      0,
-      loadMoreCount,
-    )
+    beersList(composeTestRule) {
+      waitForIdle()
+      assertEquals(
+        "load-more fired before any scroll - the list was already at its end",
+        0,
+        loadMoreCount,
+      )
+      // The list's own controls, checked while the screen is up rather than in a test of their own.
+      assertEveryClickableIsLabelled()
 
-    composeTestRule.onNodeWithTag(BEER_LIST_TAG).performScrollToIndex(lastBeerIndex)
+      scrollToBeerAt(lastBeerIndex)
 
-    // The callback runs from a LaunchedEffect collecting a snapshotFlow, so it can land after the
-    // scroll returns. Waiting on the condition rather than asserting straight away is what keeps
-    // this from passing on a warm local device and flaking on a CI runner.
-    composeTestRule.waitUntil(WAIT_TIMEOUT_MS) { loadMoreCount > 0 }
+      // The callback runs from a LaunchedEffect collecting a snapshotFlow, so it can land after the
+      // scroll returns. Waiting on the condition rather than asserting straight away is what keeps
+      // this from passing on a warm local device and flaking on a CI runner.
+      waitUntil(WAIT_TIMEOUT_MS) { loadMoreCount > 0 }
+    }
 
     assertEquals(1, loadMoreCount)
   }
@@ -106,16 +101,17 @@ class BeersListPagingUiTest {
     var loadMoreCount = 0
     setContent(PagedListFooter.Retry) { loadMoreCount++ }
 
-    composeTestRule.waitForIdle()
-    assertEquals(0, loadMoreCount)
+    beersList(composeTestRule) {
+      waitForIdle()
+      assertEquals(0, loadMoreCount)
 
-    // One past the last beer: the retry footer is its own item in the lazy list.
-    composeTestRule.onNodeWithTag(BEER_LIST_TAG).performScrollToIndex(lastBeerIndex + 1)
-    composeTestRule.waitForIdle()
+      // One past the last beer: the retry footer is its own item in the lazy list.
+      scrollToBeerAt(lastBeerIndex + 1)
+      waitForIdle()
 
-    composeTestRule
-      .onNodeWithText(string(PresentationUtilsR.string.paged_list_load_more_failed))
-      .assertIsDisplayed()
+      assertLoadMoreFailedFooterIsDisplayed()
+      assertEveryClickableIsLabelled()
+    }
 
     assertEquals(
       "auto-load fired while the retry footer was up - the user must drive this with Retry",
@@ -125,7 +121,6 @@ class BeersListPagingUiTest {
   }
 
   private companion object {
-    const val BEER_LIST_TAG = "beer_list"
     const val WAIT_TIMEOUT_MS = 5_000L
   }
 }

--- a/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListRobot.kt
+++ b/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListRobot.kt
@@ -1,0 +1,22 @@
+package com.simtop.feature.beerslist
+
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import com.simtop.presentation_utils.R as PresentationUtilsR
+import com.simtop.testing_utils_android.BaseTestRobot
+
+/** The screen's own tag, kept beside the robot that addresses it rather than inside one test. */
+private const val BEER_LIST_TAG = "beer_list"
+
+fun beersList(composeTestRule: ComposeTestRule, func: BeersListRobot.() -> Unit) =
+  BeersListRobot(composeTestRule).apply { func() }
+
+class BeersListRobot(composeTestRule: ComposeTestRule) : BaseTestRobot(composeTestRule) {
+
+  fun scrollToBeerAt(index: Int) {
+    scrollToIndexInNodeWithTag(BEER_LIST_TAG, index)
+  }
+
+  fun assertLoadMoreFailedFooterIsDisplayed() {
+    assertTextIsDisplayed(string(PresentationUtilsR.string.paged_list_load_more_failed))
+  }
+}

--- a/testing-utils-android/src/main/java/com/simtop/testing_utils_android/BaseTestRobot.kt
+++ b/testing-utils-android/src/main/java/com/simtop/testing_utils_android/BaseTestRobot.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextInput
 import androidx.test.espresso.Espresso
 import androidx.test.platform.app.InstrumentationRegistry
@@ -113,6 +114,22 @@ open class BaseTestRobot(private val composeTestRule: ComposeTestRule) {
 
   fun assertNodeWithTagIsFocused(testTag: String) {
     composeTestRule.onNodeWithTag(testTag).assertIsFocused()
+  }
+
+  /**
+   * Scrolls a lazy list by index rather than by pixel offset, so a test states the item it wants
+   * rather than a distance that depends on the device's density and item heights.
+   */
+  fun scrollToIndexInNodeWithTag(testTag: String, index: Int) {
+    composeTestRule.onNodeWithTag(testTag).performScrollToIndex(index)
+  }
+
+  fun waitForIdle() {
+    composeTestRule.waitForIdle()
+  }
+
+  fun waitUntil(timeoutMillis: Long = 5000, condition: () -> Boolean) {
+    composeTestRule.waitUntil(timeoutMillis, condition)
   }
 
   fun assertNodeWithContentDescriptionIsDisplayed(label: String) {


### PR DESCRIPTION
**Stacked on #151** — base is `test/junit-xml-reports-and-a11y-assertions`, not `master`. Both follow-ups were named as known gaps in that PR.

## The debug drawer's radios and switches

`RadioRow` put the label in a sibling `Text` while also giving the `RadioButton` its own `onClick`. That makes the button a separately focusable target carrying no label — a screen reader announces an unlabelled control right next to the one it should read. The feature-flag `Switch` had the identical shape, found only after fixing the radios.

Both now let the row own the interaction (`selectable` / `toggleable`, with an explicit `role`) and pass a null handler to the control, so its semantics merge into the row. That is the documented Material 3 pattern, and it also fixes the touch target: the whole row is now the hit area.

Verified by removing the displayed-only filter that hides these in normal runs, since a closed drawer is off-screen: **8 radio findings + 1 switch finding before, 0 after** — across the entire semantics tree, off-screen included.

## Why beerslist wasn't using a robot

Chronology, not a decision. #138 added the feature-module UI tier with `BeersListPagingUiTest`; #139 extracted `BaseTestRobot` one PR later and used it for beersearch's new test. beerslist was simply never retrofitted. Nothing was missing — the `billionbeers.android.feature.uitest` convention already puts `:testing-utils-android` on its `androidTest` configuration — and the duplicated private `string(resId)` helper was the tell.

It also mattered beyond tidiness: the new label assertion lives on the robot, so beerslist was the one opted-in module it could not reach.

Mutation-probed to prove the assertion isn't vacuous there: with the search icon's `contentDescription` set to `null`, both tests fail on the unlabelled button; restored, both pass.

`BaseTestRobot` gains the `scrollToIndexInNodeWithTag` / `waitForIdle` / `waitUntil` passthroughs the retrofit needed, and `BEER_LIST_TAG` moves next to the robot that addresses it rather than living in one test's companion.

## Verification

`make test`, `konsist`, `lint`, `screenshot-verify` green. Instrumented: `:app` 14/14, `:feature:beersearch` 4/4, `:feature:beerslist` 2/2.