### PR TITLE
chore: add build-tool forward compatibility lane

### DIFF
--- a/.github/workflows/weekly-build-tool-compat.yml
+++ b/.github/workflows/weekly-build-tool-compat.yml
@@ -1,0 +1,70 @@
+name: Weekly Build-Tool Forward Compatibility
+
+# This is deliberately separate from ci.yml. It exercises the build platform on the supported
+# wrapper and Gradle's next distribution without becoming a required per-PR release pipeline.
+# A failure is still visible on the scheduled workflow and can be run manually when Gradle or AGP
+# publishes a release candidate.
+on:
+  schedule:
+    # 05:00 UTC every Saturday, before the device-compatibility and health-report workflows.
+    - cron: '0 5 * * 6'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-tool-compat:
+    name: ${{ matrix.label }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: Supported Gradle wrapper
+            gradle-version: wrapper
+            command: ./gradlew
+          - label: Gradle nightly forward-compat
+            gradle-version: nightly
+            command: gradle
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5
+        with:
+          java-version: '23'
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+        with:
+          gradle-version: ${{ matrix.gradle-version }}
+
+      - name: Make gradlew executable
+        run: chmod +x gradlew
+
+      - name: Configure and test build-tool compatibility
+        env:
+          GRADLE_COMMAND: ${{ matrix.command }}
+          WARNING_LOG: gradle-build-tool-compat.log
+        run: |
+          set -o pipefail
+          "$GRADLE_COMMAND" help \
+            --no-configuration-cache \
+            --warning-mode all \
+            --console=plain 2>&1 | tee "$WARNING_LOG"
+          "$GRADLE_COMMAND" -p build-logic :convention:test \
+            --no-configuration-cache \
+            --warning-mode all \
+            --console=plain 2>&1 | tee -a "$WARNING_LOG"
+          bash scripts/check-gradle-warnings.sh "$WARNING_LOG"
+
+      - name: Archive build-tool compatibility log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: build-tool-compat-${{ matrix.gradle-version }}
+          path: gradle-build-tool-compat.log

--- a/docs/gradle-compatibility.md
+++ b/docs/gradle-compatibility.md
@@ -32,3 +32,12 @@ JDK and network behavior are deliberately revisited.
 
 This file should be updated in the same change as a Gradle/AGP/Detekt/AndroidX upgrade. A clean
 warning report is a release criterion for moving to Gradle 10, not a reason to suppress warnings.
+
+## Automated forward-compatibility check
+
+`.github/workflows/weekly-build-tool-compat.yml` runs every Saturday and on demand. It configures
+the full project with the checked-in Gradle wrapper, runs the convention-plugin contract tests, and
+repeats the same smoke check with Gradle nightly. The nightly job is intentionally outside the
+required PR gate: it is an early signal for Gradle/AGP changes, not a claim that nightly is a
+supported release. Both runs use `--warning-mode all`; `scripts/check-gradle-warnings.sh` fails on
+new deprecations while allowing only the two upstream warnings listed above.

--- a/scripts/check-gradle-warnings.sh
+++ b/scripts/check-gradle-warnings.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="${1:?usage: check-gradle-warnings.sh <gradle-output-log>}"
+
+if [[ ! -f "$log_file" ]]; then
+  echo "::error::Gradle warning log does not exist: $log_file"
+  exit 1
+fi
+
+# These are the two remaining warnings recorded in docs/gradle-compatibility.md. They are
+# intentionally allow-listed by their stable message prefix, not by line number or Gradle version.
+# When either upstream contract disappears, the informational notice below prompts a cleanup of
+# the inventory instead of silently letting the documentation drift.
+known_patterns=(
+  'The ReportingExtension.file\(String\) method has been deprecated\.'
+  'Using a Project object as a dependency notation has been deprecated\.'
+)
+
+# The stacktrace hint also contains the word "deprecation"; omit that secondary line so the
+# detector reports warning headers rather than implementation details of the warning machinery.
+warning_lines="$(rg -n -i 'deprecated' "$log_file" | rg -v 'full stack trace of this deprecation warning' || true)"
+if [[ -z "$warning_lines" ]]; then
+  echo "No Gradle deprecation warnings emitted. Remove any obsolete entries from docs/gradle-compatibility.md."
+  exit 0
+fi
+
+unexpected_lines="$warning_lines"
+for pattern in "${known_patterns[@]}"; do
+  unexpected_lines="$(printf '%s\n' "$unexpected_lines" | rg -v "$pattern" || true)"
+done
+
+if [[ -n "$unexpected_lines" ]]; then
+  echo "::error::Unexpected Gradle deprecation output; update the owning code or explicitly document an upstream contract."
+  printf '%s\n' "$unexpected_lines"
+  exit 1
+fi
+
+echo "Only the documented upstream Gradle warnings were emitted:"
+printf '%s\n' "$warning_lines"


### PR DESCRIPTION
Adds a weekly and manual build-tool compatibility workflow for the reusable base project.

The workflow configures the full graph with the checked-in Gradle wrapper and Gradle nightly, runs the convention-plugin contract tests, archives logs, and fails on undocumented Gradle deprecations. The documented upstream warnings remain explicitly allow-listed and described in the compatibility inventory.

Verification:
- make test
- Gradle wrapper configuration and convention-plugin tests
- shell syntax, YAML parsing, and diff checks