### PR TITLE
test: add convention plugin TestKit coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ JVM_TEST_MODULES := :core-common :testing-utils
 test: ## Run unit tests for the specified module (or all).
 ifeq ($(MODULE_TRIMMED),)
 	$(GRADLE_RUNNER) testDebugUnitTest $(addsuffix :test,$(JVM_TEST_MODULES)) --continue
+	$(GRADLE_RUNNER) -p build-logic :convention:test --continue
 else ifneq ($(filter $(MODULE_TRIMMED),$(JVM_TEST_MODULES) :konsist),)
 	$(GRADLE_RUNNER) $(MODULE_TRIMMED):test --continue
 else

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -16,4 +16,13 @@ dependencies {
     implementation(libs.detekt.gradlePlugin)
     implementation(libs.paparazzi.plugin)
     implementation(files(files((libs as Any).javaClass.superclass.protectionDomain.codeSource.location)))
+
+    testImplementation(gradleTestKit())
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }

--- a/build-logic/convention/src/test/kotlin/com/simtop/billionbeers/buildlogic/ConventionPluginFunctionalTest.kt
+++ b/build-logic/convention/src/test/kotlin/com/simtop/billionbeers/buildlogic/ConventionPluginFunctionalTest.kt
@@ -1,0 +1,133 @@
+package com.simtop.billionbeers.buildlogic
+
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class ConventionPluginFunctionalTest {
+
+  @TempDir lateinit var testProjectDir: Path
+
+  @Test
+  fun `Kotlin options convention configures the project JVM target`() {
+    writeSettings()
+    writeBuildFile(
+      """
+      import org.gradle.api.JavaVersion
+      import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
+      plugins {
+        id("org.jetbrains.kotlin.jvm") version "2.4.10"
+        id("billionbeers.kotlin.options")
+      }
+
+      java {
+        sourceCompatibility = JavaVersion.VERSION_23
+        targetCompatibility = JavaVersion.VERSION_23
+      }
+
+      tasks.withType<KotlinJvmCompile>().configureEach {
+        doLast {
+          println("CONVENTION_JVM_TARGET=" + compilerOptions.jvmTarget.get())
+        }
+      }
+      """.trimIndent(),
+    )
+    writeFile("src/main/kotlin/ConventionSource.kt", "fun conventionSource() = 42")
+
+    val result =
+      runner()
+        .withArguments("compileKotlin", "--stacktrace")
+        .build()
+
+    assertTrue(result.output.contains("CONVENTION_JVM_TARGET=JVM_23"))
+    assertTrue(result.task(":compileKotlin")?.outcome == TaskOutcome.SUCCESS)
+  }
+
+  @Test
+  fun `spotless convention exposes a check task and rejects unformatted Kotlin`() {
+    writeSettings()
+    writeBuildFile(
+      """
+      plugins {
+        id("billionbeers.spotless")
+      }
+      """.trimIndent(),
+    )
+    writeFile("src/main/kotlin/Unformatted.kt", "fun  unformatted( ) = 42")
+
+    val result =
+      runner()
+        .withArguments("spotlessCheck", "--stacktrace")
+        .buildAndFail()
+
+    assertTrue(result.output.contains("spotlessKotlinCheck"))
+  }
+
+  @Test
+  fun `managed device convention creates both device lanes and their groups`() {
+    writeSettings()
+    writeBuildFile(
+      """
+      plugins {
+        id("com.android.library") version "9.2.1"
+        id("billionbeers.android.managed.device")
+      }
+
+      android {
+        namespace = "com.simtop.conventiontest"
+        compileSdk = 37
+      }
+      """.trimIndent(),
+    )
+
+    val result = runner().withArguments("tasks", "--all", "--stacktrace").build()
+
+    assertTrue(result.output.contains("atdApi35Setup"))
+    assertTrue(result.output.contains("pixel9Api37Setup"))
+    assertTrue(result.output.contains("ciGroupDebugAndroidTest"))
+    assertTrue(result.output.contains("compatGroupDebugAndroidTest"))
+  }
+
+  private fun runner(): GradleRunner =
+    GradleRunner.create()
+      .withProjectDir(testProjectDir.toFile())
+      .withPluginClasspath()
+      .forwardOutput()
+
+  private fun writeSettings() {
+    testProjectDir.resolve("settings.gradle.kts").writeText(
+      """
+      pluginManagement {
+        repositories {
+          google()
+          mavenCentral()
+          gradlePluginPortal()
+        }
+      }
+      dependencyResolutionManagement {
+        repositories {
+          google()
+          mavenCentral()
+        }
+      }
+      rootProject.name = "convention-plugin-test"
+      """.trimIndent(),
+    )
+  }
+
+  private fun writeBuildFile(contents: String) {
+    testProjectDir.resolve("build.gradle.kts").writeText(contents)
+  }
+
+  private fun writeFile(relativePath: String, contents: String) {
+    val file = testProjectDir.resolve(relativePath)
+    file.parent.createDirectories()
+    file.writeText(contents)
+  }
+}


### PR DESCRIPTION
Adds Gradle TestKit functional coverage for the Kotlin options, Spotless, and managed-device convention plugins. The fixtures exercise real Gradle builds and assert JVM target wiring, formatting enforcement, and both managed-device lanes/groups. The full no-module make test path now runs the composite build's convention tests so CI executes them.