### PR TITLE
Invariant 13: feature modules stay off the data layer, and make the gate actually run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ when they get in the way. (`:konsist`'s build-script rules skip `bin/` for this 
 
 ## 3. Invariants — break these and the build (or an instrumented test) breaks
 
-All ten are enforced by `:konsist`; the wording here is from the tests themselves.
+All thirteen are enforced by `:konsist`; the wording here is from the tests themselves.
 
 1. **Repository interfaces do not import data-layer types.** (`RepositoryBoundaryTest`)
 2. **Feature modules never depend on other feature modules** — `beerslist` ⊥ `beerdetail`, and so
@@ -115,8 +115,22 @@ All ten are enforced by `:konsist`; the wording here is from the tests themselve
     `:benchmark:*`, `testing-utils*` and `build-logic` are exempt — for them a test library on
     `implementation` is correct. (`TestLibraryBoundaryTest` — reads the catalog and build scripts.)
 
+13. **Feature modules never declare a data-layer module.** No `feature/*` build script may name
+    `:beer_data`, `:beer_database` or `:beer_network`; a feature reaches persistence and the network
+    through the `:beerdomain:api` repository interfaces, whose implementations `:app` binds. This is
+    the edge the neighbouring rules leave open: invariant 2 reads *imports* and only for the
+    beerslist/beerdetail pair, invariant 4 fires only when a **ViewModel** imports a data type (a
+    mapper or composable in the same module passes), and invariant 6 covers `app-dev-*` only. So
+    the dependency could be declared and used with nothing firing. `:app` is exempt — assembling the
+    graph is its job. (`FeatureDataLayerBoundaryTest` — reads the build scripts.)
+
 Every invariant in this list is now mechanically enforced. If you add one, add its rule in the
 same change — a convention with no test is a convention that drifts.
+
+**`:konsist:test` declares the repo's `.kt`/`.kts` files as task inputs, and must keep doing so.**
+The rules read the project off the filesystem, which Gradle cannot see, so without that declaration
+the task goes UP-TO-DATE while the code it guards changes — measured, a flat invariant-2 violation
+left `make konsist` green at "3 up-to-date". The whole gate, not one rule.
 
 ---
 

--- a/konsist/build.gradle.kts
+++ b/konsist/build.gradle.kts
@@ -7,4 +7,29 @@ dependencies {
   testRuntimeOnly(libs.junit.platform.launcher)
 }
 
-tasks.withType<Test>().configureEach { useJUnitPlatform() }
+// The rules read the rest of the repo off the filesystem - Konsist.scopeFromProject() for the
+// import-based ones, and plain File reads for the ones that parse build.gradle.kts. None of that is
+// visible to Gradle, so with only its own sources as inputs this task went UP-TO-DATE while the
+// code it guards changed underneath it. Measured: adding a file to :feature:beerslist importing
+// :feature:beerdetail - a flat FeatureModuleBoundaryTest violation - left `make konsist` reporting
+// "3 up-to-date" and passing. That is the failure mode AGENTS.md §5 records twice, this time hiding
+// the whole architecture gate rather than one rule, and it is worse under CI's build cache, where a
+// PR touching only a feature module could restore a green result recorded before the change.
+//
+// Declaring the sources the rules actually read fixes it. Kotlin files feed the Konsist scope and
+// .kts files feed the build-script rules; build/, bin/ and the VCS/Gradle metadata are pruned for
+// the reason in AGENTS.md §2 - stale bin/ trees hold deleted sources and would fail rules on code
+// that no longer exists.
+val filesUnderRules =
+  rootProject.layout.projectDirectory.asFileTree.matching {
+    include("**/*.kt", "**/*.kts")
+    exclude("**/build/**", "**/bin/**", "**/.git/**", "**/.gradle/**", "**/gradle-user-home/**")
+  }
+
+tasks.withType<Test>().configureEach {
+  useJUnitPlatform()
+  inputs
+    .files(filesUnderRules)
+    .withPropertyName("filesUnderArchitectureRules")
+    .withPathSensitivity(PathSensitivity.RELATIVE)
+}

--- a/konsist/src/test/kotlin/com/simtop/konsist/FeatureDataLayerBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/FeatureDataLayerBoundaryTest.kt
@@ -1,0 +1,62 @@
+package com.simtop.konsist
+
+import java.io.File
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * A feature module reaches persistence and the network only through the repository *interfaces* in
+ * `:beerdomain:api`, whose implementations are bound in `:app`'s Metro graph. Declaring
+ * `:beer_data`, `:beer_database` or `:beer_network` in a feature's build script skips that seam:
+ * the feature gains Room entities, DTOs and Retrofit services as compile-time types, and the
+ * domain boundary becomes advisory.
+ *
+ * This is the *unnamed* edge the existing rules leave open, and it is worth stating explicitly:
+ * - `FeatureModuleBoundaryTest` reads imports, and only for the beerslist/beerdetail pair.
+ * - `ViewModelBoundaryTest` catches a data-layer type only when a **ViewModel** imports it. A
+ *   mapper, an extension or a composable in the same module would pass.
+ * - `DevAppDependencyBoundaryTest` forbids the same three modules, but only for `app-dev-*`.
+ *
+ * So the dependency can be declared and used today without any rule firing. This closes that.
+ *
+ * Reads build scripts directly for the reason given in [buildScripts]: Konsist does not scan
+ * `.kts`. It matches the full `project("...")` call form, since a bare `":beer_data"` would also
+ * match prose, and it strips comment lines so an explanatory comment cannot fail a correct build
+ * file.
+ *
+ * Scope is `feature/` — both the regular modules and the on-demand dynamic ones, which have the
+ * same boundary. `:app` is deliberately exempt: assembling the graph is precisely its job.
+ */
+class FeatureDataLayerBoundaryTest {
+
+  private val forbiddenDataLayerModules = listOf(":beer_data", ":beer_database", ":beer_network")
+
+  @Test
+  fun `feature modules do not depend on data-layer modules`() {
+    val root = repoRoot()
+    val featureBuildScripts =
+      File(root, "feature")
+        .listFiles { file -> file.isDirectory }
+        .orEmpty()
+        .map { File(it, "build.gradle.kts") }
+        .filter { it.exists() }
+
+    // Without this the rule passes silently if the directory is ever renamed - the failure mode
+    // that let :konsist:test itself sit un-run for weeks (AGENTS.md §5).
+    assertTrue(featureBuildScripts.isNotEmpty()) {
+      "No feature/*/build.gradle.kts found under $root - the feature module layout changed and " +
+        "this rule would pass vacuously"
+    }
+
+    featureBuildScripts.forEach { script ->
+      val text = script.uncommentedText()
+      val violations =
+        forbiddenDataLayerModules.filter { module -> text.contains("project(\"$module\")") }
+      assertTrue(violations.isEmpty()) {
+        ":feature:${script.parentFile.name} declares data-layer module(s) $violations - a feature " +
+          "depends on the repository interfaces in :beerdomain:api, and :app binds the " +
+          "implementations"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes the module-graph shape item — though not in either shape it was written as, because measuring the graph first killed both candidates.

## Why not a depth cap, and why not a snapshot

The graph is **29 modules at depth 4**. The longest chain in the project:

```
:benchmark:microbenchmark -> :beer_data -> :beer_database -> :core -> :core-common
```

A new feature module lands at depth 3; a new data module at 3–4. So a max-depth cap would **never fire** on the growth pattern this project actually has — it only moves if someone inserts a layer, which invariants 1–4 already govern. A rule that never fires is worse than no rule: it reads as coverage in `AGENTS.md` and buys nothing.

A committed graph snapshot was the other candidate. Real visibility, but it states no opinion, and it has the property that made `dependency-guard` protect the defect in #151: a baseline recorded *with* the problem already present.

## What measuring actually surfaced

An edge nothing guards. A feature module can declare `:beer_data`, `:beer_database` or `:beer_network` today and use it freely:

- `FeatureModuleBoundaryTest` (inv. 2) reads *imports*, and only for the beerslist/beerdetail pair.
- `ViewModelBoundaryTest` (inv. 4) fires only when a **ViewModel** imports a data type. A mapper, an extension or a composable in the same module passes.
- `DevAppDependencyBoundaryTest` (inv. 6) forbids the same three modules — for `app-dev-*` only.

A feature reaches persistence and the network through the `:beerdomain:api` interfaces, whose implementations `:app` binds, so the edge should not exist at all. `FeatureDataLayerBoundaryTest` reads build scripts like invariant 6 does, since Konsist doesn't scan `.kts`. `:app` is exempt — assembling the graph is its job. Green on all four feature modules.

`ViewModelBoundaryTest` stays and is **not** made redundant: it bans third-party packages (`retrofit2`, `androidx.room`, `okhttp3`) that a `project(":...")` rule structurally cannot see, it covers ViewModels in `:app` which this rule exempts, and it bans *usage* where this bans the *edge*. It's also ADR 0003's stated precondition.

## The bigger find: the gate wasn't running

While probing the new rule I found `:konsist:test` declared **no inputs** beyond its own sources. The rules read the repo off the filesystem — `Konsist.scopeFromProject()` and plain `File` reads — which Gradle cannot see, so the task went UP-TO-DATE while the code it guards changed underneath it.

Measured: a file added to `:feature:beerslist` importing `:feature:beerdetail` is a flat invariant-2 violation, and `make konsist` reported `BUILD SUCCESSFUL — 3 up-to-date`. That silently disabled **the entire architecture gate**, not one rule, and CI's build cache makes it worse: a PR touching only a feature module could restore a green result recorded before the change. Same family as the `:konsist:test` never-ran and instrumented-tests-never-ran failures already recorded in `AGENTS.md` §5.

Fixed by declaring the repo's `.kt`/`.kts` as task inputs. Both probes now fail as they should, and pass once reverted.

## Verification

Mutation-probed both rules, before and after the inputs fix:

| Probe | Before inputs fix | After |
|---|---|---|
| beerslist imports beerdetail (inv. 2) | passed, "3 up-to-date" | fails at `FeatureModuleBoundaryTest.kt:20` |
| beerslist declares `:beer_network` (inv. 13) | passed, up-to-date | fails with the module named |

`make konsist`, `make test`, `make lint` green with both probes reverted. Konsist is at 13 rules; `AGENTS.md` updated, including the stale "All ten are enforced" header.