### PR TITLE
Fix a stale-generator bug, harden jacoco exclusions, and size the daemons

### DIFF
--- a/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
@@ -39,13 +39,28 @@ val namespaceProvider = provider {
 val generatePaparazziTest = tasks.register("generatePaparazziTest") {
     val outputDir = layout.buildDirectory.dir("generated/paparazzi-test/kotlin")
     outputs.dir(outputDir)
-    
+
+    // The module namespace is the task's only input, and it must be declared. Without it the task
+    // had outputs and no inputs, so Gradle held it UP-TO-DATE forever once the file existed.
+    //
+    // That is not cosmetic. The namespace is baked into the generated runner twice: as the class
+    // name, and as the prefix it filters PreviewProviders by. Renaming a module's namespace left
+    // the stale prefix in place, so the runner would match zero providers, fall through to the
+    // DUMMY_NO_PREVIEWS_FOUND branch, and report a green screenshot run that asserted nothing.
+    // Measured before this fix: changing :core:designsystem's namespace regenerated nothing and
+    // the file kept the old value.
+    inputs.property("moduleNamespace", namespaceProvider)
+
     val nsProvider = namespaceProvider
     doLast {
         val capturedModuleNamespace = nsProvider.get()
         val safeClassName = capturedModuleNamespace.replace(".", "_").replaceFirstChar { it.uppercase() } + "ScreenshotTest"
         
         val outDirFile = outputDir.get().asFile
+        // Wipe first: the class name is derived from the namespace, so regenerating after a rename
+        // writes a *new* file and would otherwise leave the old one beside it - a second runner
+        // class still filtering on the dead prefix, which compiles and asserts nothing.
+        outDirFile.deleteRecursively()
         val packageDir = File(outDirFile, "com/simtop/billionbeers/screenshot")
         packageDir.mkdirs()
         

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,14 @@ tasks.register("ideSyncArtifacts") {
     }
 }
 
+// Modules deliberately kept out of the aggregate, by exact project path.
+//
+// This used to be `it.name.contains("presentation_utils")`, a substring match on the *name*, which
+// is fragile twice over: a rename silently drops the exclusion - the module then re-enters the
+// aggregate and nobody notices - and `contains` would also swallow any future module whose name
+// happens to embed one of these strings. Exact paths plus the check below fail loudly instead.
+val coverageExcludedProjects = setOf(":presentation_utils", ":beer_database")
+
 tasks.register<JacocoReport>("jacocoRootReport") {
     // Android debug unit tests + JVM-module `test`. The Android `test` *lifecycle* task aggregates
     // every variant (incl. the non-compiling benchmark one), so it is excluded by only taking `test`
@@ -116,10 +124,15 @@ tasks.register<JacocoReport>("jacocoRootReport") {
     )
     dependsOn(subprojects.map { it.tasks.withType<JacocoReport>() })
 
+    val unknownExclusions = coverageExcludedProjects - subprojects.map { it.path }.toSet()
+    require(unknownExclusions.isEmpty()) {
+        "coverageExcludedProjects names projects that do not exist: $unknownExclusions. " +
+            "A module was renamed or removed - update the set rather than leaving a dead entry, " +
+            "which would silently pull the module back into the coverage aggregate."
+    }
+
     val subprojectsWithJacoco = subprojects.filter {
-        it.plugins.hasPlugin("jacoco") &&
-                !it.name.contains("presentation_utils") &&
-                !it.name.contains("beer_database")
+        it.plugins.hasPlugin("jacoco") && it.path !in coverageExcludedProjects
     }
 
     val excludes = listOf(

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,19 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1G -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# Sized for the reference machine in config/build-time-budget.txt (8 cores, 16 GB): 4g Gradle +
+# 2g Kotlin leaves ~10g for the OS and an IDE. Raise both together on a bigger machine.
+#
+# Heap was 2048m, which is thin for ~30 modules with org.gradle.parallel and the configuration
+# cache both on. Metaspace is raised from 1G on direct evidence rather than a guess: a daemon on
+# this machine was found in state "STOPPED (after running out of JVM Metaspace)". That is a
+# mitigation for classloader accumulation across many builds in one daemon, not a cure - if it
+# recurs, the daemon is leaking and the number is not the problem.
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1536m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+
+# The Kotlin compile daemon is a separate JVM and was never configured, so it ran on defaults while
+# every module in the build compiles through it.
+kotlin.daemon.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=768m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
Three findings from the build review: a silent-failure bug in the screenshot generator, the fragile half of the jacoco aggregation, and memory settings.

## The Paparazzi generator could go stale and stay green

`generatePaparazziTest` declared an output directory and **no inputs**, so Gradle held it UP-TO-DATE forever once the file existed.

That matters more than it sounds. The module namespace is baked into the generated runner twice — as the class name, and as the prefix it filters `PreviewProvider`s by. So renaming a namespace left the stale prefix in place, the runner matched zero providers, fell through to the `DUMMY_NO_PREVIEWS_FOUND` branch, and reported a **green screenshot run that asserted nothing**.

Measured before the fix: changing `:core:designsystem`'s namespace regenerated nothing and the file kept the old value. The namespace is now a declared input. The task also wipes its output directory first — because the class name derives from the namespace, regenerating after a rename otherwise leaves the old file beside the new one, a second runner class still filtering on the dead prefix.

## jacocoRootReport's exclusions were a substring match on module names

`it.name.contains("presentation_utils")` is fragile twice over: a rename silently drops the exclusion — the module re-enters the aggregate and nobody notices — and `contains` would swallow any future module whose name embeds that string.

Exact project paths now, plus a `require()` that fails if an entry stops matching a real project, so the failure is loud instead of silent. Verified with a mutation probe.

Coverage is byte-identical across the change: **5714 instructions, 786 lines, 102 classes** before and after.

**This is half of that finding.** The report still reaches across `subprojects { sp.tasks.matching { } }` at configuration time, which is the actual project-isolation blocker. Fixing that properly means publishing each module's coverage data through consumable configurations and aggregating by dependency resolution — a real rewrite with a real risk of silently producing an empty report, so it belongs in its own PR rather than riding along here.

## Memory

The Gradle daemon heap goes 2g → 4g; 2g is thin for ~30 modules with `org.gradle.parallel` and the configuration cache both on.

Metaspace goes 1g → 1536m on evidence rather than a guess: a daemon on this machine was found in state `STOPPED (after running out of JVM Metaspace)`. That is a mitigation for classloader accumulation across many builds in one daemon, not a cure — if it recurs, the daemon is leaking and the number is not the problem.

`kotlin.daemon.jvmargs` was never set at all, so the Kotlin compile daemon — a separate JVM that every module compiles through — ran on defaults. Both are sized for the reference machine in `config/build-time-budget.txt` (8 cores, 16 GB): 4g + 2g leaves ~10g for the OS and an IDE.

## Verification

`make test`, `make konsist`, `make screenshot-verify`, `spotlessCheck`, and `jacocoRootReport` compared counter-by-counter against the pre-change report. `make build-budget` is running separately — it measures wall clock, so it cannot share a machine with anything else.
