### PR TITLE
chore: clean up Gradle deprecations

### DIFF
--- a/app-dev-beerslist/build.gradle.kts
+++ b/app-dev-beerslist/build.gradle.kts
@@ -17,13 +17,13 @@ android {
 dependencies {
   // Only the module under active development, plus its fakes - no :beer_data, :beer_database,
   // :beer_network, or :feature:beerdetail, so this assembles in seconds instead of minutes.
-  implementation(project(":feature:beerslist"))
-  implementation(project(":beerdomain:api"))
-  implementation(project(":beerdomain:fakes"))
-  implementation(project(":core"))
-  implementation(project(":core:designsystem"))
-  implementation(project(":navigation"))
-  implementation(project(":presentation_utils"))
+  implementation(this.project(":feature:beerslist"))
+  implementation(this.project(":beerdomain:api"))
+  implementation(this.project(":beerdomain:fakes"))
+  implementation(this.project(":core"))
+  implementation(this.project(":core:designsystem"))
+  implementation(this.project(":navigation"))
+  implementation(this.project(":presentation_utils"))
 
   implementation(libs.androidPlayCore)
   implementation(libs.androidPlayCoreKtx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,6 +12,10 @@ plugins {
 }
 
 baselineProfile {
+  // The AndroidX baseline-profile plugin currently requires a Project object here. Gradle 9.6
+  // reports its generic Project-as-dependency notation as deprecated, but the consumer extension's
+  // public API is `from(Project)` (see the plugin source). Remove this exception when AndroidX
+  // exposes a path/Provider overload.
   from(project(":benchmark:baselineprofile"))
   automaticGenerationDuringBuild = true
 }
@@ -46,22 +50,22 @@ android {
 }
 
 dependencies {
-  implementation(project(":beerdomain:api"))
-  androidTestImplementation(project(":beerdomain:fakes"))
-  testImplementation(project(":testing-utils"))
-  androidTestImplementation(project(":testing-utils"))
-  androidTestImplementation(project(":testing-utils-android"))
-  implementation(project(":feature:beerslist"))
-  implementation(project(":feature:beersearch"))
-  androidTestImplementation(project(":feature:beerdetail"))
-  androidTestImplementation(project(":feature:beerbrowse"))
-  implementation(project(":core"))
-  implementation(project(":core:designsystem"))
-  implementation(project(":navigation"))
-  implementation(project(":beer_data"))
-  implementation(project(":beer_database"))
-  implementation(project(":beer_network"))
-  implementation(project(":presentation_utils"))
+  implementation(this.project(":beerdomain:api"))
+  androidTestImplementation(this.project(":beerdomain:fakes"))
+  testImplementation(this.project(":testing-utils"))
+  androidTestImplementation(this.project(":testing-utils"))
+  androidTestImplementation(this.project(":testing-utils-android"))
+  implementation(this.project(":feature:beerslist"))
+  implementation(this.project(":feature:beersearch"))
+  androidTestImplementation(this.project(":feature:beerdetail"))
+  androidTestImplementation(this.project(":feature:beerbrowse"))
+  implementation(this.project(":core"))
+  implementation(this.project(":core:designsystem"))
+  implementation(this.project(":navigation"))
+  implementation(this.project(":beer_data"))
+  implementation(this.project(":beer_database"))
+  implementation(this.project(":beer_network"))
+  implementation(this.project(":presentation_utils"))
 
   implementation(libs.androidPlayCore)
   implementation(libs.androidPlayCoreKtx)

--- a/beer_data/build.gradle.kts
+++ b/beer_data/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
 android { namespace = "com.simtop.beer_data" }
 
 dependencies {
-  implementation(project(":core"))
-  implementation(project(":beerdomain:api"))
-  implementation(project(":beer_database"))
-  implementation(project(":beer_network"))
+  implementation(this.project(":core"))
+  implementation(this.project(":beerdomain:api"))
+  implementation(this.project(":beer_database"))
+  implementation(this.project(":beer_network"))
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.retrofit2)

--- a/beer_database/build.gradle.kts
+++ b/beer_database/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android { namespace = "com.simtop.beer_database" }
 
 dependencies {
-  implementation(project(":core"))
+  implementation(this.project(":core"))
   implementation(libs.kotlinx.serialization.json)
   // MigrationTestHelper; the Room Gradle plugin exposes the exported schemas to the test.
   androidTestImplementation(libs.roomTesting)

--- a/beer_network/build.gradle.kts
+++ b/beer_network/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 android { namespace = "com.simtop.beer_network" }
 
 dependencies {
-  implementation(project(":core"))
+  implementation(this.project(":core"))
 
   // Main declares the service and DTOs, so it needs Retrofit itself. It used to reach it only
   // transitively through the converter below - which main never actually used.
@@ -16,7 +16,7 @@ dependencies {
 
   // The converter and logging interceptor are test-only: the production Retrofit/OkHttp stack is
   // assembled in :core's NetworkingModule, and only TestMockWebService builds one by hand.
-  testImplementation(project(":beer_network:fixtures"))
+  testImplementation(this.project(":beer_network:fixtures"))
   testImplementation(libs.okhttp3Mockwebserver)
   testImplementation(libs.retrofit2ConverterSerialization)
   testImplementation(libs.okhttp3LoggingInterceptor)

--- a/beer_network/fixtures/build.gradle.kts
+++ b/beer_network/fixtures/build.gradle.kts
@@ -2,4 +2,4 @@ plugins { id("billionbeers.android.library") }
 
 android { namespace = "com.simtop.beer_network.fixtures" }
 
-dependencies { api(project(":beer_network")) }
+dependencies { api(this.project(":beer_network")) }

--- a/beerdomain/api/build.gradle.kts
+++ b/beerdomain/api/build.gradle.kts
@@ -13,7 +13,7 @@ android {
 }
 
 dependencies {
-  implementation(project(":core-common"))
+  implementation(this.project(":core-common"))
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.kotlinx.coroutines.core)
 }

--- a/beerdomain/fakes/build.gradle.kts
+++ b/beerdomain/fakes/build.gradle.kts
@@ -3,7 +3,7 @@ plugins { id("billionbeers.android.library") }
 android { namespace = "com.simtop.beerdomain.fakes" }
 
 dependencies {
-  implementation(project(":beerdomain:api"))
-  implementation(project(":core-common"))
+  implementation(this.project(":beerdomain:api"))
+  implementation(this.project(":core-common"))
   implementation(libs.kotlinx.coroutines.core)
 }

--- a/benchmark/microbenchmark/build.gradle.kts
+++ b/benchmark/microbenchmark/build.gradle.kts
@@ -30,10 +30,10 @@ dependencies {
     "implementation"(libs.testCoreKtx)
     "implementation"(libs.junitKtx)
 
-    "implementation"(project(":beer_data"))
-    "implementation"(project(":beerdomain:api"))
-    "implementation"(project(":beer_database"))
-    "implementation"(project(":beer_network"))
+    "implementation"(this.project(":beer_data"))
+    "implementation"(this.project(":beerdomain:api"))
+    "implementation"(this.project(":beer_database"))
+    "implementation"(this.project(":beer_network"))
     // BeersMapper's constructor takes LanguageProvider/Logger from core-common.
-    "implementation"(project(":core-common"))
+    "implementation"(this.project(":core-common"))
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.application.gradle.kts
@@ -79,7 +79,7 @@ android.apply {
     // nonMinifiedRelease) already extend release; this gives the hand-rolled build type the same.
     // AGP 9's built-in kotlinc compiles from the source set's kotlin dirs, so the .kt stub must be
     // added there (java.srcDir alone does not reach kotlin compilation).
-    sourceSets.getByName("benchmark").kotlin.srcDir("src/release/java")
+    sourceSets.getByName("benchmark").kotlin.directories.add("src/release/java")
 
     packaging {
         resources {
@@ -97,7 +97,7 @@ android.apply {
         // none of which understand the framework. New errors fail CI; everything present at
         // adoption is grandfathered in lint-baseline.xml and burned down over time - never by
         // regenerating the baseline to bury a regression.
-        baseline = file("lint-baseline.xml")
+        baseline = project.layout.projectDirectory.file("lint-baseline.xml").asFile
         checkDependencies = true
         abortOnError = true
         warningsAsErrors = false

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.catalog.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.catalog.gradle.kts
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-    add("implementation", project(":catalog-annotations"))
-    add("ksp", project(":catalog-processor"))
+    add("implementation", this.project(":catalog-annotations"))
+    add("ksp", this.project(":catalog-processor"))
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.dynamic.feature.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.dynamic.feature.gradle.kts
@@ -30,7 +30,7 @@ configure<DynamicFeatureExtension> {
 }
 
 dependencies {
-    "implementation"(project(":app"))
+    "implementation"(this.project(":app"))
     "implementation"(libs.coreKtx)
     "implementation"(libs.appcompat)
     "implementation"(libs.material)

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.feature.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.feature.gradle.kts
@@ -10,10 +10,10 @@ registerDataLayerClasspathBoundaryCheck()
 val libs = the<LibrariesForLibs>()
 
 dependencies {
-    "implementation"(project(":core"))
-    "implementation"(project(":core-common"))
-    "implementation"(project(":presentation_utils"))
-    "implementation"(project(":beerdomain:api"))
+    "implementation"(this.project(":core"))
+    "implementation"(this.project(":core-common"))
+    "implementation"(this.project(":presentation_utils"))
+    "implementation"(this.project(":beerdomain:api"))
 
     "implementation"(libs.lifecycleRuntimeKtx)
     "implementation"(libs.navigationFragmentKtx)

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.feature.uitest.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.feature.uitest.gradle.kts
@@ -26,11 +26,11 @@ val libs = the<LibrariesForLibs>()
 
 dependencies {
     // Fakes for the domain interfaces, so a screen test drives state without the data layer.
-    "androidTestImplementation"(project(":beerdomain:fakes"))
+    "androidTestImplementation"(this.project(":beerdomain:fakes"))
 
     // Shared robot base. Brings the Compose test rules and Espresso with it (they are `api` there),
     // so a screen robot needs nothing else.
-    "androidTestImplementation"(project(":testing-utils-android"))
+    "androidTestImplementation"(this.project(":testing-utils-android"))
 
     // Versionless: the Compose BOM is already on androidTestImplementation via
     // billionbeers.android.compose, which billionbeers.android.feature applies.

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
@@ -12,8 +12,8 @@ plugins {
 val libs = the<LibrariesForLibs>()
 
 dependencies {
-    add("implementation", project(":snapshot-testing"))
-    add("ksp", project(":snapshot-processor"))
+    add("implementation", this.project(":snapshot-testing"))
+    add("ksp", this.project(":snapshot-processor"))
 }
 
 // Paparazzi's plugin calls Test.setTestReporter(PaparazziTestReporter) on every Test task in the
@@ -140,22 +140,22 @@ val generatedKspTestResourcesDir = layout.buildDirectory.dir("generated/ksp/debu
 
 pluginManager.withPlugin("com.android.application") {
     extensions.configure<ApplicationExtension>() {
-        sourceSets.getByName("test").java.srcDir(generatedPaparazziTestDir)
-        sourceSets.getByName("test").resources.srcDir(generatedKspTestResourcesDir)
+        sourceSets.getByName("test").java.directories.add(generatedPaparazziTestDir.path)
+        sourceSets.getByName("test").resources.directories.add(generatedKspTestResourcesDir.path)
     }
 }
 
 pluginManager.withPlugin("com.android.library") {
     extensions.configure<LibraryExtension>(){
-        sourceSets.getByName("test").java.srcDir(generatedPaparazziTestDir)
-        sourceSets.getByName("test").resources.srcDir(generatedKspTestResourcesDir)
+        sourceSets.getByName("test").java.directories.add(generatedPaparazziTestDir.path)
+        sourceSets.getByName("test").resources.directories.add(generatedKspTestResourcesDir.path)
     }
 }
 
 pluginManager.withPlugin("com.android.dynamic-feature") {
     extensions.configure<DynamicFeatureExtension>(){
-        sourceSets.getByName("test").java.srcDir(generatedPaparazziTestDir)
-        sourceSets.getByName("test").resources.srcDir(generatedKspTestResourcesDir)
+        sourceSets.getByName("test").java.directories.add(generatedPaparazziTestDir.path)
+        sourceSets.getByName("test").resources.directories.add(generatedKspTestResourcesDir.path)
     }
 }
 
@@ -225,4 +225,3 @@ tasks.withType<Test>().configureEach {
         }
     }
 }
-

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.testing.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.testing.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
   // The shared MainDispatcherExtension. Every ViewModel test needs Dispatchers.setMain, and
   // hand-rolling it in each module is how the JUnit 4 rule this replaced drifted out of use.
-  "testImplementation"(project(":testing-utils"))
+  "testImplementation"(this.project(":testing-utils"))
 
   "testRuntimeOnly"(libs.bundles.unitTestJunit5Runtime)
 }

--- a/build-logic/convention/src/main/kotlin/billionbeers.detekt.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.detekt.gradle.kts
@@ -28,7 +28,7 @@ configure<DetektExtension> {
         )
     )
     config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
-    baseline = file("detekt-baseline.xml").takeIf { it.exists() }
+    baseline = layout.projectDirectory.file("detekt-baseline.xml").asFile.takeIf { it.exists() }
     buildUponDefaultConfig = true
     autoCorrect = false
     // A NEW finding fails the build; the backlog present at adoption does not, because it is

--- a/build-logic/convention/src/main/kotlin/billionbeers.jacoco.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.jacoco.gradle.kts
@@ -53,7 +53,8 @@ val debugVariants = androidComponents?.selector()?.withBuildType("debug")
 if (androidComponents != null && debugVariants != null) androidComponents.onVariants(debugVariants) { variant ->
     val testTaskName = "test${variant.name.capitalized()}UnitTest"
 
-    val reportTask = tasks.register<JacocoReport>("jacoco${variant.name.capitalize()}Report") {
+    val reportTask =
+        tasks.register<JacocoReport>("jacoco${variant.name.replaceFirstChar { it.uppercase() }}Report") {
         dependsOn(testTaskName)
 
         reports {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,8 +58,8 @@ val ideSyncGroovyModules: List<String> =
         .map { it.removeSuffix("-$ideSyncGroovyVersion.jar") }
         .sorted()
 
-val ideSyncMetadata: Configuration by configurations.creating
-val ideSyncSources: Configuration by configurations.creating { isTransitive = false }
+val ideSyncMetadata = configurations.create("ideSyncMetadata")
+val ideSyncSources = configurations.create("ideSyncSources") { isTransitive = false }
 
 ideSyncGroovyModules.forEach { module ->
     val coordinate = "org.apache.groovy:$module:$ideSyncGroovyVersion"

--- a/catalog/build.gradle.kts
+++ b/catalog/build.gradle.kts
@@ -15,10 +15,10 @@ android {
 }
 
 dependencies {
-  implementation(project(":feature:beerslist"))
-  implementation(project(":core:designsystem"))
-  implementation(project(":presentation_utils"))
-  implementation(project(":catalog-annotations"))
+  implementation(this.project(":feature:beerslist"))
+  implementation(this.project(":core:designsystem"))
+  implementation(this.project(":presentation_utils"))
+  implementation(this.project(":catalog-annotations"))
 
   // Compose: foundation, material3, ui-tooling-preview and activity-compose come from
   // billionbeers.android.compose.

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,7 +11,7 @@ android {
 }
 
 dependencies {
-  api(project(":core-common"))
+  api(this.project(":core-common"))
   implementation(libs.coreKtx)
   implementation(libs.appcompat)
   implementation(libs.material)

--- a/docs/gradle-compatibility.md
+++ b/docs/gradle-compatibility.md
@@ -1,0 +1,34 @@
+# Gradle compatibility inventory
+
+The project treats Gradle warnings as an inventory, not as noise. Run:
+
+```text
+./gradlew help --no-configuration-cache --warning-mode all --console=plain
+```
+
+## Current status
+
+As of 2026-08-23, the repository-owned Gradle 9.6 warnings are fixed:
+
+- configuration creation uses `configurations.create(...)` rather than the deprecated Kotlin DSL
+  delegated-property form;
+- Android source directories use the AGP `directories` set rather than `srcDir(...)`;
+- JaCoCo variant names use `replaceFirstChar` rather than Kotlin `capitalize()`;
+- Detekt and lint baselines use `layout.projectDirectory.file(...)`;
+- project dependencies use `DependencyHandler.project(...)` explicitly (`this.project(...)` inside a
+  `dependencies {}` block).
+
+Two warnings remain and are upstream contracts:
+
+| Warning | Owner | Reopen trigger |
+|---|---|---|
+| `ReportingExtension.file(String)` from `billionbeers.detekt.gradle.kts` | Detekt Gradle plugin | Upgrade to a Detekt release that no longer calls this deprecated Gradle API; remove the inventory entry and verify with `--warning-mode all`. |
+| Project-object dependency notation from `baselineProfile { from(...) }` | AndroidX Baseline Profile Gradle plugin | The consumer extension currently exposes `from(Project)` only. Replace it with the path/Provider overload when AndroidX publishes one. |
+
+Metro's IDE-support/Delicate API notices and the Java `URL(String)` notice in the unused-dependency
+scanner are compiler warnings, not Gradle deprecations. They remain separately owned: update the
+Metro opt-in when its API changes, and migrate the scanner to `URI`/`HttpClient` when its minimum
+JDK and network behavior are deliberately revisited.
+
+This file should be updated in the same change as a Gradle/AGP/Detekt/AndroidX upgrade. A clean
+warning report is a release criterion for moving to Gradle 10, not a reason to suppress warnings.

--- a/feature/beerbrowse/build.gradle.kts
+++ b/feature/beerbrowse/build.gradle.kts
@@ -6,14 +6,14 @@ plugins {
 android { namespace = "com.simtop.feature.beerbrowse" }
 
 dependencies {
-  implementation(project(":beerdomain:api"))
-  implementation(project(":presentation_utils"))
-  implementation(project(":core"))
-  implementation(project(":core:designsystem"))
-  implementation(project(":navigation"))
+  implementation(this.project(":beerdomain:api"))
+  implementation(this.project(":presentation_utils"))
+  implementation(this.project(":core"))
+  implementation(this.project(":core:designsystem"))
+  implementation(this.project(":navigation"))
   implementation(libs.androidx.navigation3.runtime)
   implementation(libs.kotlinx.serialization.json)
 
-  testImplementation(project(":beerdomain:fakes"))
+  testImplementation(this.project(":beerdomain:fakes"))
   testImplementation(libs.striktCore)
 }

--- a/feature/beerdetail/build.gradle.kts
+++ b/feature/beerdetail/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 android { namespace = "com.simtop.feature.beerdetail" }
 
 dependencies {
-  implementation(project(":beerdomain:api"))
-  implementation(project(":presentation_utils"))
-  implementation(project(":core"))
-  implementation(project(":core:designsystem"))
-  implementation(project(":navigation"))
+  implementation(this.project(":beerdomain:api"))
+  implementation(this.project(":presentation_utils"))
+  implementation(this.project(":core"))
+  implementation(this.project(":core:designsystem"))
+  implementation(this.project(":navigation"))
   implementation(libs.androidx.navigation3.runtime)
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.lifecycle.viewmodel.savedstate)
@@ -39,7 +39,7 @@ dependencies {
   androidTestImplementation(libs.mockkAndroid)
   androidTestImplementation(libs.junitKtx)
 
-  testImplementation(project(":beerdomain:fakes"))
+  testImplementation(this.project(":beerdomain:fakes"))
   testImplementation(libs.striktCore)
   androidTestImplementation(libs.striktCore)
 }

--- a/feature/beersearch/build.gradle.kts
+++ b/feature/beersearch/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
 android { namespace = "com.simtop.feature.beersearch" }
 
 dependencies {
-  implementation(project(":navigation"))
-  implementation(project(":core:designsystem"))
+  implementation(this.project(":navigation"))
+  implementation(this.project(":core:designsystem"))
 
-  testImplementation(project(":beerdomain:fakes"))
+  testImplementation(this.project(":beerdomain:fakes"))
   testImplementation(libs.striktCore)
 }

--- a/feature/beerslist/build.gradle.kts
+++ b/feature/beerslist/build.gradle.kts
@@ -9,9 +9,9 @@ android { namespace = "com.simtop.feature.beerslist" }
 dependencies {
   // :core, :core-common, :presentation_utils and :beerdomain:api come from the
   // billionbeers.android.feature plugin - see :feature:beersearch for the same shape.
-  implementation(project(":navigation"))
-  implementation(project(":core:designsystem"))
+  implementation(this.project(":navigation"))
+  implementation(this.project(":core:designsystem"))
   implementation(libs.kotlinx.serialization.json)
-  testImplementation(project(":beerdomain:fakes"))
+  testImplementation(this.project(":beerdomain:fakes"))
   testImplementation(libs.striktCore)
 }

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 android { namespace = "com.simtop.navigation" }
 
 dependencies {
-  implementation(project(":beerdomain:api"))
+  implementation(this.project(":beerdomain:api"))
   implementation(libs.androidx.navigation3.runtime)
   implementation(libs.kotlinx.serialization.json)
 

--- a/presentation_utils/build.gradle.kts
+++ b/presentation_utils/build.gradle.kts
@@ -8,9 +8,9 @@ plugins {
 android { namespace = "com.simtop.presentation_utils" }
 
 dependencies {
-  implementation(project(":beerdomain:api"))
-  implementation(project(":core"))
-  implementation(project(":core:designsystem"))
+  implementation(this.project(":beerdomain:api"))
+  implementation(this.project(":core"))
+  implementation(this.project(":core:designsystem"))
 
   // activity-compose, foundation, material3 and ui-tooling-preview come from
   // billionbeers.android.compose.

--- a/testing-utils/build.gradle.kts
+++ b/testing-utils/build.gradle.kts
@@ -5,5 +5,5 @@ dependencies {
   // own test source, so the JUnit 5 and coroutines-test types are part of this module's surface.
   api(libs.junit.jupiter.api)
   api(libs.coroutinesTest)
-  implementation(project(":core-common"))
+  implementation(this.project(":core-common"))
 }


### PR DESCRIPTION
Independent reapplication of the Gradle 10 compatibility cleanup on current master. It replaces repository-owned deprecated Gradle/Kotlin DSL APIs and documents the two remaining upstream warnings, without including the cancelled coverage-scope change. Verified with make test, make format, and git diff --check.