### PR TITLE
Keep the catalog's scroll position when a page arrives, and prove restoration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,7 +224,7 @@ sets it in its own `android { defaultConfig { … } }`, which overrides the conv
 — directly, or via `billionbeers.android.feature.uitest` — for `atdApi35DebugAndroidTest` to exist
 and for CI's `ciGroupDebugAndroidTest` to pick it up. Without it the tests compile and never run,
 the `:konsist:test` failure mode; invariant 10 now enforces this. Opted in today: `:app`,
-`:beer_database`, `:feature:beerslist`. `:benchmark:microbenchmark` has `androidTest` sources but is
+`:beer_database`, `:feature:beerslist`, `:feature:beersearch`. `:benchmark:microbenchmark` has `androidTest` sources but is
 *deliberately* out — it declares `AndroidBenchmarkRunner`, builds against
 `testBuildType = "release"`, and suppresses the `EMULATOR` error class, because a measurement taken
 on a managed virtual device is meaningless. It runs via `make benchmark-check`.

--- a/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListStateRestorationUiTest.kt
+++ b/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListStateRestorationUiTest.kt
@@ -1,0 +1,138 @@
+package com.simtop.feature.beerslist
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.StateRestorationTester
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.beerdomain.fakes.fakeBeerModel
+import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
+import com.simtop.core.core.CommonUiState
+import com.simtop.core.core.PagedListFooter
+import com.simtop.core.core.PagedListUiModel
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Proves the catalog's *composition-level* saved state actually restores. The screen is full of
+ * `rememberSaveable` - `rememberLazyListState()` is one - and nothing exercised the restore path,
+ * so "handled" rested entirely on the API being called rather than on it working.
+ *
+ * The state under test is the scroll position, because it is the only saveable on this screen a
+ * user can observe. (`BeersListScreen`'s `dataVisibility` is a `rememberSaveable` that is written
+ * and never read - it restores, but no assertion can tell.)
+ *
+ * **What this cannot cover:** `SavedStateHandle`. [StateRestorationTester] recreates the
+ * *composition*, not the `ViewModel`, so a handle-backed value is out of its reach by
+ * construction - a different mechanism, proven at a different tier. `BeersListViewModel` holds no
+ * handle, so there is nothing here to prove; the one place the handle's *restore* path is exercised
+ * is `BeersSearchViewModelTest`, which builds a ViewModel from a pre-populated handle. Read neither
+ * as covering the other, and neither as covering the whole project.
+ */
+class BeersListStateRestorationUiTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  /**
+   * Content goes through the tester, **not** through `composeTestRule.setContent`. The tester only
+   * recreates a composition it owns; set the content on the rule instead and
+   * `emulateSavedInstanceStateRestore()` is a silent no-op that leaves the test green.
+   */
+  private val restorationTester = StateRestorationTester(composeTestRule)
+
+  /**
+   * Long enough that item 39 is far off-screen on first layout, so the scroll has real distance.
+   */
+  private val beers: List<Beer> =
+    List(TOTAL_BEERS) { index -> fakeBeerModel.copy(id = "$index", name = "Beer $index") }
+
+  @Composable
+  private fun Content(items: List<Beer>) {
+    BillionBeersTheme {
+      BeersListContent(
+        viewState =
+          CommonUiState.Success(
+            PagedListUiModel(
+              items = items,
+              footer = PagedListFooter.Hidden,
+              totalCount = TOTAL_BEERS,
+            )
+          ),
+        onBeerClick = {},
+        onSearchClick = {},
+        onBrowseClick = {},
+        onScrollToBottom = {},
+        onRefresh = {},
+        onRetry = {},
+        onRetryLoadMore = {},
+      )
+    }
+  }
+
+  /**
+   * Mutation-probed, because a restore test that cannot fail is the default outcome here - set the
+   * content on the rule instead of on the tester and `emulateSavedInstanceStateRestore()` is a
+   * silent no-op. With `rememberLazyListState()` swapped for a plain `remember { LazyListState() }`
+   * this fails on the post-restore assertion with `'Beer 39' ... is not displayed`; restored, it is
+   * green.
+   */
+  @Test
+  fun theScrollPositionSurvivesSavedInstanceStateRestore() {
+    val firstPage = beers.take(FIRST_PAGE_SIZE)
+    restorationTester.setContent { Content(items = firstPage) }
+
+    beersList(composeTestRule) {
+      waitForIdle()
+      assertTextIsDisplayed("Beer 0")
+
+      scrollToBeerAt(firstPage.lastIndex)
+      assertTextIsDisplayed("Beer ${firstPage.lastIndex}")
+    }
+
+    restorationTester.emulateSavedInstanceStateRestore()
+
+    beersList(composeTestRule) {
+      waitForIdle()
+      assertTextIsDisplayed("Beer ${firstPage.lastIndex}")
+    }
+  }
+
+  /**
+   * Regression test for the bug the restore test above cannot see, and did not see: a scroll
+   * position lost while the process is very much alive.
+   *
+   * The list is composed inside an `AnimatedContent`, which wraps each content in
+   * `key(contentKey(state))`. With the default `contentKey` that key **is** the state, so every
+   * appended page - an `equals`-different `CommonUiState.Success` - replaced the group holding
+   * `rememberLazyListState()`. Nothing was saved and nothing was restored; the state was simply
+   * discarded, and the user was dropped back at the top of the catalog on every page load.
+   *
+   * Measured before the `contentKey = { it::class }` fix: scrolled to item 39, a page arriving left
+   * items **0-6** composed. After: **33-40**, the position held and the new page composed below it.
+   */
+  @Test
+  fun theScrollPositionSurvivesANewPageArriving() {
+    var items by mutableStateOf(beers.take(FIRST_PAGE_SIZE))
+    composeTestRule.setContent { Content(items = items) }
+
+    beersList(composeTestRule) {
+      waitForIdle()
+      scrollToBeerAt(FIRST_PAGE_SIZE - 1)
+      assertTextIsDisplayed("Beer ${FIRST_PAGE_SIZE - 1}")
+    }
+
+    composeTestRule.runOnUiThread { items = beers }
+
+    beersList(composeTestRule) {
+      waitForIdle()
+      assertTextIsDisplayed("Beer ${FIRST_PAGE_SIZE - 1}")
+    }
+  }
+
+  private companion object {
+    const val TOTAL_BEERS = 80
+    const val FIRST_PAGE_SIZE = 40
+  }
+}

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -185,6 +185,14 @@ fun BeersListContent(
     AnimatedContent(
       targetState = viewState,
       label = "ScreenStateAnimation",
+      // Keyed by *which* state, not by its contents. AnimatedContent wraps each content in a
+      // `key(contentKey(state))`, and the default contentKey is the state itself - so every
+      // appended page, being an `equals`-different CommonUiState.Success, replaced the group
+      // holding `rememberLazyListState()` and dropped the user back at the top of the catalog
+      // (and crossfaded the whole list on the way). Measured, not reasoned:
+      // BeersListStateRestorationUiTest.theScrollPositionSurvivesANewPageArriving found only
+      // items 0-6 composed after a page arrived at scroll position 39.
+      contentKey = { state -> state::class },
       transitionSpec = {
         fadeIn(animationSpec = tween(animationDurationMs)) togetherWith
           fadeOut(animationSpec = tween(animationDurationMs))


### PR DESCRIPTION
Started as the §2.5 gap — 48 `SavedStateHandle` and 13 `rememberSaveable` uses, and zero
`StateRestorationTester` anywhere, so restoration was handled but unproven. The test found a live bug
instead, and that is the headline.

## The bug: the catalog reset to the top on every page load

No process death involved. `BeersListContent` composes the list inside an `AnimatedContent`, which
wraps each content in `key(contentKey(state))` — and the default `contentKey` **is the state**. Every
appended page is an `equals`-different `CommonUiState.Success`, so each one replaced the group holding
`rememberLazyListState()`, and crossfaded the whole list on the way out.

Measured at scroll position 39, right after a page arrives:

| | composed items |
|---|---|
| before | **0–6** — back at the top |
| after `contentKey = { it::class }` | **33–40** — held, new page below it |

That item 40 renders at all is the evidence the fix did not trade a scroll bug for a stale-content
one: a matching key still re-invokes the content lambda with the new state.

The animation still fires on a real state change (Loading → Success → Error) and no longer on a
content change.

## The tests

`BeersListStateRestorationUiTest`, in `:feature:beerslist` — already in the UI tier, so **4.6s** for
both, in line with ADR 0009.

The restore half was genuinely fine: scroll to 39 → `emulateSavedInstanceStateRestore()` → still
there. It is mutation-probed, because this test fails to fail by default — content must be set on the
`StateRestorationTester`, not on the `ComposeTestRule`, or the restore is a silent no-op that stays
green. With `rememberLazyListState()` swapped for a plain `remember { LazyListState() }` it fails on
the post-restore assertion; restored, green.

## Scope, stated plainly

This closes the composition half only. `StateRestorationTester` recreates the composition, not the
ViewModel, so `SavedStateHandle` is structurally out of reach — a different mechanism at a different
tier. `BeersListViewModel` has no handle; the only place a handle's restore path is exercised is
`BeersSearchViewModelTest`. Not fixed here, worth knowing: `beerdetail`'s three ViewModel tests all
pass an empty `SavedStateHandle()`, so its toggle restore is unproven.

Checked rather than assumed: `beerdetail`'s `AnimatedContent` is correct as-is (Boolean target,
stateless content), and the `Error` arm's toast still fires on a message change — it is a
`LaunchedEffect(message)` inside the content lambda, so it restarts on its own key instead of via
group replacement.

Also corrects one stale line in AGENTS.md §5: `:feature:beersearch` is opted into the managed-device
lane, verified against the build scripts.

## Verification

`make test`, `make konsist`, `make screenshot-verify`, `make lint`, and the full
`:feature:beerslist` instrumented suite (4/4 green). Note `screenshot-verify` passing is *expected*,
not evidence — goldens render first composition, so Paparazzi is blind to `contentKey`. The
instrumented tier is the only rung that can see this.
