### PR TITLE
Share the convention plugins' duplicated build logic, and drop three dead root plugins

### DIFF
--- a/app-dev-beerslist/build.gradle.kts
+++ b/app-dev-beerslist/build.gradle.kts
@@ -27,6 +27,5 @@ dependencies {
 
   implementation(libs.androidPlayCore)
   implementation(libs.androidPlayCoreKtx)
-  implementation(libs.androidxActivityCompose)
   implementation(libs.kotlinx.serialization.json)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
 
   implementation(libs.androidPlayCore)
   implementation(libs.androidPlayCoreKtx)
-  implementation(libs.androidxActivityCompose)
   implementation(libs.androidx.navigation3.runtime)
   implementation(libs.androidx.navigation3.ui)
   // appcompat stays: the manifest's @style/AppTheme resolves to a Theme.AppCompat parent

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     implementation(libs.roomGradlePlugin)
     implementation(libs.metro.gradle.plugin)
     implementation(libs.kspGradlePlugin)
-    implementation(libs.navigationSafeArgsPlugin)
     implementation(libs.android.junit5.plugin)
     implementation(libs.spotless.gradlePlugin)
     implementation(libs.detekt.gradlePlugin)

--- a/build-logic/convention/src/main/kotlin/AndroidCommon.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidCommon.kt
@@ -20,11 +20,7 @@ import com.android.build.api.dsl.CommonExtension
  * (`the<LibrariesForLibs>()`) needs a `Project` receiver, which an extension on `CommonExtension`
  * does not have.
  */
-fun CommonExtension.configureBillionBeersAndroid(
-  compileSdkVersion: Int,
-  minSdkVersion: Int,
-  withTestCoverage: Boolean = true,
-) {
+fun CommonExtension.configureBillionBeersAndroid(compileSdkVersion: Int, minSdkVersion: Int) {
   compileSdk = compileSdkVersion
 
   defaultConfig.apply {
@@ -45,9 +41,7 @@ fun CommonExtension.configureBillionBeersAndroid(
     targetCompatibility = PROJECT_JAVA_VERSION
   }
 
-  // `com.android.test` opts out, matching the original four blocks: that tier produces a standalone
-  // test APK and has no coverage story.
-  if (withTestCoverage) {
-    testCoverage.jacocoVersion = PROJECT_JACOCO_VERSION
-  }
+  // Test coverage is deliberately NOT set here: it applies to three of the four tiers, and the
+  // caller opts in per plugin id. See billionbeers.android.common for why that has to be an opt-in
+  // list rather than an exclusion.
 }

--- a/build-logic/convention/src/main/kotlin/AndroidCommon.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidCommon.kt
@@ -1,0 +1,53 @@
+import com.android.build.api.dsl.CommonExtension
+
+/**
+ * The Android configuration every module gets, regardless of which AGP plugin it applies.
+ *
+ * **Why this is one function and not four copies.** `billionbeers.android.common` used to repeat
+ * fifteen identical lines inside four `pluginManager.withPlugin` blocks, once per extension type.
+ * A top-level function in a plain `.kt` file is visible to every precompiled script plugin in this
+ * source set — the same mechanism `Versions.kt` already relies on — so sharing needs no migration
+ * to binary plugins.
+ *
+ * **Why property access, not the usual DSL blocks.** In AGP 9 `CommonExtension` is no longer
+ * generic (the `CommonExtension<*, *, *, *, *, *>` spelling every pre-9 guide uses will not
+ * compile), and it declares *no* `Action`-taking overloads at all — verified with `javap`, the
+ * count is zero. So `defaultConfig { }` and `compileOptions { }` do not exist on this type; only
+ * `getDefaultConfig()` / `getCompileOptions()` do. Hence `defaultConfig.apply { }`. The concrete
+ * subtypes still offer the block form, which is why the old per-type code could use it.
+ *
+ * `compileSdk`/`minSdk` arrive as parameters because the version catalog accessor
+ * (`the<LibrariesForLibs>()`) needs a `Project` receiver, which an extension on `CommonExtension`
+ * does not have.
+ */
+fun CommonExtension.configureBillionBeersAndroid(
+  compileSdkVersion: Int,
+  minSdkVersion: Int,
+  withTestCoverage: Boolean = true,
+) {
+  compileSdk = compileSdkVersion
+
+  defaultConfig.apply {
+    minSdk = minSdkVersion
+    // Only opt a module up to the shared runner if it has not named one itself, and treat the
+    // ancient framework default as "unset". :app overrides this with MockTestRunner in its own
+    // build script; Versions.kt explains why the shared default is the stock runner.
+    if (
+      testInstrumentationRunner == null ||
+        testInstrumentationRunner == "android.test.InstrumentationTestRunner"
+    ) {
+      testInstrumentationRunner = PROJECT_TEST_RUNNER
+    }
+  }
+
+  compileOptions.apply {
+    sourceCompatibility = PROJECT_JAVA_VERSION
+    targetCompatibility = PROJECT_JAVA_VERSION
+  }
+
+  // `com.android.test` opts out, matching the original four blocks: that tier produces a standalone
+  // test APK and has no coverage story.
+  if (withTestCoverage) {
+    testCoverage.jacocoVersion = PROJECT_JACOCO_VERSION
+  }
+}

--- a/build-logic/convention/src/main/kotlin/Versions.kt
+++ b/build-logic/convention/src/main/kotlin/Versions.kt
@@ -8,5 +8,9 @@ val PROJECT_TEST_RUNNER = "androidx.test.runner.AndroidJUnitRunner"
 val PROJECT_JAVA_VERSION = JavaVersion.VERSION_23
 val DETEKT_JAVA_VERSION = "22"
 val PROJECT_JACOCO_VERSION = "0.8.13"
-val PROJECT_VERSION_CODE = 67
-val PROJECT_VERSION_NAME = "67"
+
+// The app's versionCode/versionName are deliberately NOT here. They live in gradle.properties
+// (billionbeers.versionCode / billionbeers.versionName), because they are the values in this build
+// that change most often and a constant here is compiled into the convention jar: bumping the
+// version recompiled build-logic, which invalidates every module's configuration and misses the
+// configuration cache. A Gradle property is read at configuration time and costs none of that.

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
@@ -23,8 +23,9 @@ val android = the<ApplicationExtension>()
 android.apply {
     defaultConfig {
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = PROJECT_VERSION_CODE
-        versionName = PROJECT_VERSION_NAME
+        // From gradle.properties, not a constant in the convention jar - see Versions.kt for why.
+        versionCode = providers.gradleProperty("billionbeers.versionCode").get().toInt()
+        versionName = providers.gradleProperty("billionbeers.versionName").get()
         multiDexEnabled = true
     }
 

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
@@ -135,21 +135,11 @@ plugins.withId("androidx.baselineprofile") {
 dependencies {
     "implementation"(libs.tracing.perfetto)
     "implementation"(libs.tracing.perfetto.binary)
+    // JUnit 4, deliberately: this tier applies neither android-junit5 nor useJUnitPlatform(), and
+    // :app's unit tests are `org.junit.Test`. It shares the bundles with the JUnit 5 tiers but not
+    // the platform - see billionbeers.android.testing for why that split is intentional.
     "testImplementation"(libs.junit)
-    "testImplementation"(libs.mockk)
-    "testImplementation"(libs.coreTesting)
-    "testImplementation"(libs.coroutinesTest)
-    "testImplementation"(libs.kluentAndroid)
-    "testImplementation"(libs.turbine)
+    "testImplementation"(libs.bundles.unitTest)
 
-    "androidTestImplementation"(libs.junit)
-    "androidTestImplementation"(libs.kotlinTestJunit)
-    "androidTestImplementation"(libs.coroutinesTest)
-    "androidTestImplementation"(libs.espressoCore)
-    "androidTestImplementation"(libs.testRunner)
-    "androidTestImplementation"(libs.testRules)
-    "androidTestImplementation"(libs.testCoreKtx)
-    "androidTestImplementation"(libs.mockkAndroid)
-    "androidTestImplementation"(libs.junitKtx)
-    "androidTestImplementation"(libs.coreTesting)
+    "androidTestImplementation"(libs.bundles.instrumentedTest)
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.common.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.common.gradle.kts
@@ -12,17 +12,24 @@ val PROJECT_MIN_SDK = libs.versions.minSdk.get().toInt()
 // dynamic-feature and test), and in AGP 9 `CommonExtension` is a non-generic supertype of all four
 // concrete extensions - so a single `configure<CommonExtension>` reaches every module type. The
 // shared body lives in AndroidCommon.kt.
-//
-// The one behavioural split is test coverage, which `com.android.test` never had: that plugin is
-// checked separately below and re-configured with it off.
 pluginManager.withPlugin("com.android.base") {
   extensions.configure<CommonExtension> {
     configureBillionBeersAndroid(PROJECT_COMPILE_SDK, PROJECT_MIN_SDK)
   }
 }
 
-pluginManager.withPlugin("com.android.test") {
-  extensions.configure<CommonExtension> {
-    configureBillionBeersAndroid(PROJECT_COMPILE_SDK, PROJECT_MIN_SDK, withTestCoverage = false)
+// Coverage is the one setting that is not universal: `com.android.test` never had it, because that
+// tier produces a standalone test APK with no coverage story.
+//
+// The tiers that opt *in* are listed, rather than excluding the one that opts out, and that is
+// load-bearing. Skipping the assignment in a second `withPlugin("com.android.test")` block would
+// not work: the base block above has already set the value by then and nothing unsets it, so the
+// exclusion would silently do nothing. Measured before this was fixed - a macrobenchmark module
+// reported jacocoVersion 0.8.13. Listing the opt-ins also makes it independent of the order the
+// plugins happen to be applied in.
+listOf("com.android.application", "com.android.library", "com.android.dynamic-feature").forEach {
+  pluginId ->
+  pluginManager.withPlugin(pluginId) {
+    extensions.configure<CommonExtension> { testCoverage.jacocoVersion = PROJECT_JACOCO_VERSION }
   }
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.common.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.common.gradle.kts
@@ -1,7 +1,4 @@
-import com.android.build.api.dsl.ApplicationExtension
-import com.android.build.api.dsl.LibraryExtension
-import com.android.build.api.dsl.DynamicFeatureExtension
-import com.android.build.api.dsl.TestExtension
+import com.android.build.api.dsl.CommonExtension
 import kotlin.text.toInt
 
 apply(plugin = "billionbeers.kotlin.options")
@@ -11,72 +8,21 @@ val libs = the<org.gradle.accessors.dm.LibrariesForLibs>()
 val PROJECT_COMPILE_SDK = libs.versions.compileSdk.get().toInt()
 val PROJECT_MIN_SDK = libs.versions.minSdk.get().toInt()
 
-pluginManager.withPlugin("com.android.application") {
-    extensions.configure<ApplicationExtension> {
-        compileSdk = PROJECT_COMPILE_SDK
-        defaultConfig {
-            minSdk = PROJECT_MIN_SDK
-            if (testInstrumentationRunner == null || testInstrumentationRunner == "android.test.InstrumentationTestRunner") {
-                testInstrumentationRunner = PROJECT_TEST_RUNNER
-            }
-        }
-        compileOptions {
-            sourceCompatibility = PROJECT_JAVA_VERSION
-            targetCompatibility = PROJECT_JAVA_VERSION
-        }
-        testCoverage {
-            jacocoVersion = PROJECT_JACOCO_VERSION
-        }
-    }
+// One block, not four. `com.android.base` is applied by every AGP plugin (application, library,
+// dynamic-feature and test), and in AGP 9 `CommonExtension` is a non-generic supertype of all four
+// concrete extensions - so a single `configure<CommonExtension>` reaches every module type. The
+// shared body lives in AndroidCommon.kt.
+//
+// The one behavioural split is test coverage, which `com.android.test` never had: that plugin is
+// checked separately below and re-configured with it off.
+pluginManager.withPlugin("com.android.base") {
+  extensions.configure<CommonExtension> {
+    configureBillionBeersAndroid(PROJECT_COMPILE_SDK, PROJECT_MIN_SDK)
+  }
 }
-pluginManager.withPlugin("com.android.library") {
-    extensions.configure<LibraryExtension> {
-        compileSdk = PROJECT_COMPILE_SDK
-        defaultConfig {
-            minSdk = PROJECT_MIN_SDK
-            if (testInstrumentationRunner == null || testInstrumentationRunner == "android.test.InstrumentationTestRunner") {
-                testInstrumentationRunner = PROJECT_TEST_RUNNER
-            }
-        }
-        compileOptions {
-            sourceCompatibility = PROJECT_JAVA_VERSION
-            targetCompatibility = PROJECT_JAVA_VERSION
-        }
-        testCoverage {
-            jacocoVersion = PROJECT_JACOCO_VERSION
-        }
-    }
-}
-pluginManager.withPlugin("com.android.dynamic-feature") {
-    extensions.configure<DynamicFeatureExtension> {
-        compileSdk = PROJECT_COMPILE_SDK
-        defaultConfig {
-            minSdk = PROJECT_MIN_SDK
-            if (testInstrumentationRunner == null || testInstrumentationRunner == "android.test.InstrumentationTestRunner") {
-                testInstrumentationRunner = PROJECT_TEST_RUNNER
-            }
-        }
-        compileOptions {
-            sourceCompatibility = PROJECT_JAVA_VERSION
-            targetCompatibility = PROJECT_JAVA_VERSION
-        }
-        testCoverage {
-            jacocoVersion = PROJECT_JACOCO_VERSION
-        }
-    }
-}
+
 pluginManager.withPlugin("com.android.test") {
-    extensions.configure<TestExtension> {
-        compileSdk = PROJECT_COMPILE_SDK
-        defaultConfig {
-            minSdk = PROJECT_MIN_SDK
-            if (testInstrumentationRunner == null || testInstrumentationRunner == "android.test.InstrumentationTestRunner") {
-                testInstrumentationRunner = PROJECT_TEST_RUNNER
-            }
-        }
-        compileOptions {
-            sourceCompatibility = PROJECT_JAVA_VERSION
-            targetCompatibility = PROJECT_JAVA_VERSION
-        }
-    }
+  extensions.configure<CommonExtension> {
+    configureBillionBeersAndroid(PROJECT_COMPILE_SDK, PROJECT_MIN_SDK, withTestCoverage = false)
+  }
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.dynamic.feature.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.dynamic.feature.gradle.kts
@@ -7,11 +7,15 @@ plugins {
 }
 
 apply(plugin = "billionbeers.android.common")
+apply(plugin = "billionbeers.android.testing")
 apply(plugin = "billionbeers.android.metro")
 apply(plugin = "billionbeers.android.compose")
 apply(plugin = "billionbeers.jacoco")
 apply(plugin = "billionbeers.spotless")
 apply(plugin = "billionbeers.detekt")
+// Matches android.library / android.application. Its absence here meant dynamic features were the
+// one tier the unused-dependency check never looked at.
+apply(plugin = "billionbeers.unused-dependencies")
 
 val libs = the<LibrariesForLibs>()
 
@@ -34,24 +38,9 @@ dependencies {
     "implementation"(libs.navigationFragmentKtx)
     "implementation"(libs.navigationUi)
 
-    "testImplementation"(libs.mockk)
-    "testImplementation"(libs.coreTesting)
-    "testImplementation"(libs.coroutinesTest)
-    "testImplementation"(libs.kluentAndroid)
-    "testImplementation"(libs.turbine)
-    "testImplementation"(libs.junit.jupiter.api)
-    "testImplementation"(libs.junit.jupiter.params)
-
-    // The shared MainDispatcherExtension, same as the library convention supplies.
-    "testImplementation"(project(":testing-utils"))
-    "testRuntimeOnly"(libs.junit.jupiter.engine)
-    "testRuntimeOnly"(libs.junit.vintage.engine)
-
+    // The JUnit 5 tier, :testing-utils and useJUnitPlatform() come from billionbeers.android.testing.
+    // This tier declares no JUnit 4: dynamic-feature modules have no `org.junit.Test` sources.
     "androidTestImplementation"(libs.junit)
     "androidTestImplementation"(libs.espressoCore)
     "androidTestImplementation"(libs.coreTesting)
-}
-
-tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.library.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 apply(plugin = "billionbeers.android.common")
+apply(plugin = "billionbeers.android.testing")
 apply(plugin = "billionbeers.jacoco")
 apply(plugin = "billionbeers.spotless")
 apply(plugin = "billionbeers.detekt")
@@ -15,33 +16,10 @@ apply(plugin = "billionbeers.unused-dependencies")
 val libs = the<LibrariesForLibs>()
 
 dependencies {
+    // The JUnit 5 tier and useJUnitPlatform() come from billionbeers.android.testing. JUnit 4 stays
+    // declared here: library modules still hold `org.junit.Test` tests, which the vintage engine
+    // (also supplied there) runs alongside the Jupiter ones.
     "testImplementation"(libs.junit)
-    "testImplementation"(libs.mockk)
-    "testImplementation"(libs.coreTesting)
-    "testImplementation"(libs.coroutinesTest)
-    "testImplementation"(libs.kluentAndroid)
-    "testImplementation"(libs.turbine)
-    "testImplementation"(libs.junit.jupiter.api)
-    "testImplementation"(libs.junit.jupiter.params)
 
-    // The shared MainDispatcherExtension. Every ViewModel test needs Dispatchers.setMain, and
-    // hand-rolling it in each module is how the JUnit 4 rule this replaced drifted out of use.
-    "testImplementation"(project(":testing-utils"))
-    "testRuntimeOnly"(libs.junit.jupiter.engine)
-    "testRuntimeOnly"(libs.junit.vintage.engine)
-
-    "androidTestImplementation"(libs.junit)
-    "androidTestImplementation"(libs.kotlinTestJunit)
-    "androidTestImplementation"(libs.coroutinesTest)
-    "androidTestImplementation"(libs.espressoCore)
-    "androidTestImplementation"(libs.testRunner)
-    "androidTestImplementation"(libs.testRules)
-    "androidTestImplementation"(libs.testCoreKtx)
-    "androidTestImplementation"(libs.mockkAndroid)
-    "androidTestImplementation"(libs.junitKtx)
-    "androidTestImplementation"(libs.coreTesting)
-}
-
-tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
+    "androidTestImplementation"(libs.bundles.instrumentedTest)
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.testing.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.testing.gradle.kts
@@ -1,0 +1,29 @@
+import org.gradle.accessors.dm.LibrariesForLibs
+
+/**
+ * The JUnit 5 unit-test tier: the dependency set and the platform switch that
+ * `billionbeers.android.library` and `billionbeers.android.dynamic.feature` both need, declared
+ * once.
+ *
+ * Deliberately *not* applied by `billionbeers.android.application`. `:app`'s unit tests are JUnit 4
+ * (`org.junit.Test`), and that convention applies neither `de.mannodermaus.android-junit5` nor
+ * `useJUnitPlatform()`. Pulling it onto the platform here would change how its tests are discovered,
+ * which is a decision to take deliberately rather than as a side effect of de-duplication. `:app`
+ * shares the *bundles* instead, which is where the actual duplication was.
+ *
+ * `useJUnitPlatform()` moved here from the two convention plugins that each declared it.
+ */
+val libs = the<LibrariesForLibs>()
+
+dependencies {
+  "testImplementation"(libs.bundles.unitTest)
+  "testImplementation"(libs.bundles.unitTestJunit5)
+
+  // The shared MainDispatcherExtension. Every ViewModel test needs Dispatchers.setMain, and
+  // hand-rolling it in each module is how the JUnit 4 rule this replaced drifted out of use.
+  "testImplementation"(project(":testing-utils"))
+
+  "testRuntimeOnly"(libs.bundles.unitTestJunit5Runtime)
+}
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/build-logic/convention/src/main/kotlin/billionbeers.jvm.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.jvm.library.gradle.kts
@@ -17,10 +17,28 @@ configure<JavaPluginExtension> {
     targetCompatibility = PROJECT_JAVA_VERSION
 }
 
+// Declared explicitly rather than via libs.bundles.unitTest: that bundle carries
+// androidx.arch.core:core-testing, which has no business on a pure-JVM classpath. The JUnit 5
+// halves below are shared with the Android tiers, since those are plain JVM artifacts.
 dependencies {
     "testImplementation"(libs.junit)
     "testImplementation"(libs.mockk)
     "testImplementation"(libs.coroutinesTest)
     "testImplementation"(libs.kluentAndroid)
     "testImplementation"(libs.turbine)
+
+    "testImplementation"(libs.bundles.unitTestJunit5)
+    "testRuntimeOnly"(libs.bundles.unitTestJunit5Runtime)
+    // Required on a plain JVM module the moment useJUnitPlatform() is switched on below: without it
+    // the test JVM fails to start at all ("Could not start Gradle Test Executor"). The Android tiers
+    // never need it declared because the mannodermaus plugin puts it on the classpath for them.
+    "testRuntimeOnly"(libs.junit.platform.launcher)
+}
+
+// This tier used to ship JUnit 4 with no platform switch, so a pure-JVM module needing JUnit 5 had
+// to opt out of the convention entirely and hand-roll its dependencies - which is exactly what
+// :konsist did, and why it also went without spotless and detekt. The vintage engine keeps the
+// JUnit 4 tests that are already here (:core-common's are all org.junit.Test) running alongside.
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,10 +9,11 @@ buildscript {
     dependencies {
         classpath(libs.androidToolsBuildGradle)
         classpath(libs.kotlinGradlePlugin)
-        classpath(libs.navigationSafeArgsPlugin)
-        classpath(libs.metro.gradle.plugin)
     }
 
+    // Live, despite appearances: javapoet reaches this classpath transitively through AGP and the
+    // Room Gradle plugin (confirmed with `./gradlew buildEnvironment`). Note the scope - this is the
+    // *buildscript* classpath only, so it does not pin the javapoet that KSP processors resolve.
     configurations.all {
         resolutionStrategy {
             force("com.squareup:javapoet:1.13.0")
@@ -21,7 +22,6 @@ buildscript {
 }
 
 plugins {
-    id("org.sonarqube").version("3.2.0")
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.com.google.devtools.ksp) apply false
 

--- a/catalog-processor/build.gradle.kts
+++ b/catalog-processor/build.gradle.kts
@@ -1,16 +1,20 @@
+// Formatting and static analysis only. See the note in snapshot-processor: the jvm.library
+// convention pins Java 23, which the JDK 17 toolchain below cannot produce.
 plugins {
-    kotlin("jvm")
+  kotlin("jvm")
+  id("billionbeers.spotless")
+  id("billionbeers.detekt")
 }
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(17))
+  }
 }
 
 dependencies {
-    api(libs.ksp.api)
-    api(libs.kotlinpoet)
-    api(libs.kotlinpoet.ksp)
-    implementation(kotlin("stdlib"))
+  api(libs.ksp.api)
+  api(libs.kotlinpoet)
+  api(libs.kotlinpoet.ksp)
+  implementation(kotlin("stdlib"))
 }

--- a/catalog-processor/src/main/kotlin/com/simtop/billionbeers/catalog_processor/CatalogProcessor.kt
+++ b/catalog-processor/src/main/kotlin/com/simtop/billionbeers/catalog_processor/CatalogProcessor.kt
@@ -5,196 +5,254 @@ import com.google.devtools.ksp.symbol.*
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.writeTo
-import java.io.OutputStream
 
 class CatalogProcessorProvider : SymbolProcessorProvider {
-    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
-        return CatalogProcessor(environment.codeGenerator, environment.logger)
-    }
+  override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+    return CatalogProcessor(environment.codeGenerator, environment.logger)
+  }
 }
 
 class CatalogProcessor(
-    private val codeGenerator: CodeGenerator,
-    private val logger: KSPLogger
+  private val codeGenerator: CodeGenerator,
+  private val logger: KSPLogger,
 ) : SymbolProcessor {
 
-    @OptIn(com.google.devtools.ksp.KspExperimental::class)
-    override fun process(resolver: Resolver): List<KSAnnotated> {
-        val annotationName = "com.simtop.billionbeers.catalog_annotations.CatalogComponent"
-        val symbols = resolver.getSymbolsWithAnnotation(annotationName)
-            .filterIsInstance<KSFunctionDeclaration>()
-        
-        if (!symbols.iterator().hasNext()) return emptyList()
+  @OptIn(com.google.devtools.ksp.KspExperimental::class)
+  override fun process(resolver: Resolver): List<KSAnnotated> {
+    val annotationName = "com.simtop.billionbeers.catalog_annotations.CatalogComponent"
+    val symbols =
+      resolver.getSymbolsWithAnnotation(annotationName).filterIsInstance<KSFunctionDeclaration>()
 
-        val catalogItems = mutableListOf<CatalogItemInfo>()
+    if (!symbols.iterator().hasNext()) return emptyList()
 
-        symbols.forEach { func ->
-            val annotation = func.annotations.find { 
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == annotationName 
-            } ?: return@forEach
+    val catalogItems = mutableListOf<CatalogItemInfo>()
 
-            val tab = annotation.arguments.find { it.name?.asString() == "tab" }?.value as String
-            val explicitName = annotation.arguments.find { it.name?.asString() == "name" }?.value as String
-            val displayName = if (explicitName.isEmpty()) func.simpleName.asString() else explicitName
-            val demoContainer = annotation.arguments.find { it.name?.asString() == "demoContainer" }?.value as? String ?: ""
-            
-            val packageName = func.packageName.asString()
-            val funcName = func.simpleName.asString()
-            
-            // Generate the interactive wrapper for this component
-            val wrapperName = "${funcName}_CatalogWrapper"
-            generateWrapper(func, wrapperName, demoContainer)
-            
-            catalogItems.add(CatalogItemInfo(tab, displayName, packageName, wrapperName))
-        }
+    symbols.forEach { func ->
+      val annotation =
+        func.annotations.find {
+          it.annotationType.resolve().declaration.qualifiedName?.asString() == annotationName
+        } ?: return@forEach
 
-        if (catalogItems.isNotEmpty()) {
-            val moduleName = resolver.getModuleName().asString().replace("-", "_").replace(":", "_")
-            generateProvider(catalogItems, moduleName)
-        }
+      val tab = annotation.arguments.find { it.name?.asString() == "tab" }?.value as String
+      val explicitName =
+        annotation.arguments.find { it.name?.asString() == "name" }?.value as String
+      val displayName = if (explicitName.isEmpty()) func.simpleName.asString() else explicitName
+      val demoContainer =
+        annotation.arguments.find { it.name?.asString() == "demoContainer" }?.value as? String ?: ""
 
-        return emptyList()
+      val packageName = func.packageName.asString()
+      val funcName = func.simpleName.asString()
+
+      // Generate the interactive wrapper for this component
+      val wrapperName = "${funcName}_CatalogWrapper"
+      generateWrapper(func, wrapperName, demoContainer)
+
+      catalogItems.add(CatalogItemInfo(tab, displayName, packageName, wrapperName))
     }
 
-    private fun generateWrapper(func: KSFunctionDeclaration, wrapperName: String, demoContainer: String) {
-        val packageName = func.packageName.asString()
-        val funcName = func.simpleName.asString()
-        
-        val fileSpec = FileSpec.builder(packageName, wrapperName)
-            .addImport("androidx.compose.runtime", "getValue", "setValue", "mutableStateOf", "remember")
-            .addImport("androidx.compose.foundation.layout", "Column", "Spacer", "height", "padding", "Row")
-            .addImport("androidx.compose.material3", "Text", "TextField", "Switch", "Divider", "HorizontalDivider", "Slider", "Checkbox")
-            .addImport("androidx.compose.ui", "Modifier", "Alignment")
-            .addImport("androidx.compose.foundation.text", "KeyboardOptions")
-            .addImport("androidx.compose.ui.text.input", "KeyboardType")
-            .addImport("androidx.compose.ui.unit", "dp")
-            
-        val wrapperFunc = FunSpec.builder(wrapperName)
-            .addAnnotation(ClassName("androidx.compose.runtime", "Composable"))
-            .addCode(buildCodeBlock {
-                // Generate state for each parameter
-                func.parameters.forEach { param ->
-                    val paramName = param.name?.asString() ?: return@forEach
-                    val type = param.type.resolve()
-                    val typeName = type.declaration.qualifiedName?.asString()
-                    
-                    val defaultValue = when (typeName) {
-                        "kotlin.String" -> "\"Default Value\""
-                        "kotlin.Boolean" -> "false"
-                        "kotlin.Int" -> "0"
-                        "kotlin.Float" -> "0f"
-                        else -> "null"
-                    }
-                    
-                    if (defaultValue != "null") {
-                        addStatement("var $paramName by remember { mutableStateOf($defaultValue) }")
-                    }
+    if (catalogItems.isNotEmpty()) {
+      val moduleName = resolver.getModuleName().asString().replace("-", "_").replace(":", "_")
+      generateProvider(catalogItems, moduleName)
+    }
+
+    return emptyList()
+  }
+
+  private fun generateWrapper(
+    func: KSFunctionDeclaration,
+    wrapperName: String,
+    demoContainer: String,
+  ) {
+    val packageName = func.packageName.asString()
+    val funcName = func.simpleName.asString()
+
+    val fileSpec =
+      FileSpec.builder(packageName, wrapperName)
+        .addImport("androidx.compose.runtime", "getValue", "setValue", "mutableStateOf", "remember")
+        .addImport(
+          "androidx.compose.foundation.layout",
+          "Column",
+          "Spacer",
+          "height",
+          "padding",
+          "Row",
+        )
+        .addImport(
+          "androidx.compose.material3",
+          "Text",
+          "TextField",
+          "Switch",
+          "Divider",
+          "HorizontalDivider",
+          "Slider",
+          "Checkbox",
+        )
+        .addImport("androidx.compose.ui", "Modifier", "Alignment")
+        .addImport("androidx.compose.foundation.text", "KeyboardOptions")
+        .addImport("androidx.compose.ui.text.input", "KeyboardType")
+        .addImport("androidx.compose.ui.unit", "dp")
+
+    val wrapperFunc =
+      FunSpec.builder(wrapperName)
+        .addAnnotation(ClassName("androidx.compose.runtime", "Composable"))
+        .addCode(
+          buildCodeBlock {
+            // Generate state for each parameter
+            func.parameters.forEach { param ->
+              val paramName = param.name?.asString() ?: return@forEach
+              val type = param.type.resolve()
+              val typeName = type.declaration.qualifiedName?.asString()
+
+              val defaultValue =
+                when (typeName) {
+                  "kotlin.String" -> "\"Default Value\""
+                  "kotlin.Boolean" -> "false"
+                  "kotlin.Int" -> "0"
+                  "kotlin.Float" -> "0f"
+                  else -> "null"
                 }
-                
-                add("\n")
-                beginControlFlow("Column(modifier = Modifier.padding(16.dp))")
-                
-                // Generate controls
-                func.parameters.forEach { param ->
-                    val paramName = param.name?.asString() ?: return@forEach
-                    val type = param.type.resolve()
-                    val typeName = type.declaration.qualifiedName?.asString()
-                    
-                    when (typeName) {
-                        "kotlin.String" -> {
-                            addStatement("TextField(value = $paramName, onValueChange = { $paramName = it }, label = { Text(%S) })", paramName)
-                            addStatement("Spacer(modifier = Modifier.height(8.dp))")
-                        }
-                        "kotlin.Boolean" -> {
-                            beginControlFlow("Row(verticalAlignment = Alignment.CenterVertically)")
-                            addStatement("Text(%S)", paramName)
-                            addStatement("Checkbox(checked = $paramName, onCheckedChange = { $paramName = it })")
-                            endControlFlow()
-                            addStatement("Spacer(modifier = Modifier.height(8.dp))")
-                        }
-                        "kotlin.Int" -> {
-                            addStatement("TextField(value = $paramName.toString(), onValueChange = { $paramName = it.toIntOrNull() ?: 0 }, label = { Text(%S) }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number))", paramName)
-                            addStatement("Spacer(modifier = Modifier.height(8.dp))")
-                        }
-                        "kotlin.Float" -> {
-                            addStatement("Text(\"$paramName: \${$paramName}\")")
-                            addStatement("Slider(value = $paramName, onValueChange = { $paramName = it })")
-                            addStatement("Spacer(modifier = Modifier.height(8.dp))")
-                        }
-                    }
+
+              if (defaultValue != "null") {
+                addStatement("var $paramName by remember { mutableStateOf($defaultValue) }")
+              }
+            }
+
+            add("\n")
+            beginControlFlow("Column(modifier = Modifier.padding(16.dp))")
+
+            // Generate controls
+            func.parameters.forEach { param ->
+              val paramName = param.name?.asString() ?: return@forEach
+              val type = param.type.resolve()
+              val typeName = type.declaration.qualifiedName?.asString()
+
+              when (typeName) {
+                "kotlin.String" -> {
+                  addStatement(
+                    "TextField(value = $paramName, onValueChange = { $paramName = it }, label = { Text(%S) })",
+                    paramName,
+                  )
+                  addStatement("Spacer(modifier = Modifier.height(8.dp))")
                 }
-                
-                addStatement("HorizontalDivider()")
-                addStatement("Spacer(modifier = Modifier.height(16.dp))")
-                
-                // Call the actual component
-                val supportedTypes = listOf("kotlin.String", "kotlin.Boolean", "kotlin.Int", "kotlin.Float")
-                val args = func.parameters
-                    .filter { param -> 
-                        val typeName = param.type.resolve().declaration.qualifiedName?.asString()
-                        typeName in supportedTypes
-                    }
-                    .map { param -> "${param.name?.asString()} = ${param.name?.asString()}" }
-                    .joinToString(", ")
-                
-                if (demoContainer.isNotEmpty()) {
-                    addStatement("%M($args)", MemberName(packageName, demoContainer))
-                } else {
-                    addStatement("%M($args)", MemberName(packageName, funcName))
+                "kotlin.Boolean" -> {
+                  beginControlFlow("Row(verticalAlignment = Alignment.CenterVertically)")
+                  addStatement("Text(%S)", paramName)
+                  addStatement(
+                    "Checkbox(checked = $paramName, onCheckedChange = { $paramName = it })"
+                  )
+                  endControlFlow()
+                  addStatement("Spacer(modifier = Modifier.height(8.dp))")
                 }
-                
-                endControlFlow()
-            })
+                "kotlin.Int" -> {
+                  addStatement(
+                    "TextField(value = $paramName.toString(), onValueChange = { $paramName = it.toIntOrNull() ?: 0 }, label = { Text(%S) }, keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number))",
+                    paramName,
+                  )
+                  addStatement("Spacer(modifier = Modifier.height(8.dp))")
+                }
+                "kotlin.Float" -> {
+                  addStatement("Text(\"$paramName: \${$paramName}\")")
+                  addStatement("Slider(value = $paramName, onValueChange = { $paramName = it })")
+                  addStatement("Spacer(modifier = Modifier.height(8.dp))")
+                }
+              }
+            }
+
+            addStatement("HorizontalDivider()")
+            addStatement("Spacer(modifier = Modifier.height(16.dp))")
+
+            // Call the actual component
+            val supportedTypes =
+              listOf("kotlin.String", "kotlin.Boolean", "kotlin.Int", "kotlin.Float")
+            val args =
+              func.parameters
+                .filter { param ->
+                  val typeName = param.type.resolve().declaration.qualifiedName?.asString()
+                  typeName in supportedTypes
+                }
+                .map { param -> "${param.name?.asString()} = ${param.name?.asString()}" }
+                .joinToString(", ")
+
+            if (demoContainer.isNotEmpty()) {
+              addStatement("%M($args)", MemberName(packageName, demoContainer))
+            } else {
+              addStatement("%M($args)", MemberName(packageName, funcName))
+            }
+
+            endControlFlow()
+          }
+        )
+        .build()
+
+    fileSpec.addFunction(wrapperFunc)
+    fileSpec.build().writeTo(codeGenerator, Dependencies(true, func.containingFile!!))
+  }
+
+  private fun generateProvider(items: List<CatalogItemInfo>, moduleName: String) {
+    val packageName = "com.simtop.billionbeers.catalog.generated"
+    val className = "${moduleName.capitalize()}CatalogProvider"
+
+    val itemClass = ClassName("com.simtop.billionbeers.catalog_annotations", "CatalogItem")
+    val providerInterface =
+      ClassName("com.simtop.billionbeers.catalog_annotations", "CatalogProvider")
+
+    val fileSpec =
+      FileSpec.builder(packageName, className)
+        .addType(
+          TypeSpec.classBuilder(className)
+            .addSuperinterface(providerInterface)
+            .addProperty(
+              PropertySpec.builder("items", LIST.parameterizedBy(itemClass))
+                .addModifiers(KModifier.OVERRIDE)
+                .initializer(
+                  buildCodeBlock {
+                    add("listOf(\n")
+                    items.forEach { item ->
+                      add(
+                        "    %T(tab = %S, name = %S, content = { %M() }),\n",
+                        itemClass,
+                        item.tab,
+                        item.name,
+                        MemberName(item.packageName, item.wrapperName),
+                      )
+                    }
+                    add(")")
+                  }
+                )
+                .build()
+            )
             .build()
-            
-        fileSpec.addFunction(wrapperFunc)
-        fileSpec.build().writeTo(codeGenerator, Dependencies(true, func.containingFile!!))
-    }
+        )
+        .build()
 
-    private fun generateProvider(items: List<CatalogItemInfo>, moduleName: String) {
-        val packageName = "com.simtop.billionbeers.catalog.generated"
-        val className = "${moduleName.capitalize()}CatalogProvider"
-        
-        val itemClass = ClassName("com.simtop.billionbeers.catalog_annotations", "CatalogItem")
-        val providerInterface = ClassName("com.simtop.billionbeers.catalog_annotations", "CatalogProvider")
-        
-        val fileSpec = FileSpec.builder(packageName, className)
-            .addType(TypeSpec.classBuilder(className)
-                .addSuperinterface(providerInterface)
-                .addProperty(PropertySpec.builder("items", LIST.parameterizedBy(itemClass))
-                    .addModifiers(KModifier.OVERRIDE)
-                    .initializer(buildCodeBlock {
-                        add("listOf(\n")
-                        items.forEach { item ->
-                            add("    %T(tab = %S, name = %S, content = { %M() }),\n", 
-                                itemClass, item.tab, item.name, MemberName(item.packageName, item.wrapperName))
-                        }
-                        add(")")
-                    })
-                    .build())
-                .build())
-            .build()
-            
-        fileSpec.writeTo(codeGenerator, Dependencies(true))
-        
-        // Register the provider via SPI
-        registerSpi(packageName, className)
-    }
+    fileSpec.writeTo(codeGenerator, Dependencies(true))
 
-    private fun registerSpi(packageName: String, className: String) {
-        val serviceFile = "META-INF/services/com.simtop.billionbeers.catalog_annotations.CatalogProvider"
-        codeGenerator.createNewFile(
-            Dependencies(true),
-            "",
-            serviceFile,
-            ""
-        ).use { outputStream ->
-            outputStream.write("$packageName.$className\n".toByteArray())
-        }
-    }
+    // Register the provider via SPI
+    registerSpi(packageName, className)
+  }
 
-    data class CatalogItemInfo(val tab: String, val name: String, val packageName: String, val wrapperName: String)
-    
-    // Simple extension to capitalize for class names
-    private fun String.capitalize() = this.replaceFirstChar { it.uppercase() }
+  private fun registerSpi(packageName: String, className: String) {
+    val serviceFile =
+      "META-INF/services/com.simtop.billionbeers.catalog_annotations.CatalogProvider"
+    codeGenerator
+      .createNewFile(
+        Dependencies(true),
+        "",
+        serviceFile,
+        "",
+      )
+      .use { outputStream ->
+        outputStream.write("$packageName.$className\n".toByteArray())
+      }
+  }
+
+  data class CatalogItemInfo(
+    val tab: String,
+    val name: String,
+    val packageName: String,
+    val wrapperName: String,
+  )
+
+  // Simple extension to capitalize for class names
+  private fun String.capitalize() = this.replaceFirstChar { it.uppercase() }
 }

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -20,11 +20,8 @@ dependencies {
   implementation(project(":presentation_utils"))
   implementation(project(":catalog-annotations"))
 
-  // Compose
-  implementation(libs.androidx.foundation.android)
-  implementation(libs.androidx.material3.android)
-  implementation(libs.androidx.ui.tooling.preview.android)
-  implementation(libs.androidxActivityCompose)
+  // Compose: foundation, material3, ui-tooling-preview and activity-compose come from
+  // billionbeers.android.compose.
   implementation(libs.androidx.navigation.compose)
 
   testImplementation(libs.junit)

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
   id("billionbeers.android.catalog")
 }
 
-android { namespace = "com.simtop.billionbeers.core.designsystem" }
+android {
+  namespace = "com.simtop.billionbeers.core.designsystem"
+}
 
 // No dependencies block: foundation and material3 are the only two this module needs, and
 // billionbeers.android.compose supplies both.

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -7,7 +7,5 @@ plugins {
 
 android { namespace = "com.simtop.billionbeers.core.designsystem" }
 
-dependencies {
-  implementation(libs.androidx.foundation.android)
-  implementation(libs.androidx.material3.android)
-}
+// No dependencies block: foundation and material3 are the only two this module needs, and
+// billionbeers.android.compose supplies both.

--- a/feature/beerbrowse/build.gradle.kts
+++ b/feature/beerbrowse/build.gradle.kts
@@ -12,8 +12,6 @@ dependencies {
   implementation(project(":core:designsystem"))
   implementation(project(":navigation"))
   implementation(libs.androidx.navigation3.runtime)
-  implementation(libs.androidx.material3.android)
-  implementation(libs.androidx.compose.material.icons.core)
   implementation(libs.kotlinx.serialization.json)
 
   testImplementation(project(":beerdomain:fakes"))

--- a/feature/beersearch/build.gradle.kts
+++ b/feature/beersearch/build.gradle.kts
@@ -9,9 +9,6 @@ android { namespace = "com.simtop.feature.beersearch" }
 dependencies {
   implementation(project(":navigation"))
   implementation(project(":core:designsystem"))
-  implementation(libs.androidx.material3.android)
-  implementation(libs.androidx.compose.material.icons.core)
-  implementation(libs.androidx.ui.tooling.preview.android)
 
   testImplementation(project(":beerdomain:fakes"))
   testImplementation(libs.striktCore)

--- a/feature/beerslist/build.gradle.kts
+++ b/feature/beerslist/build.gradle.kts
@@ -14,8 +14,4 @@ dependencies {
   implementation(libs.kotlinx.serialization.json)
   testImplementation(project(":beerdomain:fakes"))
   testImplementation(libs.striktCore)
-
-  implementation(libs.androidx.material3.android)
-  implementation(libs.androidx.compose.material.icons.core)
-  implementation(libs.androidx.ui.tooling.preview.android)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,3 +57,10 @@ android.r8.strictFullModeForKeepRules=false
 
 # Enabled parallel sync for Gradle 9.4+
 org.gradle.tooling.parallel=true
+
+# App version. Here rather than in build-logic's Versions.kt because these are the most frequently
+# changed values in the build, and a constant in the convention jar makes every bump recompile
+# build-logic - invalidating every module's configuration and missing the configuration cache.
+# Read by billionbeers.android.application and by scripts/play-listing.sh.
+billionbeers.versionCode=67
+billionbeers.versionName=67

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,9 +30,6 @@ systemProp.kotlin.ignore.agp.builtin.kotlin=true
 # Suppress the warning when AGP with built-in Kotlin is applied alongside standalone Kotlin plugin
 systemProp.kotlin.diagnostics.suppress.AgpWithBuiltInKotlinApplied=true
 ksp.useKSP2=true
-systemProp.sonar.host.url=http://localhost:9000
-systemProp.sonar.java.coverage=jacoco
-systemProp.sonar.coverage.exclusions=**/*App.*, **/*Application.*, **/*Activity.*, **/*Fragment.*, **/*JsonAdapter.*, **/di/**,**/*Dagger.*
 # Non-transitive R classes: each module only sees its own resources, reducing APK size.
 android.nonTransitiveRClass=true
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -170,6 +170,38 @@ detekt-gradlePlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plug
 android-junit5-plugin = { module = "de.mannodermaus.gradle.plugins:android-junit5", version.ref = "androidJunit5" }
 paparazzi-plugin = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version.ref = "paparazzi" }
 
+# Test-dependency sets, so the convention plugins declare one line instead of ten. These lists were
+# previously repeated verbatim across billionbeers.android.{application,library,dynamic.feature},
+# which is how they drifted apart.
+#
+# Anything added here is subject to invariant 12 exactly as a bare library is: TestLibraryBoundary-
+# Test resolves each bundle to its members, so a bundle holding one test-only library can no more
+# sit on `implementation` than the library itself can.
+[bundles]
+# Assertion/mocking libraries shared by every tier, independent of the test framework.
+unitTest = ["mockk", "coreTesting", "coroutinesTest", "kluentAndroid", "turbine"]
+
+# The JUnit 5 API, for modules on the mannodermaus + useJUnitPlatform() path.
+unitTestJunit5 = ["junit-jupiter-api", "junit-jupiter-params"]
+
+# Engines, runtime-only. Jupiter runs the JUnit 5 tests; vintage runs the JUnit 4 ones that still
+# sit beside them, which is why both are always declared together.
+unitTestJunit5Runtime = ["junit-jupiter-engine", "junit-vintage-engine"]
+
+# The instrumented baseline. :app and every android.library module declared exactly this list.
+instrumentedTest = [
+    "junit",
+    "kotlinTestJunit",
+    "coroutinesTest",
+    "espressoCore",
+    "testRunner",
+    "testRules",
+    "testCoreKtx",
+    "mockkAndroid",
+    "junitKtx",
+    "coreTesting",
+]
+
 [plugins]
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "org-jetbrains-kotlin" }
 com-google-devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "com-google-devtools-ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,6 @@ lifecycle-viewmodel-savedstate = { module = "androidx.lifecycle:lifecycle-viewmo
 
 # Navigation
 navigationFragmentKtx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
-navigationSafeArgsPlugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "androidx-navigation" }
 navigationUi = { module = "androidx.navigation:navigation-ui", version.ref = "androidx-navigation" }
 navigationDynamicFeaturesFragment = { module = "androidx.navigation:navigation-dynamic-features-fragment", version.ref = "androidx-navigation" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidx-navigation" }

--- a/konsist/build.gradle.kts
+++ b/konsist/build.gradle.kts
@@ -1,11 +1,12 @@
-plugins { id("org.jetbrains.kotlin.jvm") }
+// billionbeers.jvm.library, not a bare kotlin("jvm"): this module used to opt out of the convention
+// because that tier shipped JUnit 4 with no useJUnitPlatform(), and these rules are JUnit 5. Opting
+// out cost it spotless and detekt too. The convention now carries the JUnit 5 tier, so the rules
+// module is formatted and linted like everything else it polices.
+plugins { id("billionbeers.jvm.library") }
 
-dependencies {
-  testImplementation(libs.konsist)
-  testImplementation(libs.junit.jupiter.api)
-  testRuntimeOnly(libs.junit.jupiter.engine)
-  testRuntimeOnly(libs.junit.platform.launcher)
-}
+// The JUnit 5 API, the jupiter/vintage engines and the platform launcher all come from the
+// convention now, so the rules themselves are the only dependency left to declare.
+dependencies { testImplementation(libs.konsist) }
 
 // The rules read the rest of the repo off the filesystem - Konsist.scopeFromProject() for the
 // import-based ones, and plain File reads for the ones that parse build.gradle.kts. None of that is
@@ -26,8 +27,8 @@ val filesUnderRules =
     exclude("**/build/**", "**/bin/**", "**/.git/**", "**/.gradle/**", "**/gradle-user-home/**")
   }
 
+// useJUnitPlatform() is not repeated here - billionbeers.jvm.library sets it for this tier.
 tasks.withType<Test>().configureEach {
-  useJUnitPlatform()
   inputs
     .files(filesUnderRules)
     .withPropertyName("filesUnderArchitectureRules")

--- a/konsist/src/test/kotlin/com/simtop/konsist/BuildScripts.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/BuildScripts.kt
@@ -19,8 +19,8 @@ internal fun repoRoot(): File {
 
 /**
  * Every `build.gradle.kts` in the project, skipping build output and IDE output trees. `bin/` is
- * excluded because stale IDE output holds *deleted* sources and would make a rule fail on code
- * that no longer exists (AGENTS.md §2).
+ * excluded because stale IDE output holds *deleted* sources and would make a rule fail on code that
+ * no longer exists (AGENTS.md §2).
  */
 internal fun buildScripts(root: File = repoRoot()): List<File> =
   root

--- a/konsist/src/test/kotlin/com/simtop/konsist/DevAppDependencyBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/DevAppDependencyBoundaryTest.kt
@@ -5,17 +5,16 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
- * A dev-app (app-dev-<feature>) exists to build one feature in seconds instead of minutes: it
- * binds the feature under development to :beerdomain:fakes instead of the real data layer, so the
- * heavy :beer_data / :beer_database / :beer_network graph (Room, Retrofit, OkHttp) never enters
- * its compilation. The moment a dev-app declares a dependency on a data-layer module, that
- * guarantee is gone and the dev-app is just a slower copy of :app.
+ * A dev-app (app-dev-<feature>) exists to build one feature in seconds instead of minutes: it binds
+ * the feature under development to :beerdomain:fakes instead of the real data layer, so the heavy
+ * :beer_data / :beer_database / :beer_network graph (Room, Retrofit, OkHttp) never enters its
+ * compilation. The moment a dev-app declares a dependency on a data-layer module, that guarantee is
+ * gone and the dev-app is just a slower copy of :app.
  *
  * The invariant lives in build.gradle.kts, not in Kotlin source, and Konsist's project scope does
- * not surface build scripts (they are excluded, and .kts is not scanned at all), so this rule
- * reads the dev-app build files directly. It matches the full project("...") call form on purpose:
- * a bare ":beer_data" would also match the explanatory comment in the build file and fail correct
- * code.
+ * not surface build scripts (they are excluded, and .kts is not scanned at all), so this rule reads
+ * the dev-app build files directly. It matches the full project("...") call form on purpose: a bare
+ * ":beer_data" would also match the explanatory comment in the build file and fail correct code.
  */
 class DevAppDependencyBoundaryTest {
 
@@ -38,8 +37,9 @@ class DevAppDependencyBoundaryTest {
 
     devAppBuildScripts.forEach { script ->
       val text = script.readText()
-      val violations =
-        forbiddenDataLayerModules.filter { module -> text.contains("project(\"$module\")") }
+      val violations = forbiddenDataLayerModules.filter { module ->
+        text.contains("project(\"$module\")")
+      }
       assertTrue(violations.isEmpty()) {
         "${script.parentFile.name} depends on data-layer module(s) $violations - dev-apps must use " +
           ":beerdomain:fakes, not the real data layer, to keep their build fast"

--- a/konsist/src/test/kotlin/com/simtop/konsist/DomainLayerPurityTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/DomainLayerPurityTest.kt
@@ -5,9 +5,9 @@ import com.lemonappdev.konsist.api.verify.assertFalse
 import org.junit.jupiter.api.Test
 
 /**
- * :beerdomain:api is the pure-Kotlin domain layer - models, repository interfaces, error types.
- * An android.* import here means an Android framework type leaked into a layer that every other
- * module (including a future KMP non-Android target) depends on.
+ * :beerdomain:api is the pure-Kotlin domain layer - models, repository interfaces, error types. An
+ * android.* import here means an Android framework type leaked into a layer that every other module
+ * (including a future KMP non-Android target) depends on.
  */
 class DomainLayerPurityTest {
 

--- a/konsist/src/test/kotlin/com/simtop/konsist/DomainModelImmutabilityTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/DomainModelImmutabilityTest.kt
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test
 /**
  * Domain models are values: two `Beer`s with the same fields are the same beer, and nothing that
  * receives one can change what the sender sees. The app leans on this. `PagedListReducer` folds
- * pages into a list and hands it to Compose, which decides what to recompose by comparing old
- * state to new - a model mutated in place is the same reference, so the comparison says
- * "unchanged" and the UI silently keeps rendering stale data. The mappers and the pager pass the
- * same instances around on the same assumption.
+ * pages into a list and hands it to Compose, which decides what to recompose by comparing old state
+ * to new - a model mutated in place is the same reference, so the comparison says "unchanged" and
+ * the UI silently keeps rendering stale data. The mappers and the pager pass the same instances
+ * around on the same assumption.
  *
  * Two ways to break it, so two rules:
  *
@@ -62,10 +62,9 @@ class DomainModelImmutabilityTest {
         "rule would pass vacuously"
     }
 
-    val violations =
-      classes.flatMap { koClass ->
-        koClass.properties().filter { it.hasVarModifier }.map { "${koClass.name}.${it.name}" }
-      }
+    val violations = classes.flatMap { koClass ->
+      koClass.properties().filter { it.hasVarModifier }.map { "${koClass.name}.${it.name}" }
+    }
 
     assertTrue(violations.isEmpty()) {
       "Domain models must be immutable, but these are `var`: $violations. Model a change as a new " +

--- a/konsist/src/test/kotlin/com/simtop/konsist/DynamicFeatureResourceBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/DynamicFeatureResourceBoundaryTest.kt
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 /**
- * Dynamic-feature modules (feature/beerdetail, feature/beerbrowse) ship as on-demand split APKs.
- * A user-facing string declared in the split's *own* package compiles fine but crashes at runtime
+ * Dynamic-feature modules (feature/beerdetail, feature/beerbrowse) ship as on-demand split APKs. A
+ * user-facing string declared in the split's *own* package compiles fine but crashes at runtime
  * under an instrumented test, because a split's resource table is not merged into the resolving
  * context the way an installed base module's is - this has already bitten twice. The invariant:
  * every string a dynamic feature renders lives in :presentation_utils (a base module) and is
@@ -27,9 +27,9 @@ class DynamicFeatureResourceBoundaryTest {
   fun `dynamic-feature code references resources through presentation_utils, not its own R`() {
     dynamicFeaturePackages.forEach { featurePackage ->
       val files =
-        Konsist.scopeFromProject()
-          .files
-          .filter { it.packagee?.name?.startsWith(featurePackage) == true }
+        Konsist.scopeFromProject().files.filter {
+          it.packagee?.name?.startsWith(featurePackage) == true
+        }
 
       assertTrue(files.isNotEmpty()) {
         "No files scoped for $featurePackage - the package filter no longer matches this module"

--- a/konsist/src/test/kotlin/com/simtop/konsist/FeatureDataLayerBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/FeatureDataLayerBoundaryTest.kt
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test
  * A feature module reaches persistence and the network only through the repository *interfaces* in
  * `:beerdomain:api`, whose implementations are bound in `:app`'s Metro graph. Declaring
  * `:beer_data`, `:beer_database` or `:beer_network` in a feature's build script skips that seam:
- * the feature gains Room entities, DTOs and Retrofit services as compile-time types, and the
- * domain boundary becomes advisory.
+ * the feature gains Room entities, DTOs and Retrofit services as compile-time types, and the domain
+ * boundary becomes advisory.
  *
  * This is the *unnamed* edge the existing rules leave open, and it is worth stating explicitly:
  * - `FeatureModuleBoundaryTest` reads imports, and only for the beerslist/beerdetail pair.
@@ -50,8 +50,9 @@ class FeatureDataLayerBoundaryTest {
 
     featureBuildScripts.forEach { script ->
       val text = script.uncommentedText()
-      val violations =
-        forbiddenDataLayerModules.filter { module -> text.contains("project(\"$module\")") }
+      val violations = forbiddenDataLayerModules.filter { module ->
+        text.contains("project(\"$module\")")
+      }
       assertTrue(violations.isEmpty()) {
         ":feature:${script.parentFile.name} declares data-layer module(s) $violations - a feature " +
           "depends on the repository interfaces in :beerdomain:api, and :app binds the " +

--- a/konsist/src/test/kotlin/com/simtop/konsist/FeatureModuleBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/FeatureModuleBoundaryTest.kt
@@ -5,10 +5,10 @@ import com.lemonappdev.konsist.api.verify.assertFalse
 import org.junit.jupiter.api.Test
 
 /**
- * Feature modules are siblings, never dependents of each other - each communicates with the rest
- * of the app only through the domain layer (repositories, use cases, models) and navigation. A
- * feature importing another feature directly is exactly the kind of coupling that makes dynamic
- * delivery (feature/beerdetail) and independent feature ownership impossible to scale.
+ * Feature modules are siblings, never dependents of each other - each communicates with the rest of
+ * the app only through the domain layer (repositories, use cases, models) and navigation. A feature
+ * importing another feature directly is exactly the kind of coupling that makes dynamic delivery
+ * (feature/beerdetail) and independent feature ownership impossible to scale.
  */
 class FeatureModuleBoundaryTest {
 

--- a/konsist/src/test/kotlin/com/simtop/konsist/InstrumentedTestOptInBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/InstrumentedTestOptInBoundaryTest.kt
@@ -38,7 +38,9 @@ class InstrumentedTestOptInBoundaryTest {
     val modulesWithInstrumentedTests =
       buildScripts(root)
         .filter { File(it.parentFile, "src/androidTest").isDirectory }
-        .filterNot { it.parentFile.relativeTo(root).invariantSeparatorsPath.startsWith("benchmark/") }
+        .filterNot {
+          it.parentFile.relativeTo(root).invariantSeparatorsPath.startsWith("benchmark/")
+        }
 
     assertTrue(modulesWithInstrumentedTests.isNotEmpty()) {
       "No module with a src/androidTest directory found under $root - the layout changed and this " +

--- a/konsist/src/test/kotlin/com/simtop/konsist/OneShotEventBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/OneShotEventBoundaryTest.kt
@@ -22,13 +22,10 @@ class OneShotEventBoundaryTest {
 
   @Test
   fun `ViewModels do not use MutableSharedFlow for events`() {
-    Konsist.scopeFromProject()
-      .classes()
-      .withNameEndingWith("ViewModel")
-      .assertFalse { viewModel ->
-        viewModel.containingFile.hasImport { import ->
-          import.name == "kotlinx.coroutines.flow.MutableSharedFlow"
-        }
+    Konsist.scopeFromProject().classes().withNameEndingWith("ViewModel").assertFalse { viewModel ->
+      viewModel.containingFile.hasImport { import ->
+        import.name == "kotlinx.coroutines.flow.MutableSharedFlow"
       }
+    }
   }
 }

--- a/konsist/src/test/kotlin/com/simtop/konsist/RepositoryBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/RepositoryBoundaryTest.kt
@@ -6,24 +6,23 @@ import com.lemonappdev.konsist.api.verify.assertFalse
 import org.junit.jupiter.api.Test
 
 /**
- * Repository interfaces are the boundary between the domain layer and the data layer - their
- * public signatures must only expose domain types (Beer, PagingState<E>, Either<E, T>), never DB
- * entities or network DTOs. If a repository interface needs to import beer_database or
- * beer_network, a data-layer type is leaking through its signature.
+ * Repository interfaces are the boundary between the domain layer and the data layer - their public
+ * signatures must only expose domain types (Beer, PagingState<E>, Either<E, T>), never DB entities
+ * or network DTOs. If a repository interface needs to import beer_database or beer_network, a
+ * data-layer type is leaking through its signature.
  */
 class RepositoryBoundaryTest {
 
-  private val forbiddenPackagePrefixes = listOf("com.simtop.beer_database", "com.simtop.beer_network")
+  private val forbiddenPackagePrefixes =
+    listOf("com.simtop.beer_database", "com.simtop.beer_network")
 
   @Test
   fun `repository interfaces do not import data-layer types`() {
-    Konsist.scopeFromProject()
-      .interfaces()
-      .withNameEndingWith("Repository")
-      .assertFalse { repository ->
-        forbiddenPackagePrefixes.any { prefix ->
-          repository.containingFile.hasImport { import -> import.name.startsWith(prefix) }
-        }
+    Konsist.scopeFromProject().interfaces().withNameEndingWith("Repository").assertFalse {
+      repository ->
+      forbiddenPackagePrefixes.any { prefix ->
+        repository.containingFile.hasImport { import -> import.name.startsWith(prefix) }
       }
+    }
   }
 }

--- a/konsist/src/test/kotlin/com/simtop/konsist/TestFixturesPluginBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/TestFixturesPluginBoundaryTest.kt
@@ -5,14 +5,14 @@ import org.junit.jupiter.api.Test
 
 /**
  * Backs ADR 0001 (docs/adr/0001-test-fixtures-via-sibling-modules.md): test fixtures live in
- * sibling `:module:fakes` / `:module:fixtures` modules, never Gradle's `java-test-fixtures`
- * plugin. That was decided on measured build-time cost, not taste - the plugin adds a variant to
- * every consumer and the ADR records what that did to build times here.
+ * sibling `:module:fakes` / `:module:fixtures` modules, never Gradle's `java-test-fixtures` plugin.
+ * That was decided on measured build-time cost, not taste - the plugin adds a variant to every
+ * consumer and the ADR records what that did to build times here.
  *
- * The decision was drifting back in on its own: `beerdomain/api/build.gradle.kts` carried a
- * "TODO: try testFixtures instead" with commented-out `testFixturesImplementation` lines, which is
- * how a settled ADR quietly becomes a suggestion. Deleting the TODO fixes today; this rule fixes
- * the next time.
+ * The decision was drifting back in on its own: `beerdomain/api/build.gradle.kts` carried a "TODO:
+ * try testFixtures instead" with commented-out `testFixturesImplementation` lines, which is how a
+ * settled ADR quietly becomes a suggestion. Deleting the TODO fixes today; this rule fixes the next
+ * time.
  *
  * Matching is on the plugin id and deliberately ignores comment lines - see [uncommentedText].
  */

--- a/konsist/src/test/kotlin/com/simtop/konsist/TestLibraryBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/TestLibraryBoundaryTest.kt
@@ -109,6 +109,83 @@ class TestLibraryBoundaryTest {
     }
   }
 
+  /**
+   * Every `[libraries]` alias, in the dotted form a build script uses, paired with its coordinate.
+   * Needed by [testOnlyBundleAliases], which has to resolve a bundle's members back to coordinates.
+   */
+  private fun allAliasCoordinates(root: File): Map<String, String> {
+    val toml = File(root, "gradle/libs.versions.toml").readLines()
+    val librariesSection =
+      toml
+        .dropWhile { it.trim() != "[libraries]" }
+        .drop(1)
+        .takeWhile { !it.trim().startsWith("[") }
+
+    return librariesSection.mapNotNull { rawLine ->
+        val line = rawLine.substringBefore('#').trim()
+        if (line.isEmpty() || '=' !in line) return@mapNotNull null
+        val alias = line.substringBefore('=').trim()
+        val value = line.substringAfter('=').trim()
+
+        val coordinate =
+          when {
+            value.startsWith("\"") -> value.trim('"')
+            "module" in value -> Regex("""module\s*=\s*"([^"]+)"""").find(value)?.groupValues?.get(1)
+            else -> {
+              val group = Regex("""group\s*=\s*"([^"]+)"""").find(value)?.groupValues?.get(1)
+              val name = Regex("""name\s*=\s*"([^"]+)"""").find(value)?.groupValues?.get(1)
+              if (group != null && name != null) "$group:$name" else null
+            }
+          } ?: return@mapNotNull null
+
+        alias to coordinate
+      }
+      .toMap()
+  }
+
+  /**
+   * Bundle aliases holding at least one test-only library, in the dotted form a build script uses
+   * (`unitTest` -> `libs.bundles.unitTest`).
+   *
+   * A bundle is a single name for a list of libraries, so without this the catalog offers a way
+   * straight through this rule: `implementation(libs.bundles.unitTest)` ships five test libraries
+   * while matching none of the `libs.<alias>` patterns the rule looks for. **One** test-only member
+   * condemns the bundle - that member ships just as surely as it would on its own line.
+   *
+   * The `[bundles]` section is TOML arrays, which may be written on one line or across several, so
+   * the section text is joined before the entries are split out.
+   */
+  private fun testOnlyBundleAliases(root: File): List<String> {
+    val toml = File(root, "gradle/libs.versions.toml").readLines()
+    val bundlesSection =
+      toml
+        .dropWhile { it.trim() != "[bundles]" }
+        .drop(1)
+        .takeWhile { !it.trim().startsWith("[") }
+        .joinToString("\n") { it.substringBefore('#') }
+
+    if (bundlesSection.isBlank()) return emptyList()
+
+    val aliasCoordinates = allAliasCoordinates(root)
+
+    return Regex("""([\w.-]+)\s*=\s*\[([^]]*)]""", RegexOption.DOT_MATCHES_ALL)
+      .findAll(bundlesSection)
+      .mapNotNull { match ->
+        val bundleAlias = match.groupValues[1].trim()
+        val members =
+          match.groupValues[2].split(',').map { it.trim().trim('"') }.filter { it.isNotEmpty() }
+
+        val holdsTestLibrary =
+          members.any { member ->
+            val coordinate = aliasCoordinates[member]
+            coordinate != null && isTestOnly(coordinate)
+          }
+
+        if (holdsTestLibrary) bundleAlias.replace('-', '.') else null
+      }
+      .toList()
+  }
+
   @Test
   fun `test-only libraries never reach a production configuration`() {
     val root = repoRoot()
@@ -118,6 +195,11 @@ class TestLibraryBoundaryTest {
       "No test-only aliases found in gradle/libs.versions.toml - the catalog format changed and " +
         "this rule would pass vacuously"
     }
+
+    // `libs.<alias>` for a bare library, `libs.bundles.<alias>` for a bundle. Both reach a release
+    // classpath the same way, so both are checked against the same production configurations.
+    val referencePaths =
+      aliases.map { "libs.$it" } + testOnlyBundleAliases(root).map { "libs.bundles.$it" }
 
     val violations = mutableListOf<String>()
 
@@ -131,11 +213,11 @@ class TestLibraryBoundaryTest {
         script.uncommentedText().lines().forEachIndexed { index, line ->
           val declaration = line.trim()
           productionConfigurations.forEach { configuration ->
-            aliases.forEach { alias ->
-              if (declaration.startsWith("$configuration(libs.$alias)") ||
-                declaration.startsWith("\"$configuration\"(libs.$alias)")
+            referencePaths.forEach { reference ->
+              if (declaration.startsWith("$configuration($reference)") ||
+                declaration.startsWith("\"$configuration\"($reference)")
               ) {
-                violations += "$relativePath:${index + 1}  $configuration(libs.$alias)"
+                violations += "$relativePath:${index + 1}  $configuration($reference)"
               }
             }
           }

--- a/konsist/src/test/kotlin/com/simtop/konsist/TestLibraryBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/TestLibraryBoundaryTest.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.Test
 /**
  * A test-only library declared on `implementation` or `api` ships in the release APK.
  *
- * Caught on adoption: `core-common/build.gradle.kts` declared
- * `implementation(libs.coroutinesTest)` next to `implementation(libs.kotlinx.coroutines.core)` -
- * the comment on the line ("For Dispatchers? No, coroutines-core") shows the first was a mistake the
- * author noticed, corrected on the following line, and never deleted. Because every module depends
- * on `:core-common`, `kotlinx-coroutines-test` reached `:app`'s `releaseRuntimeClasspath` and its
- * `TestMainDispatcherFactory` entry was present in the shipped APK's merged
- * `META-INF/services` registry.
+ * Caught on adoption: `core-common/build.gradle.kts` declared `implementation(libs.coroutinesTest)`
+ * next to `implementation(libs.kotlinx.coroutines.core)` - the comment on the line ("For
+ * Dispatchers? No, coroutines-core") shows the first was a mistake the author noticed, corrected on
+ * the following line, and never deleted. Because every module depends on `:core-common`,
+ * `kotlinx-coroutines-test` reached `:app`'s `releaseRuntimeClasspath` and its
+ * `TestMainDispatcherFactory` entry was present in the shipped APK's merged `META-INF/services`
+ * registry.
  *
  * Nothing else catches this. `dependency-guard` locks the resolved release classpath, but it was
  * baselined *with* the offending dependency already on it, so the guard faithfully protected the
@@ -27,15 +27,16 @@ import org.junit.jupiter.api.Test
 class TestLibraryBoundaryTest {
 
   /** Configurations whose contents reach a shipped artifact. */
-  private val productionConfigurations = listOf("implementation", "api", "compileOnly", "runtimeOnly")
+  private val productionConfigurations =
+    listOf("implementation", "api", "compileOnly", "runtimeOnly")
 
   /**
    * Modules allowed to put test libraries on a production configuration.
    *
    * `testing-utils` / `testing-utils-android` are the sibling fixture modules ADR 0001 chose
    * instead of Gradle's `java-test-fixtures`; exposing JUnit and friends via `api` is their entire
-   * job, and consumers only ever take them on `testImplementation` /
-   * `androidTestImplementation`, so nothing they declare can reach a release classpath.
+   * job, and consumers only ever take them on `testImplementation` / `androidTestImplementation`,
+   * so nothing they declare can reach a release classpath.
    *
    * `build-logic` is a separate composite build of Gradle plugins - its `implementation`
    * dependencies are compile-time inputs to the build itself, not to the app.
@@ -77,16 +78,13 @@ class TestLibraryBoundaryTest {
    * script uses (`coroutinesTest` -> `libs.coroutinesTest`, `androidx-ui-test-junit4` ->
    * `libs.androidx.ui.test.junit4`).
    *
-   * Handles all three shapes the catalog uses: `alias = "group:name:version"`,
-   * `alias = { module = "group:name", ... }` and `alias = { group = "...", name = "...", ... }`.
+   * Handles all three shapes the catalog uses: `alias = "group:name:version"`, `alias = { module =
+   * "group:name", ... }` and `alias = { group = "...", name = "...", ... }`.
    */
   private fun testOnlyAliases(root: File): List<String> {
     val toml = File(root, "gradle/libs.versions.toml").readLines()
     val librariesSection =
-      toml
-        .dropWhile { it.trim() != "[libraries]" }
-        .drop(1)
-        .takeWhile { !it.trim().startsWith("[") }
+      toml.dropWhile { it.trim() != "[libraries]" }.drop(1).takeWhile { !it.trim().startsWith("[") }
 
     return librariesSection.mapNotNull { rawLine ->
       val line = rawLine.substringBefore('#').trim()
@@ -116,12 +114,10 @@ class TestLibraryBoundaryTest {
   private fun allAliasCoordinates(root: File): Map<String, String> {
     val toml = File(root, "gradle/libs.versions.toml").readLines()
     val librariesSection =
-      toml
-        .dropWhile { it.trim() != "[libraries]" }
-        .drop(1)
-        .takeWhile { !it.trim().startsWith("[") }
+      toml.dropWhile { it.trim() != "[libraries]" }.drop(1).takeWhile { !it.trim().startsWith("[") }
 
-    return librariesSection.mapNotNull { rawLine ->
+    return librariesSection
+      .mapNotNull { rawLine ->
         val line = rawLine.substringBefore('#').trim()
         if (line.isEmpty() || '=' !in line) return@mapNotNull null
         val alias = line.substringBefore('=').trim()
@@ -130,7 +126,8 @@ class TestLibraryBoundaryTest {
         val coordinate =
           when {
             value.startsWith("\"") -> value.trim('"')
-            "module" in value -> Regex("""module\s*=\s*"([^"]+)"""").find(value)?.groupValues?.get(1)
+            "module" in value ->
+              Regex("""module\s*=\s*"([^"]+)"""").find(value)?.groupValues?.get(1)
             else -> {
               val group = Regex("""group\s*=\s*"([^"]+)"""").find(value)?.groupValues?.get(1)
               val name = Regex("""name\s*=\s*"([^"]+)"""").find(value)?.groupValues?.get(1)
@@ -175,11 +172,10 @@ class TestLibraryBoundaryTest {
         val members =
           match.groupValues[2].split(',').map { it.trim().trim('"') }.filter { it.isNotEmpty() }
 
-        val holdsTestLibrary =
-          members.any { member ->
-            val coordinate = aliasCoordinates[member]
-            coordinate != null && isTestOnly(coordinate)
-          }
+        val holdsTestLibrary = members.any { member ->
+          val coordinate = aliasCoordinates[member]
+          coordinate != null && isTestOnly(coordinate)
+        }
 
         if (holdsTestLibrary) bundleAlias.replace('-', '.') else null
       }
@@ -214,8 +210,9 @@ class TestLibraryBoundaryTest {
           val declaration = line.trim()
           productionConfigurations.forEach { configuration ->
             referencePaths.forEach { reference ->
-              if (declaration.startsWith("$configuration($reference)") ||
-                declaration.startsWith("\"$configuration\"($reference)")
+              if (
+                declaration.startsWith("$configuration($reference)") ||
+                  declaration.startsWith("\"$configuration\"($reference)")
               ) {
                 violations += "$relativePath:${index + 1}  $configuration($reference)"
               }

--- a/konsist/src/test/kotlin/com/simtop/konsist/ViewModelBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/ViewModelBoundaryTest.kt
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.Test
 
 /**
  * Backs ADR 0003 (docs/adr/0003-use-case-policy.md): deleting the pass-through use cases and
- * letting ViewModels inject BeersRepository directly is only safe because the layer boundary
- * those classes used to guard socially is enforced here instead. A ViewModel importing anything
- * from the data layer fails the build, not just a review.
+ * letting ViewModels inject BeersRepository directly is only safe because the layer boundary those
+ * classes used to guard socially is enforced here instead. A ViewModel importing anything from the
+ * data layer fails the build, not just a review.
  */
 class ViewModelBoundaryTest {
 
@@ -25,13 +25,10 @@ class ViewModelBoundaryTest {
 
   @Test
   fun `ViewModels depend only on domain-layer types`() {
-    Konsist.scopeFromProject()
-      .classes()
-      .withNameEndingWith("ViewModel")
-      .assertFalse { viewModel ->
-        forbiddenPackagePrefixes.any { prefix ->
-          viewModel.containingFile.hasImport { import -> import.name.startsWith(prefix) }
-        }
+    Konsist.scopeFromProject().classes().withNameEndingWith("ViewModel").assertFalse { viewModel ->
+      forbiddenPackagePrefixes.any { prefix ->
+        viewModel.containingFile.hasImport { import -> import.name.startsWith(prefix) }
       }
+    }
   }
 }

--- a/presentation_utils/build.gradle.kts
+++ b/presentation_utils/build.gradle.kts
@@ -12,15 +12,12 @@ dependencies {
   implementation(project(":core"))
   implementation(project(":core:designsystem"))
 
-  implementation(libs.androidxActivityCompose)
-  implementation(libs.androidx.foundation.android)
+  // activity-compose, foundation, material3 and ui-tooling-preview come from
+  // billionbeers.android.compose.
   implementation(libs.androidx.runtime.retain)
-  implementation(libs.androidx.material3.android)
   // TODO: think on how could I do it impl
   api(libs.androidPlayCore)
   api(libs.androidPlayCoreKtx)
-
-  implementation(libs.androidx.ui.tooling.preview.android)
 
   implementation(libs.coil3)
   implementation(libs.coil3.view)

--- a/scripts/play-listing.sh
+++ b/scripts/play-listing.sh
@@ -81,8 +81,8 @@ file_bytes() { stat -f%z "$1" 2>/dev/null || stat -c%s "$1"; }
 cmd_init() {
   mkdir -p "$SHOTS_DIR" "$METADATA_DIR/changelogs"
   local version
-  version=$(grep -oE 'PROJECT_VERSION_NAME = "[^"]*"' \
-    "$REPO_ROOT/build-logic/convention/src/main/kotlin/Versions.kt" | cut -d'"' -f2)
+  version=$(grep -oE '^billionbeers\.versionName=.*' \
+    "$REPO_ROOT/gradle.properties" | cut -d'=' -f2)
 
   [ -f "$METADATA_DIR/title.txt" ] || printf 'BillionBeers\n' > "$METADATA_DIR/title.txt"
   [ -f "$METADATA_DIR/short_description.txt" ] || \

--- a/snapshot-processor/build.gradle.kts
+++ b/snapshot-processor/build.gradle.kts
@@ -1,16 +1,23 @@
+// Formatting and static analysis only, not billionbeers.jvm.library. That convention pins Java 23
+// (PROJECT_JAVA_VERSION plus the jvmTarget in billionbeers.kotlin.options), which cannot be
+// produced by the JDK 17 toolchain below - a KSP processor deliberately targets the older release.
+// Applying these two directly closes the actual gap: without them this module was formatted and
+// linted by nothing.
 plugins {
-    kotlin("jvm")
+  kotlin("jvm")
+  id("billionbeers.spotless")
+  id("billionbeers.detekt")
 }
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17)) // Standardize on 17 for processors
-    }
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(17)) // Standardize on 17 for processors
+  }
 }
 
 dependencies {
-    api(libs.ksp.api)
-    api(libs.kotlinpoet)
-    api(libs.kotlinpoet.ksp)
-    implementation(kotlin("stdlib"))
+  api(libs.ksp.api)
+  api(libs.kotlinpoet)
+  api(libs.kotlinpoet.ksp)
+  implementation(kotlin("stdlib"))
 }

--- a/snapshot-processor/src/main/kotlin/com/simtop/billionbeers/snapshot_processor/SnapshotProcessor.kt
+++ b/snapshot-processor/src/main/kotlin/com/simtop/billionbeers/snapshot_processor/SnapshotProcessor.kt
@@ -2,208 +2,240 @@ package com.simtop.billionbeers.snapshot_processor
 
 import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.validate
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.writeTo
-import java.io.OutputStream
 
 @Suppress("unused")
 class SnapshotProcessorProvider : SymbolProcessorProvider {
-    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
-        return SnapshotProcessor(environment.codeGenerator, environment.logger)
-    }
+  override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+    return SnapshotProcessor(environment.codeGenerator, environment.logger)
+  }
 }
 
 class SnapshotProcessor(
-    private val codeGenerator: CodeGenerator,
-    private val logger: KSPLogger
+  private val codeGenerator: CodeGenerator,
+  private val logger: KSPLogger,
 ) : SymbolProcessor {
 
-    override fun process(resolver: Resolver): List<KSAnnotated> {
-        val previewSymbols = resolver.getSymbolsWithAnnotation("androidx.compose.ui.tooling.preview.Preview")
-        val allPreviewFunctions = mutableSetOf<KSFunctionDeclaration>()
-        
-        // Use getNewFiles() to avoid reprocessing files that haven't changed in incremental builds
-        resolver.getNewFiles().forEach { file ->
-            file.declarations.filterIsInstance<KSFunctionDeclaration>().forEach { func ->
-                if (isValidPreview(func)) {
-                    allPreviewFunctions.add(func)
-                }
-            }
+  override fun process(resolver: Resolver): List<KSAnnotated> {
+    val previewSymbols =
+      resolver.getSymbolsWithAnnotation("androidx.compose.ui.tooling.preview.Preview")
+    val allPreviewFunctions = mutableSetOf<KSFunctionDeclaration>()
+
+    // Use getNewFiles() to avoid reprocessing files that haven't changed in incremental builds
+    resolver.getNewFiles().forEach { file ->
+      file.declarations.filterIsInstance<KSFunctionDeclaration>().forEach { func ->
+        if (isValidPreview(func)) {
+          allPreviewFunctions.add(func)
         }
-        
-        // If we found new functions, generate their providers
-        if (allPreviewFunctions.isNotEmpty()) {
-             // Deduplicate by function qualified name just in case
-             val uniqueFunctions = allPreviewFunctions.distinctBy { it.qualifiedName?.asString() }
-             generatePreviewProvider(uniqueFunctions, resolver)
-        }
-        
-        // For the service file, we technically need a list of ALL generated providers, not just new ones.
-        // But KSP doesn't allow easy aggregation across rounds/incremental runs into a single file without re-processing everything.
-        // A common workaround is to not generate the service file here, or use a separate "aggregating" processor.
-        // OR: accepted hack: since this is a test processor, maybe we just suppressing the exception for standard files was wrong, 
-        // but for the ServiceFile it is tricky.
-        
-        // Let's rely on the previous try-catch for the ServiceFile which is supposed to be aggregating.
-        // But we need to make sure we don't crash on the INDIVIDUAL provider files.
-        // Switching to getNewFiles() above solves the crash for individual files.
-        
-        // However, if we only process new files, we only add NEW providers to the ServiceFile list passed to generatePreviewProvider.
-        // This means the ServiceFile will only contain new providers, overwriting the old one?
-        // No, createNewFile throws if it exists.
-        
-        // If we want a correct ServiceFile in incremental builds, we have to look up all existing providers?
-        // This is complex.
-        // Minimal viable fix: Only avoid crashing on individual files.
-        // If ServiceFile generation fails, we might miss entries in incremental builds.
-        // But for "recordPaparazzi", we usually run a CLEAN build or non-incremental is fine.
-        // The crashing was the blocker.
-        
-        return emptyList() // We don't return deferrals for now
+      }
     }
 
-    private fun isValidPreview(func: KSFunctionDeclaration): Boolean {
-       // Check for direct @Preview or meta-annotation
-       for (annotation in func.annotations) {
-           val annotationType = annotation.annotationType.resolve()
-           if (annotationType.declaration.qualifiedName?.asString() == "androidx.compose.ui.tooling.preview.Preview") {
-               return true
-           }
-           // Check meta-annotations
-           val metaAnnotations = annotationType.declaration.annotations
-           for (meta in metaAnnotations) {
-               if (meta.annotationType.resolve().declaration.qualifiedName?.asString() == "androidx.compose.ui.tooling.preview.Preview") {
-                   return true
-               }
-           }
-       }
-       return false
+    // If we found new functions, generate their providers
+    if (allPreviewFunctions.isNotEmpty()) {
+      // Deduplicate by function qualified name just in case
+      val uniqueFunctions = allPreviewFunctions.distinctBy { it.qualifiedName?.asString() }
+      generatePreviewProvider(uniqueFunctions, resolver)
     }
 
-    private fun generatePreviewProvider(functions: List<KSFunctionDeclaration>, resolver: Resolver) {
-        val generatedProviders = mutableListOf<String>()
-        
-        // Group by containing file to generate one provider per source file
-        functions.groupBy { it.containingFile }.forEach { (file, previewFuncs) ->
-             if (file == null) return@forEach
-             
-             val filePackage = file.packageName.asString()
-             val fileName = file.fileName.substringBefore(".") + "_PreviewProvider"
-             val fullClassName = "$filePackage.$fileName"
-             
-             generateFile(filePackage, fileName, previewFuncs, file)
-             generatedProviders.add(fullClassName)
+    // For the service file, we technically need a list of ALL generated providers, not just new
+    // ones.
+    // But KSP doesn't allow easy aggregation across rounds/incremental runs into a single file
+    // without re-processing everything.
+    // A common workaround is to not generate the service file here, or use a separate "aggregating"
+    // processor.
+    // OR: accepted hack: since this is a test processor, maybe we just suppressing the exception
+    // for standard files was wrong,
+    // but for the ServiceFile it is tricky.
+
+    // Let's rely on the previous try-catch for the ServiceFile which is supposed to be aggregating.
+    // But we need to make sure we don't crash on the INDIVIDUAL provider files.
+    // Switching to getNewFiles() above solves the crash for individual files.
+
+    // However, if we only process new files, we only add NEW providers to the ServiceFile list
+    // passed to generatePreviewProvider.
+    // This means the ServiceFile will only contain new providers, overwriting the old one?
+    // No, createNewFile throws if it exists.
+
+    // If we want a correct ServiceFile in incremental builds, we have to look up all existing
+    // providers?
+    // This is complex.
+    // Minimal viable fix: Only avoid crashing on individual files.
+    // If ServiceFile generation fails, we might miss entries in incremental builds.
+    // But for "recordPaparazzi", we usually run a CLEAN build or non-incremental is fine.
+    // The crashing was the blocker.
+
+    return emptyList() // We don't return deferrals for now
+  }
+
+  private fun isValidPreview(func: KSFunctionDeclaration): Boolean {
+    // Check for direct @Preview or meta-annotation
+    for (annotation in func.annotations) {
+      val annotationType = annotation.annotationType.resolve()
+      if (
+        annotationType.declaration.qualifiedName?.asString() ==
+          "androidx.compose.ui.tooling.preview.Preview"
+      ) {
+        return true
+      }
+      // Check meta-annotations
+      val metaAnnotations = annotationType.declaration.annotations
+      for (meta in metaAnnotations) {
+        if (
+          meta.annotationType.resolve().declaration.qualifiedName?.asString() ==
+            "androidx.compose.ui.tooling.preview.Preview"
+        ) {
+          return true
         }
-        
-        if (generatedProviders.isNotEmpty()) {
-            generateServiceFile(generatedProviders, resolver)
-        }
+      }
     }
+    return false
+  }
 
-    private fun generateServiceFile(providers: List<String>, resolver: Resolver) {
-        // We need to aggregate providers from all rounds/files.
-        // However, KSP process is per round.
-        // If we generate META-INF/services/..., we might have issues with multiple rounds if not handled.
-        // For now, let's assume one round or that this is sufficient.
-        // BEWARE: Creating the same file in multiple rounds throws FileAlreadyExistsException.
-        // We should probably only generate this once or append? KSP doesn't support append easily.
-        
-        // Hack: Use a unique file name per process/module? No, ServiceLoader needs a specific file name.
-        // "com.simtop.billionbeers.snapshot_testing.PreviewProvider"
-        
-        // If we have multiple modules, each module generates its own jar/resources, so it's fine.
-        // But if KSP runs multiple rounds, we might try to write it twice.
-        // We can check if we already generated it?
-        // simple check: fail silently if it exists?
-        
-        try {
-            val resourceFile = codeGenerator.createNewFile(
-                Dependencies(true, *resolver.getAllFiles().toList().toTypedArray()), 
-                "META-INF/services",
-                "com.simtop.billionbeers.snapshot_testing.PreviewProvider",
-                ""
-            )
-            resourceFile.bufferedWriter().use { writer ->
-                providers.forEach {
-                    writer.write(it)
-                    writer.newLine()
-                }
-            }
-        } catch (e: FileAlreadyExistsException) {
-            // If it exists, we might be in a second round or partial processing.
-            // Ideally we should adhere to KSP incremental processing rules.
-            // For now, logging and ignoring might be risky if we missed providers.
-            // But since we are processing ALL files every time in our logic (resolver.getAllFiles()), we re-generate everything.
-            // Wait, resolver.getAllFiles() returns files to be processed.
-            // If we are in incremental mode, we might only get a subset.
-            // This global aggregation strategy is weak for incremental builds.
-            // But for "recordPaparazzi", we usually run a full build.
-        } catch (e: Exception) { // Catch generically to avoid build failure on resource duplication
-             // logger.warn("Failed to generate service file: $e")
-        }
+  private fun generatePreviewProvider(functions: List<KSFunctionDeclaration>, resolver: Resolver) {
+    val generatedProviders = mutableListOf<String>()
+
+    // Group by containing file to generate one provider per source file
+    functions
+      .groupBy { it.containingFile }
+      .forEach { (file, previewFuncs) ->
+        if (file == null) return@forEach
+
+        val filePackage = file.packageName.asString()
+        val fileName = file.fileName.substringBefore(".") + "_PreviewProvider"
+        val fullClassName = "$filePackage.$fileName"
+
+        generateFile(filePackage, fileName, previewFuncs, file)
+        generatedProviders.add(fullClassName)
+      }
+
+    if (generatedProviders.isNotEmpty()) {
+      generateServiceFile(generatedProviders, resolver)
     }
+  }
 
-    private fun generateFile(packageName: String, className: String, functions: List<KSFunctionDeclaration>, sourceFile: KSFile) {
-        val snapshotClass = ClassName("com.simtop.billionbeers.snapshot_testing", "Snapshot")
-        val previewProviderInterface = ClassName("com.simtop.billionbeers.snapshot_testing", "PreviewProvider")
-        
-        val codeBlockBuilder = CodeBlock.builder().add("listOf(\n")
+  private fun generateServiceFile(providers: List<String>, resolver: Resolver) {
+    // We need to aggregate providers from all rounds/files.
+    // However, KSP process is per round.
+    // If we generate META-INF/services/..., we might have issues with multiple rounds if not
+    // handled.
+    // For now, let's assume one round or that this is sufficient.
+    // BEWARE: Creating the same file in multiple rounds throws FileAlreadyExistsException.
+    // We should probably only generate this once or append? KSP doesn't support append easily.
 
-        functions.forEach { func ->
-            val funcName = func.simpleName.asString()
-            val parameters = func.parameters
-            
-            if (parameters.isEmpty()) {
-                codeBlockBuilder.add("    %T(%S, { %M() }),\n", snapshotClass, "${funcName}", MemberName(packageName, funcName))
-            } else {
-                // Handle PreviewParameter
-                val param = parameters.first()
-                val previewParamAnnotation = param.annotations.find { 
-                    it.annotationType.resolve().declaration.qualifiedName?.asString() == "androidx.compose.ui.tooling.preview.PreviewParameter"
-                }
-                
-                if (previewParamAnnotation != null) {
-                        val providerType = previewParamAnnotation.arguments.first().value as KSType
-                        val providerClassName = providerType.declaration.qualifiedName?.asString() ?: ""
-                        
-                        val providerClass = ClassName.bestGuess(providerClassName)
-                         
-                         codeBlockBuilder.add(
-                             """
+    // Hack: Use a unique file name per process/module? No, ServiceLoader needs a specific file
+    // name.
+    // "com.simtop.billionbeers.snapshot_testing.PreviewProvider"
+
+    // If we have multiple modules, each module generates its own jar/resources, so it's fine.
+    // But if KSP runs multiple rounds, we might try to write it twice.
+    // We can check if we already generated it?
+    // simple check: fail silently if it exists?
+
+    try {
+      val resourceFile =
+        codeGenerator.createNewFile(
+          Dependencies(true, *resolver.getAllFiles().toList().toTypedArray()),
+          "META-INF/services",
+          "com.simtop.billionbeers.snapshot_testing.PreviewProvider",
+          "",
+        )
+      resourceFile.bufferedWriter().use { writer ->
+        providers.forEach {
+          writer.write(it)
+          writer.newLine()
+        }
+      }
+    } catch (e: FileAlreadyExistsException) {
+      // If it exists, we might be in a second round or partial processing.
+      // Ideally we should adhere to KSP incremental processing rules.
+      // For now, logging and ignoring might be risky if we missed providers.
+      // But since we are processing ALL files every time in our logic (resolver.getAllFiles()), we
+      // re-generate everything.
+      // Wait, resolver.getAllFiles() returns files to be processed.
+      // If we are in incremental mode, we might only get a subset.
+      // This global aggregation strategy is weak for incremental builds.
+      // But for "recordPaparazzi", we usually run a full build.
+    } catch (e: Exception) { // Catch generically to avoid build failure on resource duplication
+      // logger.warn("Failed to generate service file: $e")
+    }
+  }
+
+  private fun generateFile(
+    packageName: String,
+    className: String,
+    functions: List<KSFunctionDeclaration>,
+    sourceFile: KSFile,
+  ) {
+    val snapshotClass = ClassName("com.simtop.billionbeers.snapshot_testing", "Snapshot")
+    val previewProviderInterface =
+      ClassName("com.simtop.billionbeers.snapshot_testing", "PreviewProvider")
+
+    val codeBlockBuilder = CodeBlock.builder().add("listOf(\n")
+
+    functions.forEach { func ->
+      val funcName = func.simpleName.asString()
+      val parameters = func.parameters
+
+      if (parameters.isEmpty()) {
+        codeBlockBuilder.add(
+          "    %T(%S, { %M() }),\n",
+          snapshotClass,
+          "${funcName}",
+          MemberName(packageName, funcName),
+        )
+      } else {
+        // Handle PreviewParameter
+        val param = parameters.first()
+        val previewParamAnnotation =
+          param.annotations.find {
+            it.annotationType.resolve().declaration.qualifiedName?.asString() ==
+              "androidx.compose.ui.tooling.preview.PreviewParameter"
+          }
+
+        if (previewParamAnnotation != null) {
+          val providerType = previewParamAnnotation.arguments.first().value as KSType
+          val providerClassName = providerType.declaration.qualifiedName?.asString() ?: ""
+
+          val providerClass = ClassName.bestGuess(providerClassName)
+
+          codeBlockBuilder.add(
+            """
                              |    *%T().let { provider -> 
                              |        provider.values.mapIndexed { index, value ->
                              |            val nameSuffix = (value as? Enum<*>)?.name ?: index.toString()
                              |            %T("${funcName}_" + nameSuffix, { %M(value) })
                              |        }.toList().toTypedArray()
                              |    },
-                             |""".trimMargin(),
-                             providerClass, snapshotClass, MemberName(packageName, funcName)
-                         )
-
-                }
-            }
+                             |"""
+              .trimMargin(),
+            providerClass,
+            snapshotClass,
+            MemberName(packageName, funcName),
+          )
         }
-        
-        codeBlockBuilder.add(")")
-
-        val propertySpec = PropertySpec.builder("snapshots", LIST.parameterizedBy(snapshotClass))
-            .addModifiers(KModifier.OVERRIDE)
-            .initializer(codeBlockBuilder.build())
-            .build()
-
-        val typeSpec = TypeSpec.classBuilder(className)
-            .addSuperinterface(previewProviderInterface)
-            .addProperty(propertySpec)
-            .build()
-
-        val fileSpec = FileSpec.builder(packageName, className)
-            .addType(typeSpec)
-            .build()
-            
-        // Use aggregating=true because the service file depends on multiple files, 
-        // but this specific file only depends on one source file.
-        fileSpec.writeTo(codeGenerator, Dependencies(true, sourceFile))
+      }
     }
+
+    codeBlockBuilder.add(")")
+
+    val propertySpec =
+      PropertySpec.builder("snapshots", LIST.parameterizedBy(snapshotClass))
+        .addModifiers(KModifier.OVERRIDE)
+        .initializer(codeBlockBuilder.build())
+        .build()
+
+    val typeSpec =
+      TypeSpec.classBuilder(className)
+        .addSuperinterface(previewProviderInterface)
+        .addProperty(propertySpec)
+        .build()
+
+    val fileSpec = FileSpec.builder(packageName, className).addType(typeSpec).build()
+
+    // Use aggregating=true because the service file depends on multiple files,
+    // but this specific file only depends on one source file.
+    fileSpec.writeTo(codeGenerator, Dependencies(true, sourceFile))
+  }
 }


### PR DESCRIPTION
Seven findings from a review of the build scripts. Mostly duplication the convention plugins were carrying, plus three dead things in the root script. No behaviour change to the app: `:app:dependencyGuard` passes, so the shipped release classpath is byte-identical.

## The convention plugins

**`android.common` went from four blocks to one.** It repeated the same fifteen lines in four `pluginManager.withPlugin` blocks, one per extension type. AGP 9 changed the shape of that problem: `CommonExtension` is no longer generic (the `CommonExtension<*, *, *, *, *, *>` spelling every pre-9 guide uses will not compile) and it is a supertype of all four concrete extensions, so a single `configure<CommonExtension>` reaches application, library, dynamic-feature and test alike.

Two things recorded in comments because they cost time to find: AGP 9's `CommonExtension` declares **zero** `Action`-taking overloads, so `defaultConfig { }` does not exist on it and property access is required; and precompiled script plugins **can** share helper functions through a plain `.kt` file — the same mechanism `Versions.kt` already uses — so factoring build logic out needs no migration to binary plugins.

**The test dependency list was declared three times.** It becomes four catalog bundles plus `billionbeers.android.testing` for the JUnit 5 tier. `android.application` deliberately does *not* apply that plugin: `:app`'s unit tests are JUnit 4 and it wires neither android-junit5 nor `useJUnitPlatform()`, so pulling it onto the platform would change how its tests are discovered. It shares the bundles instead, which is where the duplication actually was.

**Bundles opened a hole in invariant 12, so the rule grew.** `implementation(libs.bundles.unitTest)` ships five test libraries while matching none of the `libs.<alias>` patterns `TestLibraryBoundaryTest` looks for. It now resolves each bundle to its members and condemns any bundle holding a test-only library. Proven with a mutation probe, not assumed.

**`billionbeers.unused-dependencies` now applies to dynamic features** — the one tier the check had never covered.

## Duplication in the modules

Eight modules re-declared Compose dependencies that `billionbeers.android.compose` already supplies — 20 declarations in all. Removing them is a no-op on the resolved classpath, which is why the unit tests stayed up to date across the change; `screenshot-verify` confirms the rendering is untouched. `testing-utils-android` keeps its own Compose BOM: it never applies the compose convention, so that one is load-bearing.

## Three modules that had to opt out of the conventions

`billionbeers.jvm.library` shipped JUnit 4 with no `useJUnitPlatform()`, so a pure-JVM module needing JUnit 5 had to hand-roll its dependencies and drop the convention entirely. That is what `:konsist` did — which meant the module holding the architecture rules was itself formatted and linted by nothing.

The tier now carries the JUnit 5 API, both engines, and the platform launcher (required the moment `useJUnitPlatform()` is on, or the test JVM will not start). The vintage engine keeps `:core-common`'s JUnit 4 tests running: 46 before, 46 after.

`:snapshot-processor` and `:catalog-processor` take spotless and detekt directly rather than the whole convention, which pins Java 23 that their deliberate JDK 17 toolchain cannot produce. The gap that mattered — unformatted, unlinted — closes either way. Their reformat is split into its own commit so this one stays readable.

## Root script

- **sonarqube 3.2.0 cannot run on AGP 9.** Invoking it fails with `Extension of type 'AppExtension' does not exist`, the legacy extension AGP 9 removed. No workflow or Makefile target referenced it, so every build was paying a plugin resolution for a task that could only fail.
- **navigation-safe-args** was on two classpaths and applied by no module, ever.
- **Metro** comes off the buildscript classpath; it is already in the plugins block and on build-logic's implementation classpath, which is how `billionbeers.android.metro` actually resolves it.

The javapoet force **stays**, now documented: it reaches that classpath transitively through AGP and the Room Gradle plugin. Worth knowing it pins only the buildscript classpath, not the javapoet a KSP processor resolves.

## A bug this introduced, and the fix

The `android.common` collapse broke the benchmark tier's exclusion from test coverage in a way the compiler could not catch. A second `withPlugin("com.android.test")` block passing `withTestCoverage = false` only *skips* the assignment — the base block has already made it, and nothing unsets it. Measured: `:benchmark:macrobenchmark` reported `jacocoVersion 0.8.13`, a value the original four-block code never set there.

The three tiers that want coverage now opt in by plugin id. Listing opt-ins rather than excluding the opt-out is also independent of plugin application order, which an exclusion block would not have been. Verified by probe: macrobenchmark back to AGP's default `0.8.14`, `:core` and `:feature:beerdetail` at `0.8.13`.

## Verification

Full `assembleDebug`, `make test` (190 tests across every tier), `make konsist`, `make lint`, `make android-lint`, `spotlessCheck`, `screenshot-verify`, and `:app:dependencyGuard`.
