### PR TITLE
Close the classpath gap in invariant 13, harden three Konsist rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,12 @@ jobs:
       - name: Run Konsist Architecture Rules
         run: make konsist
 
+      # Konsist reads each feature's own build-script text, so it can't see a data-layer module
+      # arriving through an intermediate dependency's api(...) declaration. This resolves the
+      # actual compile classpath instead - same invariant (13, AGENTS.md), the gap Konsist leaves.
+      - name: Check data-layer classpath boundary
+        run: make check-data-layer-boundary
+
       # High-water ratchet: jacocoRootReport reuses the debug unit tests just run above (they're
       # up-to-date), then fails if line coverage dropped below config/coverage-floor.txt.
       - name: Coverage floor check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,17 @@ All thirteen are enforced by `:konsist`; the wording here is from the tests them
     the dependency could be declared and used with nothing firing. `:app` is exempt — assembling the
     graph is its job. (`FeatureDataLayerBoundaryTest` — reads the build scripts.)
 
+    `FeatureDataLayerBoundaryTest` only sees a data-layer module named in the feature's *own* build
+    script. It cannot see one arriving through an intermediate dependency's `api(...)` declaration —
+    a type the feature's compiler genuinely resolves, with nothing in the feature's own text to
+    catch it. `checkDataLayerClasspathBoundary`, a real Gradle task (not a Konsist test — it needs a
+    resolved dependency graph, which Konsist's static scan doesn't have) wired into `check` on every
+    `billionbeers.android.feature` / `billionbeers.android.dynamic.feature` module, closes that:
+    it resolves the module's own `debugCompileClasspath` and fails if a forbidden module shows up
+    anywhere in it. An `implementation(...)`-declared path is correctly not flagged — Gradle's own
+    configuration elision already keeps that off the compile classpath, so there is no real
+    violation to catch there. (`build-logic/convention/src/main/kotlin/FeatureBoundaryChecks.kt`.)
+
 Every invariant in this list is now mechanically enforced. If you add one, add its rule in the
 same change — a convention with no test is a convention that drifts.
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ UI_TEST_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,:app:)
 # Wrapper for Gradle to support build-brief (bb) or rtk if available
 GRADLE_RUNNER := $(shell if command -v bb >/dev/null 2>&1; then echo "bb ./gradlew"; elif command -v build-brief >/dev/null 2>&1; then echo "build-brief --gradle ./gradlew"; elif command -v rtk >/dev/null 2>&1; then echo "rtk ./gradlew"; else echo "./gradlew"; fi)
 
-.PHONY: detekt-baseline help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist compose-metrics ui-test screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline verification-metadata health benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark build-budget build-budget-check jacoco-report coverage-check install-profiler install-diffuse new-feature-module new-dev-app play-listing-check play-listing-capture play-listing-reset store-frames
+.PHONY: detekt-baseline help setup setup-ai-tools update-android-skills build bundle-release install clean test konsist check-data-layer-boundary compose-metrics ui-test screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline verification-metadata health benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark build-budget build-budget-check jacoco-report coverage-check install-profiler install-diffuse new-feature-module new-dev-app play-listing-check play-listing-capture play-listing-reset store-frames
 
 help: ## Show this help message.
 	@echo "\n📊 BillionBeers Makefile Help"
@@ -104,6 +104,9 @@ endif
 
 konsist: ## Run Konsist architecture rules.
 	$(GRADLE_RUNNER) :konsist:test
+
+check-data-layer-boundary: ## Fail if a feature module's resolved compile classpath includes a data-layer module, even transitively (invariant 13's classpath backstop - konsist reads build-script text only).
+	$(GRADLE_RUNNER) checkDataLayerClasspathBoundary
 
 compose-metrics: ## Regenerate Compose compiler stability/skippability reports into each module's build/compose_compiler.
 	# --rerun-tasks so up-to-date modules re-emit; reports are opt-in (composeCompilerReports) to

--- a/build-logic/convention/src/main/kotlin/FeatureBoundaryChecks.kt
+++ b/build-logic/convention/src/main/kotlin/FeatureBoundaryChecks.kt
@@ -1,0 +1,104 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.register
+
+/**
+ * A feature module (regular or on-demand dynamic) reaches persistence and the network only through
+ * the repository interfaces in `:beerdomain:api` - invariant 13, AGENTS.md. `FeatureDataLayerBoundaryTest`
+ * (`:konsist`) enforces the direct half of that: it reads each feature's build script text for a
+ * `project(":beer_data")`-shaped declaration. What it structurally cannot see is one of those
+ * modules arriving *indirectly* - declared by something the feature depends on, rather than by the
+ * feature's own build script. Source-level text scanning has no view of the resolved graph.
+ *
+ * This closes that gap by resolving the module's own `debugCompileClasspath` at task-execution
+ * time and failing if a forbidden module shows up anywhere in it, direct or transitive.
+ *
+ * Verified empirically, not assumed: the case this actually catches is a data-layer module arriving
+ * through an intermediate dependency's `api(...)` declaration - the type is then genuinely visible
+ * to the feature's compiler, so it is a real violation, and one `FeatureDataLayerBoundaryTest` would
+ * miss if the feature module's own build script never names the data-layer module directly. An
+ * `implementation(...)` declaration on the intermediate module does *not* trip this check, and
+ * correctly so: Gradle's own configuration elision already keeps an `implementation` dependency off
+ * a consumer's compile classpath, so the type was never resolvable in the feature's code to begin
+ * with - there is nothing for this task, or anything else, to catch there.
+ *
+ * `debugCompileClasspath`, not `debugRuntimeClasspath`, is the deliberate choice: dynamic-feature
+ * modules declare `implementation(project(":app"))` to install correctly, and `:app` itself depends
+ * on all three data-layer modules (assembling the graph is its exempted job). `:app` declares them
+ * on `implementation`, so ordinary Gradle configuration elision already keeps them off a consumer's
+ * *compile* classpath - only `:app`'s `api` dependencies would leak through. Checking the runtime
+ * classpath instead would flag that structurally-required edge as a violation, not a real one.
+ *
+ * Reads the resolved graph through `resolutionResult.rootComponent`, not `resolutionResult.allComponents`
+ * directly - the latter needs a live `Configuration`/`Project` at task-execution time, which the
+ * configuration cache forbids. `rootComponent` is the `Provider<ResolvedComponentResult>` Gradle
+ * built for exactly this: safe to capture at configuration time, resolved lazily, serializable
+ * across a configuration-cache boundary.
+ *
+ * Registration happens inside `afterEvaluate`: AGP creates `debugCompileClasspath` while it builds
+ * its variants, which is *after* the convention plugin script - applying `com.android.library` /
+ * `com.android.dynamic-feature` does not make the configuration exist yet - so `configurations.named`
+ * called any earlier throws `Configuration with name 'debugCompileClasspath' not found`. Same
+ * pattern the existing `UnusedDependenciesPlugin` uses for the same reason.
+ */
+fun Project.registerDataLayerClasspathBoundaryCheck() {
+  afterEvaluate {
+    val debugCompileClasspath = configurations.named("debugCompileClasspath")
+    val rootComponent = debugCompileClasspath.flatMap { it.incoming.resolutionResult.rootComponent }
+
+    val checkTask =
+      tasks.register<DataLayerClasspathBoundaryTask>("checkDataLayerClasspathBoundary") {
+        group = "verification"
+        description =
+          "Fails if this module's resolved debugCompileClasspath includes a data-layer module, " +
+            "even transitively (invariant 13, AGENTS.md)."
+        this.projectPath.set(path)
+        this.forbiddenModules.set(setOf(":beer_data", ":beer_database", ":beer_network"))
+        this.rootComponent.set(rootComponent)
+      }
+
+    tasks.named("check") { dependsOn(checkTask) }
+  }
+}
+
+abstract class DataLayerClasspathBoundaryTask : DefaultTask() {
+
+  @get:Input abstract val projectPath: Property<String>
+
+  @get:Input abstract val forbiddenModules: SetProperty<String>
+
+  // Not @Input: a dependency graph isn't a hashable value, it's a lazily-resolved object graph.
+  // The task has no declared outputs, so Gradle never considers it up-to-date and it runs every
+  // time regardless - the usual shape for a verification task with nothing to cache.
+  @get:Internal abstract val rootComponent: Property<ResolvedComponentResult>
+
+  @TaskAction
+  fun verify() {
+    val resolvedProjectPaths = mutableSetOf<String>()
+    val visited = mutableSetOf<ResolvedComponentResult>()
+
+    fun visit(component: ResolvedComponentResult) {
+      if (!visited.add(component)) return
+      (component.id as? ProjectComponentIdentifier)?.let { resolvedProjectPaths += it.projectPath }
+      component.dependencies.filterIsInstance<ResolvedDependencyResult>().forEach {
+        visit(it.selected)
+      }
+    }
+    visit(rootComponent.get())
+
+    val violations = forbiddenModules.get().intersect(resolvedProjectPaths)
+    check(violations.isEmpty()) {
+      "${projectPath.get()} resolves data-layer module(s) $violations on debugCompileClasspath - " +
+        "a feature reaches persistence and the network only through the :beerdomain:api " +
+        "repository interfaces, whose implementations :app binds (invariant 13, AGENTS.md)."
+    }
+  }
+}

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.dynamic.feature.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.dynamic.feature.gradle.kts
@@ -17,6 +17,8 @@ apply(plugin = "billionbeers.detekt")
 // one tier the unused-dependency check never looked at.
 apply(plugin = "billionbeers.unused-dependencies")
 
+registerDataLayerClasspathBoundaryCheck()
+
 val libs = the<LibrariesForLibs>()
 
 configure<DynamicFeatureExtension> {

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.feature.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.feature.gradle.kts
@@ -5,6 +5,7 @@ apply(plugin = "billionbeers.android.metro")
 apply(plugin = "billionbeers.android.compose")
 apply(plugin = "billionbeers.jacoco")
 
+registerDataLayerClasspathBoundaryCheck()
 
 val libs = the<LibrariesForLibs>()
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -100,6 +100,11 @@ android.r8.strictFullModeForKeepRules=false
 # Enabled parallel sync for Gradle 9.4+
 org.gradle.tooling.parallel=true
 
+# Turn off codegen for a build feature nothing here uses. Only `shaders` still has a live global
+# default flag on AGP 9 (verified against the AGP jar's BooleanOption class) - buildconfig/aidl/
+# renderscript are already unconditionally off there, so a flag for them would be dead weight.
+android.defaults.buildfeatures.shaders=false
+
 # App version. Here rather than in build-logic's Versions.kt because these are the most frequently
 # changed values in the build, and a constant in the convention jar makes every bump recompile
 # build-logic - invalidating every module's configuration and missing the configuration cache.

--- a/konsist/src/test/kotlin/com/simtop/konsist/BuildScripts.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/BuildScripts.kt
@@ -1,6 +1,7 @@
 package com.simtop.konsist
 
 import java.io.File
+import org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * Helpers for the rules that have to read `build.gradle.kts` directly.
@@ -36,3 +37,52 @@ internal fun buildScripts(root: File = repoRoot()): List<File> =
  */
 internal fun File.uncommentedText(): String =
   readLines().filterNot { it.trimStart().startsWith("//") }.joinToString("\n")
+
+/**
+ * A deny-list rule is only as good as the strings it searches for. If one of them is misspelled or
+ * the thing it names gets renamed, the rule keeps passing - not because nothing violates it, but
+ * because the check now matches nothing at all. That failure is silent: the test stays green, so
+ * nothing points at it.
+ *
+ * [assertModulePathsExist] and [assertConventionPluginsExist] are the positive controls for the two
+ * cases here where a hardcoded string can be checked against something real: a module path can be
+ * checked against the filesystem, a convention-plugin id against its precompiled script file (which
+ * is always named `<id>.gradle.kts`). Not every hardcoded needle has an equivalent - a banned API
+ * name like `MutableSharedFlow` names nothing that should exist in the repo, so there is nothing to
+ * check it against; that gap is accepted, not fixed here.
+ */
+internal fun assertModulePathsExist(modules: Collection<String>, root: File = repoRoot()) {
+  // An empty list would make every check below vacuously pass - the exact failure mode this
+  // function exists to close, one level up.
+  assertTrue(modules.isNotEmpty()) { "No module paths given to check - nothing would be verified" }
+
+  modules.forEach { module ->
+    val dir = File(root, module.removePrefix(":").replace(':', '/'))
+    assertTrue(dir.isDirectory) {
+      "Module path \"$module\" does not resolve to a real directory under $root - this rule's " +
+        "hardcoded module list has drifted (typo, or the module was renamed/moved), and the " +
+        "boundary check built on top of it is now silently matching nothing"
+    }
+  }
+}
+
+/**
+ * Where precompiled script plugins live - a plugin id `foo.bar` is the file `foo.bar.gradle.kts`.
+ */
+private fun conventionPluginDir(root: File): File =
+  File(root, "build-logic/convention/src/main/kotlin")
+
+internal fun assertConventionPluginsExist(pluginIds: Collection<String>, root: File = repoRoot()) {
+  // Same vacuous-pass guard as assertModulePathsExist: an empty list would check nothing.
+  assertTrue(pluginIds.isNotEmpty()) { "No plugin ids given to check - nothing would be verified" }
+
+  val dir = conventionPluginDir(root)
+  pluginIds.forEach { id ->
+    val script = File(dir, "$id.gradle.kts")
+    assertTrue(script.isFile) {
+      "Plugin id \"$id\" has no precompiled script plugin at ${script.relativeTo(root)} - this " +
+        "rule's hardcoded plugin-id list has drifted (typo, or the plugin was renamed/moved), and " +
+        "the opt-in check built on top of it is now silently matching nothing"
+    }
+  }
+}

--- a/konsist/src/test/kotlin/com/simtop/konsist/DevAppDependencyBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/DevAppDependencyBoundaryTest.kt
@@ -20,6 +20,13 @@ class DevAppDependencyBoundaryTest {
 
   private val forbiddenDataLayerModules = listOf(":beer_data", ":beer_database", ":beer_network")
 
+  // A positive control on the list above: if one of those strings drifts (typo, or the module gets
+  // renamed/moved), this fails loudly instead of the rule below silently matching nothing.
+  @Test
+  fun `forbidden data-layer module list names real modules`() {
+    assertModulePathsExist(forbiddenDataLayerModules)
+  }
+
   @Test
   fun `dev-apps do not depend on data-layer modules`() {
     val root = repoRoot()

--- a/konsist/src/test/kotlin/com/simtop/konsist/FeatureDataLayerBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/FeatureDataLayerBoundaryTest.kt
@@ -31,6 +31,13 @@ class FeatureDataLayerBoundaryTest {
 
   private val forbiddenDataLayerModules = listOf(":beer_data", ":beer_database", ":beer_network")
 
+  // A positive control on the list above: if one of those strings drifts (typo, or the module gets
+  // renamed/moved), this fails loudly instead of the rule below silently matching nothing.
+  @Test
+  fun `forbidden data-layer module list names real modules`() {
+    assertModulePathsExist(forbiddenDataLayerModules)
+  }
+
   @Test
   fun `feature modules do not depend on data-layer modules`() {
     val root = repoRoot()

--- a/konsist/src/test/kotlin/com/simtop/konsist/InstrumentedTestOptInBoundaryTest.kt
+++ b/konsist/src/test/kotlin/com/simtop/konsist/InstrumentedTestOptInBoundaryTest.kt
@@ -31,6 +31,13 @@ class InstrumentedTestOptInBoundaryTest {
   private val optInPluginIds =
     listOf("billionbeers.android.managed.device", "billionbeers.android.feature.uitest")
 
+  // A positive control on the list above: if one of those ids drifts (typo, or the plugin gets
+  // renamed/moved), this fails loudly instead of the rule below silently matching nothing.
+  @Test
+  fun `opt-in plugin id list names real convention plugins`() {
+    assertConventionPluginsExist(optInPluginIds)
+  }
+
   @Test
   fun `modules with instrumented tests opt into the managed device`() {
     val root = repoRoot()


### PR DESCRIPTION
## Summary
- `checkDataLayerClasspathBoundary`: a new Gradle task, wired into `check` on both feature convention plugins, that resolves each feature module's actual `debugCompileClasspath` and fails if a data-layer module (`:beer_data`/`:beer_database`/`:beer_network`) shows up in it. `FeatureDataLayerBoundaryTest` only reads a feature's own build-script text, so a data-layer module arriving through an intermediate dependency's `api(...)` declaration was invisible to it - verified empirically (a temporary `api(...)` probe on `:presentation_utils` reproduced and was caught; an `implementation(...)` probe correctly did not, since Gradle's own configuration elision already keeps that off the compile classpath). CI never invokes the `check` lifecycle task on any module, so this is also wired into `make check-data-layer-boundary` and called directly in the same CI job as `make konsist`.
- Three Konsist rules with hardcoded module-path / plugin-id lists (`FeatureDataLayerBoundaryTest`, `DevAppDependencyBoundaryTest`, `InstrumentedTestOptInBoundaryTest`) now carry a positive-control test: each list's strings are checked against the filesystem / convention-plugin files they're supposed to name, so a typo or a rename fails loudly instead of silently turning the rule into a no-op that still reports green.
- `gradle.properties`: turns off codegen for `shaders`, the one AGP build feature that still has a live global default flag on this AGP version (checked against AGP's own `BooleanOption` class - `buildconfig`/`aidl`/`renderscript` are already unconditionally off on AGP 9).
- AGENTS.md invariant 13 updated to describe the classpath backstop.

## Test plan
- [x] `./gradlew :konsist:test` - all rules pass, including the three new positive-control tests
- [x] `./gradlew checkDataLayerClasspathBoundary` - passes on all four feature modules
- [x] Verified the check actually fails: temporarily added `api(project(":beer_data"))` to `:presentation_utils`, confirmed `checkDataLayerClasspathBoundary` failed with the expected message, reverted
- [x] Verified the check doesn't false-positive on the dynamic-feature `:app` edge (`implementation(project(":app"))`)
- [x] `./gradlew spotlessCheck detekt` - clean
- [x] `./gradlew compileDebugKotlin` - full project compiles
- [x] Confirmed `classify_path` in `detect-change-scope.sh` runs the unit-tests lane (where this new CI step lives) on any `build.gradle.kts`-only change