### PR TITLE
feat: add accessibility coverage matrix

### DIFF
--- a/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/MainActivityComposeTest.kt
@@ -92,9 +92,11 @@ class MainActivityComposeTest {
       detailScreen {
         waitUntilNodeWithTextIsDisplayed(fakeBeer.description)
         assertToggleButtonShowsMarkAsEmpty()
+        assertAvailabilityActionSemantics(com.simtop.presentation_utils.R.string.beer_available)
         clickToggleAvailability()
         waitUntilToggleButtonShowsRefillBarrels()
         assertToggleButtonShowsRefillBarrels()
+        assertAvailabilityActionSemantics(com.simtop.presentation_utils.R.string.beer_out_of_stock)
         navigateBack()
       }
 
@@ -124,6 +126,7 @@ class MainActivityComposeTest {
         assertEveryClickableIsLabelled()
 
         clickOnBreweriesTab()
+        assertBreweriesTabIsSelected()
         waitUntilNodeWithTextIsDisplayed(fakeBrewery.name)
         assertBreweryIsDisplayed(fakeBrewery.name)
 

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/BrowseScreenRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/BrowseScreenRobot.kt
@@ -18,6 +18,10 @@ class BrowseScreenRobot(composeTestRule: ComposeTestRule) : BaseTestRobot(compos
     clickOnNodeWithText(string(R.string.browse_tab_breweries))
   }
 
+  fun assertBreweriesTabIsSelected() {
+    assertTextIsSelected(string(R.string.browse_tab_breweries))
+  }
+
   fun assertBreweryIsDisplayed(breweryName: String) {
     assertTextIsDisplayed(breweryName)
   }

--- a/app/src/androidTest/java/com/simtop/billionbeers/robots/DetailScreenRobot.kt
+++ b/app/src/androidTest/java/com/simtop/billionbeers/robots/DetailScreenRobot.kt
@@ -1,5 +1,6 @@
 package com.simtop.billionbeers.robots
 
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import com.simtop.presentation_utils.R
 import com.simtop.testing_utils_android.BaseTestRobot
@@ -20,6 +21,11 @@ class DetailScreenRobot(composeTestRule: ComposeTestRule) : BaseTestRobot(compos
 
   fun assertToggleButtonShowsMarkAsEmpty() {
     assertTextIsDisplayed(string(R.string.mark_as_empty))
+  }
+
+  fun assertAvailabilityActionSemantics(stateDescription: Int) {
+    assertNodeWithTagHasRole("toggle_availability", Role.Button)
+    assertNodeWithTagHasStateDescription("toggle_availability", string(stateDescription))
   }
 
   fun waitUntilToggleButtonShowsRefillBarrels() {

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts
@@ -70,7 +70,11 @@ val generatePaparazziTest = tasks.register("generatePaparazziTest") {
 
             import app.cash.paparazzi.DeviceConfig
             import app.cash.paparazzi.Paparazzi
+            import com.android.resources.LayoutDirection
+            import com.android.resources.NightMode
+            import com.android.resources.UiMode
             import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
+            import com.simtop.billionbeers.snapshot_testing.PreviewConfiguration
             import com.simtop.billionbeers.snapshot_testing.PreviewProvider
             import com.simtop.billionbeers.snapshot_testing.SnapshotImageEnvironment
             import org.junit.Assume
@@ -83,19 +87,24 @@ val generatePaparazziTest = tasks.register("generatePaparazziTest") {
             @RunWith(Parameterized::class)
             class ${safeClassName}(
                 private val snapshotName: String,
-                private val content: @androidx.compose.runtime.Composable () -> Unit
+                private val content: @androidx.compose.runtime.Composable () -> Unit,
+                private val configuration: PreviewConfiguration
             ) {
 
                 @get:Rule
                 val paparazzi = Paparazzi(
-                    deviceConfig = DeviceConfig.PIXEL_5,
-                    theme = "android:Theme.Material.Light.NoActionBar"
+                    deviceConfig = deviceConfig(configuration),
+                    theme = if (configuration.theme == "dark") {
+                        "android:Theme.Material.NoActionBar"
+                    } else {
+                        "android:Theme.Material.Light.NoActionBar"
+                    }
                 )
 
                 @Test
                 fun snapshot() {
                     Assume.assumeTrue("Skipping dummy snapshot", snapshotName != "DUMMY_NO_PREVIEWS_FOUND")
-                    
+
                     paparazzi.snapshot(name = snapshotName) {
                         SnapshotImageEnvironment {
                             BillionBeersTheme {
@@ -103,6 +112,29 @@ val generatePaparazziTest = tasks.register("generatePaparazziTest") {
                             }
                         }
                     }
+                }
+
+                private fun deviceConfig(configuration: PreviewConfiguration): DeviceConfig {
+                    val base = if (configuration.width == "expanded") {
+                        DeviceConfig.PIXEL_TABLET
+                    } else {
+                        DeviceConfig.PIXEL_5
+                    }
+                    return base.copy(
+                        fontScale = configuration.fontScale,
+                        locale = configuration.locale,
+                        layoutDirection = if (configuration.layoutDirection == "rtl") {
+                            LayoutDirection.RTL
+                        } else {
+                            LayoutDirection.LTR
+                        },
+                        uiMode = UiMode.NORMAL,
+                        nightMode = if (configuration.theme == "dark") {
+                            NightMode.NIGHT
+                        } else {
+                            NightMode.NOTNIGHT
+                        },
+                    )
                 }
 
                 companion object {
@@ -119,11 +151,17 @@ val generatePaparazziTest = tasks.register("generatePaparazziTest") {
                         val allSnapshots = localProviders.flatMap { it.snapshots }
                         
                         if (allSnapshots.isEmpty()) {
-                            return listOf(arrayOf("DUMMY_NO_PREVIEWS_FOUND", @androidx.compose.runtime.Composable {}))
+                            return listOf(
+                                arrayOf(
+                                    "DUMMY_NO_PREVIEWS_FOUND",
+                                    @androidx.compose.runtime.Composable {},
+                                    PreviewConfiguration.Default,
+                                )
+                            )
                         }
 
                         return allSnapshots.map { snapshot ->
-                            arrayOf(snapshot.name, snapshot.content)
+                            arrayOf(snapshot.name, snapshot.content, snapshot.configuration)
                         }
                     }
                 }

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/DesignAnnotations.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/DesignAnnotations.kt
@@ -31,3 +31,16 @@ annotation class PreviewFontScales
 @Preview(name = "Foldable", group = "Devices", device = PIXEL_FOLD, showBackground = true)
 @Preview(name = "Tablet", group = "Devices", device = PIXEL_TABLET, showBackground = true)
 annotation class PreviewDevices
+
+/**
+ * Marks a representative screen or component for the screenshot accessibility matrix.
+ *
+ * The screenshot convention expands this marker into the canonical light/dark, font, locale, and
+ * width variants. Keep it on a small number of representative previews; ordinary previews retain
+ * their existing one-case behavior.
+ */
+@Preview(name = "Accessibility Matrix", group = "Accessibility", showBackground = true)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
+@Suppress("PreviewAnnotationNaming")
+annotation class AccessibilityMatrixPreview

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/DialogWithProgressBar.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/DialogWithProgressBar.kt
@@ -142,3 +142,16 @@ class DialogProgressProvider : PreviewParameterProvider<Float> {
 fun DialogContentPreview(@PreviewParameter(DialogProgressProvider::class) progress: Float) {
   BillionBeersTheme { DialogContent(number = progress, text = "Downloading feature...") }
 }
+
+@AccessibilityMatrixPreview
+@Composable
+@Suppress("PreviewPublic")
+internal fun DialogContentAccessibilityMatrixPreview() {
+  BillionBeersTheme {
+    DialogContent(
+      number = 0.5f,
+      text =
+        "Downloading a very long feature description that must remain readable at large font sizes.",
+    )
+  }
+}

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4efa8e435c469ab2adcb14983b98504c8b02ca7e7494360df10ed37d8c350b5
+size 14565

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc44d81bfdb1453deaad91ac1138011987223da560b6b5a6b07c75a97ed4d00f
+size 9865

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4efa8e435c469ab2adcb14983b98504c8b02ca7e7494360df10ed37d8c350b5
+size 14565

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc44d81bfdb1453deaad91ac1138011987223da560b6b5a6b07c75a97ed4d00f
+size 9865

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4efa8e435c469ab2adcb14983b98504c8b02ca7e7494360df10ed37d8c350b5
+size 14565

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc44d81bfdb1453deaad91ac1138011987223da560b6b5a6b07c75a97ed4d00f
+size 9865

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b73062092d45bf92f0adee3a53b1b7615da87839cc8cdd99eb61077da5b5d9d
+size 21947

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a82c160fc3aaa4858a790daf95c1b4a82a7adc7dadb52e6f181b182a5364b20
+size 13909

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b73062092d45bf92f0adee3a53b1b7615da87839cc8cdd99eb61077da5b5d9d
+size 21947

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a82c160fc3aaa4858a790daf95c1b4a82a7adc7dadb52e6f181b182a5364b20
+size 13909

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b73062092d45bf92f0adee3a53b1b7615da87839cc8cdd99eb61077da5b5d9d
+size 21947

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a82c160fc3aaa4858a790daf95c1b4a82a7adc7dadb52e6f181b182a5364b20
+size 13909

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74f42a905d74af71720f535d3133e6f91476883a6101ce0d061070d7068884b8
+size 24400

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23039a227ba62ea3b771e4a40f6cbc4ce8db9dc6178c9965ea4fbeb9af934122
+size 15930

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74f42a905d74af71720f535d3133e6f91476883a6101ce0d061070d7068884b8
+size 24400

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23039a227ba62ea3b771e4a40f6cbc4ce8db9dc6178c9965ea4fbeb9af934122
+size 15930

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74f42a905d74af71720f535d3133e6f91476883a6101ce0d061070d7068884b8
+size 24400

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23039a227ba62ea3b771e4a40f6cbc4ce8db9dc6178c9965ea4fbeb9af934122
+size 15930

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11758fe5bfdbc2ca09e2aaa5bead84bc5ff151fc2107622c1ba89c87ba3c7362
+size 14880

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f89ccf053e72fc6dd88e64ed2d84e01f1b4dd51e6562c933938055192a3108c0
+size 9984

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11758fe5bfdbc2ca09e2aaa5bead84bc5ff151fc2107622c1ba89c87ba3c7362
+size 14880

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f89ccf053e72fc6dd88e64ed2d84e01f1b4dd51e6562c933938055192a3108c0
+size 9984

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:11758fe5bfdbc2ca09e2aaa5bead84bc5ff151fc2107622c1ba89c87ba3c7362
+size 14880

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f89ccf053e72fc6dd88e64ed2d84e01f1b4dd51e6562c933938055192a3108c0
+size 9984

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f131cf5acd9d72142ef24ee6b26575e106b868f85cefa65476008352c3fc3af3
+size 22925

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:409ab838064acffed34e4a05230e97d7ea65e74991110a0a2a219ef58bd722a2
+size 14268

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f131cf5acd9d72142ef24ee6b26575e106b868f85cefa65476008352c3fc3af3
+size 22925

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:409ab838064acffed34e4a05230e97d7ea65e74991110a0a2a219ef58bd722a2
+size 14268

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f131cf5acd9d72142ef24ee6b26575e106b868f85cefa65476008352c3fc3af3
+size 22925

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:409ab838064acffed34e4a05230e97d7ea65e74991110a0a2a219ef58bd722a2
+size 14268

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_en_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c38f9344c75699f2b087200bc705873f5b214289860ff250b5864371036afd2
+size 25407

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d83fe50d27c38c85a8e97fe764020f266717166480df29fe28bb43ae4aece45
+size 16468

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_en_rtl_compact]_dialogcontentaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c38f9344c75699f2b087200bc705873f5b214289860ff250b5864371036afd2
+size 25407

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_dialogcontentaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d83fe50d27c38c85a8e97fe764020f266717166480df29fe28bb43ae4aece45
+size 16468

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_dialogcontentaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c38f9344c75699f2b087200bc705873f5b214289860ff250b5864371036afd2
+size 25407

--- a/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
+++ b/core/designsystem/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_billionbeers_core_designsystemScreenshotTest_snapshot[DialogContentAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_dialogcontentaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d83fe50d27c38c85a8e97fe764020f266717166480df29fe28bb43ae4aece45
+size 16468

--- a/docs/accessibility-release-qa.md
+++ b/docs/accessibility-release-qa.md
@@ -1,0 +1,57 @@
+# Accessibility release QA
+
+This checklist is the manual complement to Compose semantics tests and screenshot coverage. It is not
+replaced by an instrumented test: release candidates must be exercised with TalkBack and a hardware
+keyboard on real devices.
+
+## Matrix
+
+Run the checklist for:
+
+- English (`en`) and French (`fr`) resource builds;
+- Arabic (`ar`) with right-to-left layout;
+- compact phone width;
+- expanded tablet or unfolded-foldable width;
+- normal, 1.5x, and 2.0x system font scales;
+- light and dark themes.
+
+Use representative catalog, search, browse, and detail states, including loading, error, retry,
+long-content, and end-of-list states.
+
+## TalkBack
+
+- [ ] Focus starts on a sensible, visible control and follows reading order from app bar to content.
+- [ ] Back, search, browse, clear, tabs, beer rows, retry, and availability controls announce a useful label.
+- [ ] Interactive controls announce the correct role: button, tab, or text field.
+- [ ] The availability control announces its current state, and the announcement changes after toggling.
+- [ ] Selecting the Browse tabs announces the selected tab and does not leave focus stranded.
+- [ ] Error messages and retry affordances are announced after an error appears.
+- [ ] Pull-to-refresh, load-more failure, and end-of-list feedback are understandable without sight.
+- [ ] Long names, descriptions, and translated strings are not truncated in a way that hides meaning.
+- [ ] RTL reading order, back navigation, icons, and scrolling feel natural in Arabic.
+- [ ] The rotor or controls navigation reaches every actionable element and skips decorative images.
+- [ ] Focus remains usable when content changes, when a dialog appears, and after returning from detail.
+
+## Keyboard and IME
+
+- [ ] Tab and Shift-Tab traverse controls in a logical order on an expanded device.
+- [ ] Enter or Space activates focused buttons, tabs, rows, retry, and availability actions.
+- [ ] The search field receives focus, exposes its label/hint, and accepts text from a physical keyboard.
+- [ ] The clear action becomes reachable when text is present and returns focus to a sensible location.
+- [ ] The IME action and Back dismiss or navigate as expected without losing the query.
+- [ ] The keyboard does not cover the active field, error action, or availability control.
+- [ ] Focus and traversal remain logical at 1.5x and 2.0x font scales and in RTL.
+
+## Reduced motion and form factors
+
+- [ ] With system animator duration set to zero, state changes remain understandable and no control is
+  stranded by an animation.
+- [ ] On a compact phone, content scrolls without horizontal clipping or unreachable controls.
+- [ ] On a tablet and an unfolded foldable, expanded content uses the available width without making
+  text or actions uncomfortably distant.
+- [ ] Rotation or fold/unfold preserves the current destination and does not lose the active query,
+  selected tab, or visible state unexpectedly.
+
+Record device, Android version, locale, font scale, theme, and any failed step with the release QA
+result. Adaptive multi-pane navigation is a separate implementation follow-up; this checklist is
+intended to expose its product-level failures before that work lands.

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersScreen.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseBeersScreen.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.billionbeers.core.designsystem.component.AccessibilityMatrixPreview
 import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
 import com.simtop.billionbeers.core.designsystem.component.showToast
 import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
@@ -224,6 +225,37 @@ fun BrowseBeersScreenPreview(
     BrowseBeersContent(
       title = case.title,
       viewState = case.state,
+      onBack = {},
+      onBeerClick = {},
+      onScrollToBottom = {},
+      onRetryLoadMore = {},
+      onRetryFirstPage = {},
+    )
+  }
+}
+
+@AccessibilityMatrixPreview
+@Composable
+@Suppress("PreviewPublic")
+internal fun BrowseBeersAccessibilityMatrixPreview() {
+  BillionBeersTheme {
+    BrowseBeersContent(
+      title = "A Very Long Beer Style Name That Must Wrap Correctly",
+      viewState =
+        CommonUiState.Success(
+          PagedListUiModel(
+            items =
+              listOf(
+                Beer.empty.copy(
+                  name = "A Very Long Beer Name That Must Wrap Correctly",
+                  tagline = "A long tagline exercises the browse result layout.",
+                ),
+                Beer.empty.copy(name = "Second Beer", tagline = "Another beer"),
+              ),
+            totalCount = 2,
+            footer = PagedListFooter.EndReached,
+          )
+        ),
       onBack = {},
       onBeerClick = {},
       onScrollToBottom = {},

--- a/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseHomeScreen.kt
+++ b/feature/beerbrowse/src/main/java/com/simtop/feature/beerbrowse/presentation/BrowseHomeScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.simtop.beerdomain.domain.models.BeerStyle
 import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.billionbeers.core.designsystem.component.AccessibilityMatrixPreview
 import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
 import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
 import com.simtop.core.core.CommonUiState
@@ -246,6 +247,42 @@ fun BrowseHomeScreenPreview(
       styles = case.styles,
       breweries = case.breweries,
       selectedTab = case.selectedTab,
+      onTabSelected = {},
+      onStyleClick = {},
+      onBreweryClick = {},
+      onBack = {},
+      onRetryStyles = {},
+      onRetryBreweries = {},
+    )
+  }
+}
+
+@AccessibilityMatrixPreview
+@Composable
+@Suppress("PreviewPublic")
+internal fun BrowseHomeAccessibilityMatrixPreview() {
+  BillionBeersTheme {
+    BrowseHomeContent(
+      styles =
+        CommonUiState.Success(
+          listOf(
+            BeerStyle(id = "long-style", name = "A Very Long Beer Style Name That Must Wrap"),
+            BeerStyle(id = "stout", name = "Imperial Stout"),
+          )
+        ),
+      breweries =
+        CommonUiState.Success(
+          listOf(
+            Brewery(
+              id = "long-brewery",
+              name = "A Brewery With A Deliberately Long Name For Accessibility Testing",
+              countryCode = "ES",
+              foundedYear = 1972,
+              imageUrl = "",
+            )
+          )
+        ),
+      selectedTab = TAB_BREWERIES,
       onTabSelected = {},
       onStyleClick = {},
       onBreweryClick = {},

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03f16b1cf52dada44ad1415848b1b6cb964f9992e78030ddfec913de77f65edb
+size 46853

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b203c58aada5d1e923afa06def34c8a6e14e7b8b0d6d999814b871dc624ae5cf
+size 33857

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:03f16b1cf52dada44ad1415848b1b6cb964f9992e78030ddfec913de77f65edb
+size 46853

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b203c58aada5d1e923afa06def34c8a6e14e7b8b0d6d999814b871dc624ae5cf
+size 33857

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf6fa03fcdee74e87859cef6b50368e13d7bd1cf822f662a86a19a16812633c4
+size 47507

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cabe6aaa067299c65ad0cd3ec76be73ce9d0e241a9fb270ce6b430b4f4bebda2
+size 34544

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90ddfa93b49cff1e296c4ddb12925194fb50e19660e240121caf9d40fe0b1482
+size 61901

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c65d9a6a2d38609182f18b07c6f66977aa3ad52d5c1e208887b8bc5572875e3
+size 44817

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90ddfa93b49cff1e296c4ddb12925194fb50e19660e240121caf9d40fe0b1482
+size 61901

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c65d9a6a2d38609182f18b07c6f66977aa3ad52d5c1e208887b8bc5572875e3
+size 44817

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b2f00634a05a37cf5aad0d421f65b6df0133de1e8c6d2964174514fdfa0debf
+size 63507

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddebe133647c4cf247efc05f0d356dbd623eda5a81e52e772ef9710e0f78d504
+size 45627

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e632e53627662b00dbb13976dba2a67006dda77e486e82ac988b2f5c01623d42
+size 53846

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4903eeadd1293fb4e83a0ae466aafdd14ded9680729df5b42e2be287a1951bc
+size 54450

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e632e53627662b00dbb13976dba2a67006dda77e486e82ac988b2f5c01623d42
+size 53846

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4903eeadd1293fb4e83a0ae466aafdd14ded9680729df5b42e2be287a1951bc
+size 54450

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cabf443df3791316853c64f5f0bbfd33b9000f1363d54125c48b4efba767583
+size 53767

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9955d214101420f7c1cb1ac165c247daeae4c5b00a0285b129504faabf63d208
+size 55549

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c1e9d5e6959dbaafd301b95ee9886246025a2e3e00f442d196aa452e2cc4441
+size 47895

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da77fe0b804b322d607b9edbb8ec54682f2517e41e06daa91bd55cb8aeb40008
+size 34732

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c1e9d5e6959dbaafd301b95ee9886246025a2e3e00f442d196aa452e2cc4441
+size 47895

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da77fe0b804b322d607b9edbb8ec54682f2517e41e06daa91bd55cb8aeb40008
+size 34732

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9202e1dca684c1d1143b0b547d34900d4d6df121e6bea01970b30f1ca00c7da9
+size 48595

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f814185636928e7b7088a078956b9c4b88658248e014085e631d0108b6104bd6
+size 35325

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c0e5fa891cf41137c589e2048bc1ba0dde4504f8ac153cdf10b0050a7f40aa9
+size 63726

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36dd7f38d7cbc70fdbdf9c1fe3e57ce954f48e7ededef0ea7a22e3562ece422a
+size 46077

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c0e5fa891cf41137c589e2048bc1ba0dde4504f8ac153cdf10b0050a7f40aa9
+size 63726

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36dd7f38d7cbc70fdbdf9c1fe3e57ce954f48e7ededef0ea7a22e3562ece422a
+size 46077

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a9fc657418ab16debf0158b2d8da556289458234edf245c66f1dd8c9f549356
+size 65103

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dff0297e47f58228684054749068ccb656f4bc953d498836fb7b0324035fb019
+size 46912

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_en_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa1b73f96374dcdde7b399f10795eb430c7d1119c4e9ca9eb09226c2e88d622
+size 56274

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d784d9bd4a3551e0d107e746c4e97eee50b5aca39cde6ae74401a261077b1c
+size 55775

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_en_rtl_compact]_browsebeersaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa1b73f96374dcdde7b399f10795eb430c7d1119c4e9ca9eb09226c2e88d622
+size 56274

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_browsebeersaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4d784d9bd4a3551e0d107e746c4e97eee50b5aca39cde6ae74401a261077b1c
+size 55775

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_browsebeersaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42d66da65641965db8542f8fcd2415c65bce8c2cc6c3f1177882eb45aea4b4e2
+size 55997

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_browsebeersaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05a05e2498f24440b0e02984c4556bc3d98e6b9ffc0826b0fa5082f9bd451207
+size 56819

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersScreenPreview_0]_browsebeersscreenpreview_0.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseBeersScreenPreview_0]_browsebeersscreenpreview_0.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1499cc43a7acdf8d3414994c11c6a56b8cdb7ef1f2572d0c9daf205527075c0f
-size 32244
+oid sha256:42c8d71b14a0d9878d4c4522e592f58379db6b5ca59ae95be586bbaddce24dc2
+size 32238

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b7d34a8ca1f1576d5d13f1b8ae14e55d37ceec84cffdb7ec5b3e1d8512310b2
+size 20008

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db63df2e846f82672862374b7ce993ccd985d0f7184083e175974121671e6515
+size 13797

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f941063f2dfdf1d87b6cf59e5504d0a181cfae3309c3f31ced2123e409e34db
+size 20015

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c74682744844fe40290d078de9fac0813252447771c6b8234eadc44045bd9c42
+size 13793

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b2af48c92cac57f790669afeee8beb18f05b53dfdd739cc6c4825491458b443
+size 20155

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4ba55b38a95618e8de8bf1b268935771f67688eb1e8486b88d0da50ac7aaf84
+size 13892

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5a10f778388a30576f56f53d0a82633609fe3d89ca90f9c8c10a526cd461484
+size 27187

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16eb531edac235ee0de23bd190d3ff219409e419337fc732fb4f1b1bcc4a456b
+size 19226

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:952196e0f17383028ad9b633435c98d3f920318078ae5627dafde19b89860871
+size 27182

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:924b327b9f4d3ef45bf1af6ff17a545353c8c4dbd8014ddd0b3f536f7f7413f8
+size 19269

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8803406cae4ee97876a69281dbcd4bf4cc5ffb2fc79a66c2b4f6ea0fc95e55b2
+size 27302

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74979d67af1b850c3f76506188e44f8ed446b3f9d5d2831e024d6d0c94b5dd7b
+size 19393

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7858c06716e07324fd063fb5382749bfb8076080edb430380293e7c53c099332
+size 31600

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:94a4c03a3fcbc09af38573eed9ceaf5669178dd34b97362f2e8117aea1060dad
+size 22521

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55cccda3d899c6e82cfe20226f56b1aebf3451a4e25eb5fac0adfa9485749cfd
+size 31647

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e93f5b5dec18a0ae450b958a1dc6380f06db0bb676945d45a307953ed11a24fd
+size 22526

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81f6b6d97e5d8d54e0b80615ce0793889ee2c0eaa85e350f41b1f75d09638072
+size 32058

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e57adf0ea7bc9b8d5fc0aa52bbf8338d8639ff89d8613932015ca2eee13c500
+size 22970

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:facf2344db80757114d4bd8b0bad57245aaf6d18be70d04c74f88151a79ccd16
+size 20789

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90a0cc74aefd8de1fcb83240d2ce080079a05cfc2484543792b80eeaa107d55c
+size 14414

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a6bdf5996d8218ecd209fed3f9f4ff73e0396861cbcd6152ce0c74e69139e0f
+size 20763

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c0b2660d59dbb514884f068f89ab11341e245dc832cfc0ca90f6aeea50b57aa
+size 14411

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbd94a7066d0e1da50dd6915953ac41c0410210682b737c609afdcd792403461
+size 21002

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4fdc1ea2869667eaea815efbf060c769cf91e56bd4df812d63fe030228abb673
+size 14463

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb74c836ee064848bc536a560e0c35fe230ecdff2abc09d7fa06fa766eb217c9
+size 27915

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d25b0eeed555bc2cd4d968919cb467b2f4d0215d3dcb169c177aa0f81693be08
+size 19985

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b687faacb02d3bb045cf1a4f4bb5693933b8071c3dc754fbcbde40869dccc20f
+size 27920

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22d62fb31c9f1b823ead393f948fe00a347b72eb4ca6c89d953280fcfc1c0fd7
+size 19991

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9ab62a20faa8860481118205f325d8effd6cc30f4e536f0a704c46bb03b6e07
+size 28082

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea2c21e95b04e6f722fbef28d66941b8c2e9f7c697c46b08eaefbee326c4f7ed
+size 20079

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_en_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d7d08083c942ab31aff0efbb2c87939f6e1ca212d517be4d4cb010104915522
+size 32649

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7b107d71038aa308cd71fc2e42e140f6ed886acd889a895e29b6c61e96e9f3b
+size 23273

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_en_rtl_compact]_browsehomeaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a115f7c9be5ab4b69e339d6dc3566fe59b289dfb23a7b1c0faa5543de1e379db
+size 32643

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_browsehomeaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e7a77878199dbb1628c3035dcb5faa9b5351300d183608cde5672790c44a303
+size 23351

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_browsehomeaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a2a001819740d2726b4675f2347579cc62d7f5009497afc8207f3ccf01a1029
+size 33034

--- a/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
+++ b/feature/beerbrowse/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerbrowseScreenshotTest_snapshot[BrowseHomeAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_browsehomeaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:debcfdcbc6d431d969abd4173c3523891bdc1c95fdf391679cd436956d0dba1b
+size 23798

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
@@ -39,6 +39,7 @@ import coil3.request.crossfade
 import coil3.request.error
 import coil3.request.placeholder
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.billionbeers.core.designsystem.component.AccessibilityMatrixPreview
 import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
 import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
 import com.simtop.presentation_utils.R
@@ -401,6 +402,34 @@ fun ComposeBeerDetailWithoutEnrichedFieldsPreview() {
           description = "A light, crisp and bitter IPA.",
           abv = 4.5,
           ibu = 60.0,
+        ),
+      onBackClick = {},
+      onToggleAvailability = {},
+    )
+  }
+}
+
+@AccessibilityMatrixPreview
+@Composable
+@Suppress("PreviewPublic")
+internal fun ComposeBeerDetailAccessibilityMatrixPreview() {
+  BillionBeersTheme {
+    ComposeBeerDetail(
+      beer =
+        Beer.empty.copy(
+          name = "A Very Long Beer Name That Must Wrap Correctly",
+          tagline = "A long tagline for large-font accessibility coverage.",
+          description =
+            "A deliberately long description that exercises scrolling, wrapping, RTL layout, and " +
+              "compact versus expanded widths.",
+          abv = 5.6,
+          ibu = 41.5,
+          foodPairing = listOf("Spicy chicken tikka masala", "Grilled chicken quesadilla"),
+          styleName = "IPA (Indian Pale Ale)",
+          breweryName = "A Brewery With A Deliberately Long Name For Accessibility Testing",
+          availability = true,
+          ingredients = listOf("Pale malt", "Cascade hops", "American ale yeast"),
+          recommendedGlasses = listOf("Pint glass", "Tulip"),
         ),
       onBackClick = {},
       onToggleAvailability = {},

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6e8429ab871310a948ec066e42742b31272eacba2ddea956c95540d6ceea7a6
+size 79613

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7efc1d0b90c7336b484eaa71e3ecc3b31b1f300700b909673da8535a34e3eeb
+size 53029

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6e8429ab871310a948ec066e42742b31272eacba2ddea956c95540d6ceea7a6
+size 79613

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7efc1d0b90c7336b484eaa71e3ecc3b31b1f300700b909673da8535a34e3eeb
+size 53029

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3aa47c6e66a283a79b00bbf02390054b7494d7ca957dd431bf404b726afa5f0e
+size 82012

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3b722ff540b959d668a13c37abc17b3f1d4bc22ea65fa9ea9a30998a7d7e9a2
+size 54798

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf4a8114a0201ad794defbcc1512b5b61f70fbc7c6201b75502cfed85153a949
+size 84268

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77a78c62f696e468b7425c6ad08a21f67d047084153863efe6f31815b58e117c
+size 65933

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf4a8114a0201ad794defbcc1512b5b61f70fbc7c6201b75502cfed85153a949
+size 84268

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77a78c62f696e468b7425c6ad08a21f67d047084153863efe6f31815b58e117c
+size 65933

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58a51753301a0fa030a329c28e09942a6c773341281e983100a85fca6444b730
+size 83395

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c775f283349b94cdcc1265b3bb207a40f81e9aacd62061962244965f813482a8
+size 67975

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40dc20754e5fa9847630ad542e542dc21deb9c0ad06bf9387a708c3af08955bd
+size 74895

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a49a1e75eced70427d9a20fa85aaa3a7ebf18d7096d3199537509a34062ebbc
+size 68991

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40dc20754e5fa9847630ad542e542dc21deb9c0ad06bf9387a708c3af08955bd
+size 74895

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a49a1e75eced70427d9a20fa85aaa3a7ebf18d7096d3199537509a34062ebbc
+size 68991

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0d4e2712a1ac45d8dadcf463e63c7a17e6591abafc1405f03b194c0d05957034
+size 75925

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b84f169ff71203d4a62f10210295e1a6e0f4d6f49b5838d159a0c7e80dada250
+size 70288

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0fe553858fdb730b8efe7a459aa2963e60e15fb66088f96eb4b1124c1028016
+size 83380

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d7f28052f088da69401d909f2059a71785c75c2fa510aaad894c0bb07112494
+size 54641

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0fe553858fdb730b8efe7a459aa2963e60e15fb66088f96eb4b1124c1028016
+size 83380

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d7f28052f088da69401d909f2059a71785c75c2fa510aaad894c0bb07112494
+size 54641

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42e086d625a886043fb9daa6ab4fc6f938916b5d819eaaa1d9c37ed88178cb4d
+size 86044

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:596e9e0dd5f73429a918bd58a06df880fd8b0e4cd0513857e41d2ac661863119
+size 56461

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84d821390d205eb80e768d7eee59fd5cbf8979c2f330fe1abb946677ebf50638
+size 87783

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44c4c2374e7f0b4ddabbcde280c66e2b31a6674f7e49723dcafbd1f9242dd409
+size 67815

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84d821390d205eb80e768d7eee59fd5cbf8979c2f330fe1abb946677ebf50638
+size 87783

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44c4c2374e7f0b4ddabbcde280c66e2b31a6674f7e49723dcafbd1f9242dd409
+size 67815

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52aaee1abe5447393474b33594536583197f9cbd11c649eeacbedc0e58ceb913
+size 87131

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51832e6833f63c898dc68fabff39b2e8134fecc26ab4843b0b328d54e76cf754
+size 70139

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_en_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b27338fc0de561e94fcb6ce35b87302c076b0f5e2b1365fdfd5c8ca173c212f4
+size 79479

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d1c41be8af38aaae562f0bfc1349ab659bec5160e8f650cd6d1e2ca32ca13e1
+size 71519

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_en_rtl_compact]_composebeerdetailaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b27338fc0de561e94fcb6ce35b87302c076b0f5e2b1365fdfd5c8ca173c212f4
+size 79479

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d1c41be8af38aaae562f0bfc1349ab659bec5160e8f650cd6d1e2ca32ca13e1
+size 71519

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_composebeerdetailaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:658266af452f12b575f6b9b457ffd960539acededf8fd7e28423559cb40e0c87
+size 80823

--- a/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
+++ b/feature/beerdetail/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerdetailScreenshotTest_snapshot[ComposeBeerDetailAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_composebeerdetailaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:60dba16d3ed1f462d9013b45eece7bcd06a74d688bbd30d04b22820440e5ecc4
+size 73103

--- a/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchScreen.kt
+++ b/feature/beersearch/src/main/java/com/simtop/feature/beersearch/BeersSearchScreen.kt
@@ -41,6 +41,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.billionbeers.core.designsystem.component.AccessibilityMatrixPreview
 import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
 import com.simtop.billionbeers.core.designsystem.component.showToast
 import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
@@ -274,6 +275,39 @@ fun BeersSearchScreenPreview(
     BeersSearchContent(
       viewState = case.state,
       query = case.query,
+      onQueryChange = {},
+      onBeerClick = {},
+      onBack = {},
+      onScrollToBottom = {},
+      onRetryLoadMore = {},
+      onRetrySearch = {},
+      autoFocus = false,
+    )
+  }
+}
+
+@AccessibilityMatrixPreview
+@Composable
+@Suppress("PreviewPublic")
+internal fun BeersSearchAccessibilityMatrixPreview() {
+  BillionBeersTheme {
+    BeersSearchContent(
+      viewState =
+        CommonUiState.Success(
+          PagedListUiModel(
+            items =
+              listOf(
+                Beer.empty.copy(
+                  name = "A Very Long Search Result Name That Must Wrap",
+                  tagline =
+                    "A long tagline exercises the search result layout at large font sizes.",
+                ),
+                Beer.empty.copy(name = "Second Result", tagline = "Another result"),
+              ),
+            totalCount = 2,
+          )
+        ),
+      query = "a very long query that should remain understandable",
       onQueryChange = {},
       onBeerClick = {},
       onBack = {},

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0535b8e96949a8badd5ff3752cc878ae13f1dbee65abeb34c93e2c339349a72
+size 42215

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf167ac40ebdd06cbcddcf3dfa7d04a031a488dd57a88cb5e2c3015f72d74a19
+size 33641

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0535b8e96949a8badd5ff3752cc878ae13f1dbee65abeb34c93e2c339349a72
+size 42215

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf167ac40ebdd06cbcddcf3dfa7d04a031a488dd57a88cb5e2c3015f72d74a19
+size 33641

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa192031d1a52992334a45d014ad4e3ddec2fd5296634781cae2cfca06ca0e4c
+size 42699

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c52fa76ec4c0c9ddd4120207faf160b6db5b52250443455c9c2c9721ee59119e
+size 34169

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3b23d80e53c09f672b00b67e94f82725fb46cbbc39574142835f9fdb407ec88
+size 51448

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9b65fae4c886c3f5adaa7b9de0aa27eeec909163d320df9eda25f274f6ad3cc
+size 44944

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3b23d80e53c09f672b00b67e94f82725fb46cbbc39574142835f9fdb407ec88
+size 51448

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9b65fae4c886c3f5adaa7b9de0aa27eeec909163d320df9eda25f274f6ad3cc
+size 44944

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a830e8f5f11a7040c79cda1fe4e6420d16e45faac6946fba5a67731aff160224
+size 52609

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8490531d04904eb7024d265557c2ff13d9fac8936cab6203bb49127fe39531b9
+size 45425

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b038cadf5f9a3cb6ba2157beb7250214c21fe1c13753798c56a42437eacf927e
+size 49173

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fefd80ec6cf655dcc962ab8d38c84db99a6ef7005b88142121399742c699813
+size 53319

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b038cadf5f9a3cb6ba2157beb7250214c21fe1c13753798c56a42437eacf927e
+size 49173

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fefd80ec6cf655dcc962ab8d38c84db99a6ef7005b88142121399742c699813
+size 53319

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f946c4600b4f022e595144f5d3894a70c4422492662ac342af81ec7339e6db4
+size 44242

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7fdea0c37a0ac08c88c0236e837f1f03b99409e8c25cd9fd3632ad61a273b7ca
+size 53876

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9aea31f9c9a221e06af3619354fec1ef16c3e8ab4ba398b6d94a36a4c645148d
+size 43269

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d435913ed3cea76d2a98260114f31a636a9fab9513162e95b2cb71187b402cd
+size 34545

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9aea31f9c9a221e06af3619354fec1ef16c3e8ab4ba398b6d94a36a4c645148d
+size 43269

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d435913ed3cea76d2a98260114f31a636a9fab9513162e95b2cb71187b402cd
+size 34545

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:087ca1e021c184857ea0a035316525c248275ae5b22d86e8490b4371f53b66f5
+size 43897

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d16a6b2f8d1e1b75265d985df4ecbc24cddefcd8877ad7c61b07793e21ca00ae
+size 35055

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d0248c3309f9d9bed22c0dbfdcfbe41ffe6a89f0930fc64919d60a62fe6cdfa
+size 52830

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67c61f8fa10a1602f307923c0f3a4f20b034f3854202f9737b1b1820c2547bf3
+size 46413

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d0248c3309f9d9bed22c0dbfdcfbe41ffe6a89f0930fc64919d60a62fe6cdfa
+size 52830

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67c61f8fa10a1602f307923c0f3a4f20b034f3854202f9737b1b1820c2547bf3
+size 46413

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efade01b3c4bfcad4e838d51e2298376725ee909c02d72ed2b62f9c95d677b46
+size 54161

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c41efd0646d372b40091f1a7e121e6dbc2f04ad81aae0e544065d98f1df91dc2
+size 46837

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_en_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0026c7606a280c8e06884cac87c49dc061d7840fca703f03a499d830260bea8d
+size 50999

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea3e0fd41976a37086d41ac6ab27179ea72e7682668190bb35ed123605e59dbc
+size 54670

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_en_rtl_compact]_beerssearchaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0026c7606a280c8e06884cac87c49dc061d7840fca703f03a499d830260bea8d
+size 50999

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_beerssearchaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea3e0fd41976a37086d41ac6ab27179ea72e7682668190bb35ed123605e59dbc
+size 54670

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_beerssearchaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dd7611aa4aba5830763c1bb1fece024434238a2b358405623fa7e9d123f6dcf
+size 45969

--- a/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
+++ b/feature/beersearch/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beersearchScreenshotTest_snapshot[BeersSearchAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_beerssearchaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4536d3382076ff9044249bcb857991ee802b1526764cde0c53372e9a33f92fe5
+size 55328

--- a/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListPagingUiTest.kt
+++ b/feature/beerslist/src/androidTest/java/com/simtop/feature/beerslist/BeersListPagingUiTest.kt
@@ -1,6 +1,7 @@
 package com.simtop.feature.beerslist
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.test.junit4.createComposeRule
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.fakes.fakeBeerModel
@@ -118,6 +119,31 @@ class BeersListPagingUiTest {
       0,
       loadMoreCount,
     )
+  }
+
+  @Test
+  fun screenErrorsAreAnnouncedPolitely() {
+    val message = "The catalog could not be refreshed."
+    composeTestRule.setContent {
+      BillionBeersTheme {
+        BeersListContent(
+          viewState = CommonUiState.Error(message = message),
+          onBeerClick = {},
+          onSearchClick = {},
+          onBrowseClick = {},
+          onScrollToBottom = {},
+          onRefresh = {},
+          onRetry = {},
+          onRetryLoadMore = {},
+        )
+      }
+    }
+
+    beersList(composeTestRule) {
+      assertTextIsDisplayed(message)
+      assertTextHasLiveRegion(message, LiveRegionMode.Polite)
+      assertEveryClickableIsLabelled()
+    }
   }
 
   private companion object {

--- a/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
+++ b/feature/beerslist/src/main/java/com/simtop/feature/beerslist/BeersListScreen.kt
@@ -63,6 +63,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.billionbeers.core.designsystem.component.AccessibilityMatrixPreview
 import com.simtop.billionbeers.core.designsystem.component.PreviewLightDark
 import com.simtop.billionbeers.core.designsystem.component.shimmerBrush
 import com.simtop.billionbeers.core.designsystem.component.showToast
@@ -377,6 +378,43 @@ fun BeersListScreenPreview(
   BillionBeersTheme {
     BeersListContent(
       viewState = state.uiState,
+      onBeerClick = {},
+      onSearchClick = {},
+      onBrowseClick = {},
+      onScrollToBottom = {},
+      onRefresh = {},
+      onRetry = {},
+      onRetryLoadMore = {},
+    )
+  }
+}
+
+@AccessibilityMatrixPreview
+@Composable
+@Suppress("PreviewPublic")
+internal fun BeersListAccessibilityMatrixPreview() {
+  BillionBeersTheme {
+    BeersListContent(
+      viewState =
+        CommonUiState.Success(
+          PagedListUiModel(
+            items =
+              listOf(
+                Beer.empty.copy(
+                  name = "A Very Long Beer Name That Must Wrap Correctly",
+                  tagline = "A detailed bitter experience with a deliberately long description.",
+                  availability = true,
+                ),
+                Beer.empty.copy(
+                  name = "Another Seasonal Beer",
+                  tagline = "A second item keeps list spacing and actions visible.",
+                  availability = false,
+                ),
+              ),
+            footer = PagedListFooter.Retry,
+            totalCount = 24,
+          )
+        ),
       onBeerClick = {},
       onSearchClick = {},
       onBrowseClick = {},

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_en_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cff33050e41c8305b6d03f372dcbbc3314165397995e2c4c862db7d1e271b0b0
+size 51282

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e6555dfc8b7c4cfcec303660a8456bf5e2c76772558f0340cbb5f9ec97afe50
+size 36638

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_beerslistaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_en_rtl_compact]_beerslistaccessibilitymatrixpreview_dark_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cff33050e41c8305b6d03f372dcbbc3314165397995e2c4c862db7d1e271b0b0
+size 51282

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_dark_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e6555dfc8b7c4cfcec303660a8456bf5e2c76772558f0340cbb5f9ec97afe50
+size 36638

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6cce23293645c56f6f3febffb5901320d2a866f8c04bf4dc772c2d330714053
+size 55181

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font100_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7c22bbd97b424ad450edbd5c9de142ff840f42ea62721ac12671af29f13f8eb
+size 39822

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_en_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6ea937491cc281e597f07fd9e60dc4e7609d9f3b9f078742a1aa3f668aee629
+size 64514

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7a44331d2a09a219fcdd787ecb5dd4f9c8a5b6d7121ff29ae5477ee0b67cdab
+size 50625

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_beerslistaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_en_rtl_compact]_beerslistaccessibilitymatrixpreview_dark_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6ea937491cc281e597f07fd9e60dc4e7609d9f3b9f078742a1aa3f668aee629
+size 64514

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_dark_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7a44331d2a09a219fcdd787ecb5dd4f9c8a5b6d7121ff29ae5477ee0b67cdab
+size 50625

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b599a78b32639abbd19724b7267e43c1b1fb0498e0273fd0f2d5f8d9f1d6979
+size 72868

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font150_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4821cf4bfff79ccae7803ad729819935429ca4b7e69e33f8d90504b1d4819e2d
+size 54964

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_en_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15a6e52a45ca11f3c2e040274b2a09279a4f2386d0c917bc6bf49423e9e43579
+size 50137

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e9e206e3ba9797638d51bf90c5fa7125adbc1d519501cea18dddbec227deda3
+size 60616

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_beerslistaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_en_rtl_compact]_beerslistaccessibilitymatrixpreview_dark_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15a6e52a45ca11f3c2e040274b2a09279a4f2386d0c917bc6bf49423e9e43579
+size 50137

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_dark_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e9e206e3ba9797638d51bf90c5fa7125adbc1d519501cea18dddbec227deda3
+size 60616

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_dark_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb3ef4eef6ebb50f021673e6d76dc9a6f99a6db6d80e0f48904127a72d43b9c8
+size 52516

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_dark_font200_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_dark_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e564150ca73a073b2ca2ce2bbb522dd246bc38ecb53c2162cca1b416480ea1d
+size 66149

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_en_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_en_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font100_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:765db06ab0c593390f24d1dae6b66d38cff770b9997ab35e040e6c0de74af1b7
+size 51617

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font100_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:710fc47de6ffca89fe00d82dd54ebd26fd2b633687ed7d29cafd1a07d396cfc9
+size 37301

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_en_rtl_compact]_beerslistaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_en_rtl_compact]_beerslistaccessibilitymatrixpreview_light_font100_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:765db06ab0c593390f24d1dae6b66d38cff770b9997ab35e040e6c0de74af1b7
+size 51617

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_light_font100_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:710fc47de6ffca89fe00d82dd54ebd26fd2b633687ed7d29cafd1a07d396cfc9
+size 37301

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font100_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f5dd485453592a553b4d6749667f7c481e91ec28bff522307d730b70d069ee1
+size 55488

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font100_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font100_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9720b1ef8917ea301c5ef1354c9d5099a8fa4ab41d4d9a00946e64c21a9fb044
+size 40422

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_en_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_en_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font150_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1568656215aa91ee167e1c4f5bd0550ed6539810c39df8a3163cba8057f27d1
+size 65716

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font150_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edca296f4e839c280b79e47193b936b5abd181df3ec1436aacc87713588441f5
+size 50971

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_en_rtl_compact]_beerslistaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_en_rtl_compact]_beerslistaccessibilitymatrixpreview_light_font150_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1568656215aa91ee167e1c4f5bd0550ed6539810c39df8a3163cba8057f27d1
+size 65716

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_light_font150_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edca296f4e839c280b79e47193b936b5abd181df3ec1436aacc87713588441f5
+size 50971

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font150_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06ec71fb05e2cdaf8752a7030b64c9470066f3186e54d31d8f829ac63f7e7734
+size 74043

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font150_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font150_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7ae2e2caf7a671454e3cb8cfdf03583e70329486d9e930a3ef017e9ec07b58a4
+size 55282

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_en_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_en_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font200_en_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f4882ba60e62ddb5f48ff998fb417e86f0624697a0a166e31351ec2c75a1fb
+size 51924

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_en_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font200_en_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:227bef393811701800f24e7dff7f58b068c76b0a5237267aefbbe91916ed2835
+size 61524

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_en_rtl_compact]_beerslistaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_en_rtl_compact]_beerslistaccessibilitymatrixpreview_light_font200_en_rtl_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:68f4882ba60e62ddb5f48ff998fb417e86f0624697a0a166e31351ec2c75a1fb
+size 51924

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_en_rtl_expanded]_beerslistaccessibilitymatrixpreview_light_font200_en_rtl_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:227bef393811701800f24e7dff7f58b068c76b0a5237267aefbbe91916ed2835
+size 61524

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_fr_ltr_compact]_beerslistaccessibilitymatrixpreview_light_font200_fr_ltr_compact.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d61dcd5f9a02d8d67a6af2569f92b43de0cbcff854d01de0e6e24e131ad3abe4
+size 54290

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListAccessibilityMatrixPreview_light_font200_fr_ltr_expanded]_beerslistaccessibilitymatrixpreview_light_font200_fr_ltr_expanded.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4539578d11554ba9179238a3b67c8f2a9ae20dacf884c4f78825ab6f9cfa34c9
+size 67080

--- a/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_LOADING]_beerslistscreenpreview_loading.png
+++ b/feature/beerslist/src/test/snapshots/images/com.simtop.billionbeers.screenshot_Com_simtop_feature_beerslistScreenshotTest_snapshot[BeersListScreenPreview_LOADING]_beerslistscreenpreview_loading.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eb195bc9f8f3e0e83c8fc2dea265c22c634a38c6b8959a37d9eb3543d6576a6d
-size 29573
+oid sha256:81fef8bd43c438839f605b5f3eee8d2167ebe11b9d9694329ebc1b130b4741f6
+size 29570

--- a/snapshot-processor/src/main/kotlin/com/simtop/billionbeers/snapshot_processor/SnapshotProcessor.kt
+++ b/snapshot-processor/src/main/kotlin/com/simtop/billionbeers/snapshot_processor/SnapshotProcessor.kt
@@ -70,27 +70,39 @@ class SnapshotProcessor(
   }
 
   private fun isValidPreview(func: KSFunctionDeclaration): Boolean {
-    // Check for direct @Preview or meta-annotation
+    // Check for direct @Preview, a one-level preview meta-annotation, or the matrix marker.
     for (annotation in func.annotations) {
       val annotationType = annotation.annotationType.resolve()
-      if (
-        annotationType.declaration.qualifiedName?.asString() ==
-          "androidx.compose.ui.tooling.preview.Preview"
-      ) {
+      val qualifiedName = annotationType.declaration.qualifiedName?.asString()
+      if (qualifiedName == ACCESSIBILITY_MATRIX_PREVIEW) {
+        return true
+      }
+      if (qualifiedName == PREVIEW_ANNOTATION) {
         return true
       }
       // Check meta-annotations
       val metaAnnotations = annotationType.declaration.annotations
       for (meta in metaAnnotations) {
         if (
-          meta.annotationType.resolve().declaration.qualifiedName?.asString() ==
-            "androidx.compose.ui.tooling.preview.Preview"
+          meta.annotationType.resolve().declaration.qualifiedName?.asString() == PREVIEW_ANNOTATION
         ) {
           return true
         }
       }
     }
     return false
+  }
+
+  private fun isAccessibilityMatrixPreview(func: KSFunctionDeclaration): Boolean =
+    func.annotations.any {
+      it.annotationType.resolve().declaration.qualifiedName?.asString() ==
+        ACCESSIBILITY_MATRIX_PREVIEW
+    }
+
+  private companion object {
+    const val PREVIEW_ANNOTATION = "androidx.compose.ui.tooling.preview.Preview"
+    const val ACCESSIBILITY_MATRIX_PREVIEW =
+      "com.simtop.billionbeers.core.designsystem.component.AccessibilityMatrixPreview"
   }
 
   private fun generatePreviewProvider(functions: List<KSFunctionDeclaration>, resolver: Resolver) {
@@ -162,62 +174,118 @@ class SnapshotProcessor(
     }
   }
 
+  private fun addSnapshotsForFunction(
+    builder: CodeBlock.Builder,
+    packageName: String,
+    snapshotClass: ClassName,
+    accessibilityMatrixClass: ClassName,
+    function: KSFunctionDeclaration,
+  ) {
+    val functionName = function.simpleName.asString()
+    if (function.parameters.isEmpty()) {
+      addNoParameterSnapshots(
+        builder = builder,
+        packageName = packageName,
+        snapshotClass = snapshotClass,
+        accessibilityMatrixClass = accessibilityMatrixClass,
+        function = function,
+      )
+      return
+    }
+
+    val parameter = function.parameters.first()
+    val annotation = parameter.annotations.find { previewParameterAnnotation(it) }
+    if (annotation != null) {
+      addParameterizedSnapshots(
+        builder = builder,
+        packageName = packageName,
+        snapshotClass = snapshotClass,
+        functionName = functionName,
+        annotation = annotation,
+      )
+    }
+  }
+
+  private fun addNoParameterSnapshots(
+    builder: CodeBlock.Builder,
+    packageName: String,
+    snapshotClass: ClassName,
+    accessibilityMatrixClass: ClassName,
+    function: KSFunctionDeclaration,
+  ) {
+    val functionName = function.simpleName.asString()
+    if (isAccessibilityMatrixPreview(function)) {
+      builder.add(
+        """
+                         |    *%T.configurations.map { configuration ->
+                         |        %T("${functionName}_" + configuration.name, { %M() }, configuration)
+                         |    }.toTypedArray(),
+                         |"""
+          .trimMargin(),
+        accessibilityMatrixClass,
+        snapshotClass,
+        MemberName(packageName, functionName),
+      )
+    } else {
+      builder.add(
+        "    %T(%S, { %M() }),\n",
+        snapshotClass,
+        functionName,
+        MemberName(packageName, functionName),
+      )
+    }
+  }
+
+  private fun addParameterizedSnapshots(
+    builder: CodeBlock.Builder,
+    packageName: String,
+    snapshotClass: ClassName,
+    functionName: String,
+    annotation: KSAnnotation,
+  ) {
+    val providerType = annotation.arguments.first().value as KSType
+    val providerClassName = providerType.declaration.qualifiedName?.asString() ?: ""
+    builder.add(
+      """
+                       |    *%T().let { provider ->
+                       |        provider.values.mapIndexed { index, value ->
+                       |            val nameSuffix = (value as? Enum<*>)?.name ?: index.toString()
+                       |            %T("${functionName}_" + nameSuffix, { %M(value) })
+                       |        }.toList().toTypedArray()
+                       |    },
+                       |"""
+        .trimMargin(),
+      ClassName.bestGuess(providerClassName),
+      snapshotClass,
+      MemberName(packageName, functionName),
+    )
+  }
+
+  private fun previewParameterAnnotation(annotation: KSAnnotation): Boolean =
+    annotation.annotationType.resolve().declaration.qualifiedName?.asString() ==
+      "androidx.compose.ui.tooling.preview.PreviewParameter"
+
   private fun generateFile(
     packageName: String,
     className: String,
     functions: List<KSFunctionDeclaration>,
     sourceFile: KSFile,
   ) {
-    val snapshotClass = ClassName("com.simtop.billionbeers.snapshot_testing", "Snapshot")
-    val previewProviderInterface =
-      ClassName("com.simtop.billionbeers.snapshot_testing", "PreviewProvider")
-
+    val snapshotPackage = "com.simtop.billionbeers.snapshot_testing"
+    val snapshotClass = ClassName(snapshotPackage, "Snapshot")
+    val accessibilityMatrixClass = ClassName(snapshotPackage, "AccessibilityMatrix")
+    val previewProviderInterface = ClassName(snapshotPackage, "PreviewProvider")
     val codeBlockBuilder = CodeBlock.builder().add("listOf(\n")
 
-    functions.forEach { func ->
-      val funcName = func.simpleName.asString()
-      val parameters = func.parameters
-
-      if (parameters.isEmpty()) {
-        codeBlockBuilder.add(
-          "    %T(%S, { %M() }),\n",
-          snapshotClass,
-          "${funcName}",
-          MemberName(packageName, funcName),
-        )
-      } else {
-        // Handle PreviewParameter
-        val param = parameters.first()
-        val previewParamAnnotation =
-          param.annotations.find {
-            it.annotationType.resolve().declaration.qualifiedName?.asString() ==
-              "androidx.compose.ui.tooling.preview.PreviewParameter"
-          }
-
-        if (previewParamAnnotation != null) {
-          val providerType = previewParamAnnotation.arguments.first().value as KSType
-          val providerClassName = providerType.declaration.qualifiedName?.asString() ?: ""
-
-          val providerClass = ClassName.bestGuess(providerClassName)
-
-          codeBlockBuilder.add(
-            """
-                             |    *%T().let { provider -> 
-                             |        provider.values.mapIndexed { index, value ->
-                             |            val nameSuffix = (value as? Enum<*>)?.name ?: index.toString()
-                             |            %T("${funcName}_" + nameSuffix, { %M(value) })
-                             |        }.toList().toTypedArray()
-                             |    },
-                             |"""
-              .trimMargin(),
-            providerClass,
-            snapshotClass,
-            MemberName(packageName, funcName),
-          )
-        }
-      }
+    functions.forEach { function ->
+      addSnapshotsForFunction(
+        builder = codeBlockBuilder,
+        packageName = packageName,
+        snapshotClass = snapshotClass,
+        accessibilityMatrixClass = accessibilityMatrixClass,
+        function = function,
+      )
     }
-
     codeBlockBuilder.add(")")
 
     val propertySpec =

--- a/snapshot-testing/src/main/java/com/simtop/billionbeers/snapshot_testing/PreviewProvider.kt
+++ b/snapshot-testing/src/main/java/com/simtop/billionbeers/snapshot_testing/PreviewProvider.kt
@@ -6,4 +6,54 @@ interface PreviewProvider {
   val snapshots: List<Snapshot>
 }
 
-data class Snapshot(val name: String, val content: @Composable () -> Unit)
+data class PreviewConfiguration(
+  val name: String,
+  val theme: String,
+  val fontScale: Float,
+  val locale: String,
+  val layoutDirection: String,
+  val width: String,
+) {
+  companion object {
+    val Default = PreviewConfiguration("default", "light", 1f, "en", "ltr", "compact")
+  }
+}
+
+object AccessibilityMatrix {
+  private const val LARGE_FONT_SCALE = 1.5f
+  private const val EXTRA_LARGE_FONT_SCALE = 2f
+  private val fontScales = listOf(1f, LARGE_FONT_SCALE, EXTRA_LARGE_FONT_SCALE)
+
+  val configurations: List<PreviewConfiguration> =
+    listOf("light", "dark").flatMap { theme ->
+      fontScales.flatMap { fontScale ->
+        listOf(
+            "en" to "ltr",
+            "fr" to "ltr",
+            // Keep layout direction independent from locale so RTL goldens do not vary with
+            // locale-specific numeral shaping across Paparazzi environments.
+            "en" to "rtl",
+          )
+          .flatMap { (locale, layoutDirection) ->
+            listOf("compact", "expanded").map { width ->
+              PreviewConfiguration(
+                name =
+                  "${theme}_font${(fontScale * 100).toInt()}_${locale.replace('-', '_')}_" +
+                    "${layoutDirection}_$width",
+                theme = theme,
+                fontScale = fontScale,
+                locale = locale,
+                layoutDirection = layoutDirection,
+                width = width,
+              )
+            }
+          }
+      }
+    }
+}
+
+data class Snapshot(
+  val name: String,
+  val content: @Composable () -> Unit,
+  val configuration: PreviewConfiguration = PreviewConfiguration.Default,
+)

--- a/testing-utils-android/src/main/java/com/simtop/testing_utils_android/BaseTestRobot.kt
+++ b/testing-utils-android/src/main/java/com/simtop/testing_utils_android/BaseTestRobot.kt
@@ -1,13 +1,17 @@
 package com.simtop.testing_utils_android
 
 import androidx.annotation.StringRes
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.junit4.ComposeTestRule
@@ -96,6 +100,10 @@ open class BaseTestRobot(private val composeTestRule: ComposeTestRule) {
     composeTestRule.onNodeWithText(text).assertIsDisplayed()
   }
 
+  fun assertTextIsSelected(text: String) {
+    composeTestRule.onNodeWithText(text).assertIsSelected()
+  }
+
   fun assertNodeWithTagIsDisplayed(testTag: String) {
     composeTestRule.onNodeWithTag(testTag).assertIsDisplayed()
   }
@@ -114,6 +122,24 @@ open class BaseTestRobot(private val composeTestRule: ComposeTestRule) {
 
   fun assertNodeWithTagIsFocused(testTag: String) {
     composeTestRule.onNodeWithTag(testTag).assertIsFocused()
+  }
+
+  fun assertNodeWithTagHasRole(testTag: String, role: Role) {
+    composeTestRule
+      .onNodeWithTag(testTag)
+      .assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, role))
+  }
+
+  fun assertNodeWithTagHasStateDescription(testTag: String, description: String) {
+    composeTestRule
+      .onNodeWithTag(testTag)
+      .assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, description))
+  }
+
+  fun assertTextHasLiveRegion(text: String, mode: LiveRegionMode) {
+    composeTestRule
+      .onNodeWithText(text)
+      .assert(SemanticsMatcher.expectValue(SemanticsProperties.LiveRegion, mode))
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a real Paparazzi accessibility matrix covering light/dark, 1.0/1.5/2.0 font scales, English/French/Arabic RTL, and compact/expanded widths
- add representative long-content previews, generated environment-aware runners, and 234 screenshot goldens
- add Compose semantics assertions plus a committed TalkBack and keyboard release-QA checklist

## Verification
- make test
- make screenshot-verify
- make konsist
- make lint
- make android-lint
- make format