### PR TITLE
fix: correct activity lifecycle ordering

### DIFF
--- a/app/src/main/java/com/simtop/billionbeers/presentation/MainActivity.kt
+++ b/app/src/main/java/com/simtop/billionbeers/presentation/MainActivity.kt
@@ -32,9 +32,9 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     installSplashScreen()
+    super.onCreate(savedInstanceState)
     val appGraph = (applicationContext as BillionBeersApplication).appGraph
     splitInstallManager = appGraph.splitInstallManager
-    super.onCreate(savedInstanceState)
     enableEdgeToEdge()
     deepLinkUri = intent?.data
     setContent {


### PR DESCRIPTION
## Summary

- Call `super.onCreate(savedInstanceState)` before reading the application graph or assigning the split-install manager.
- Preserve the existing splash-first order and all app-graph, edge-to-edge, deep-link, theme, and Compose wiring.

## Verification

Passed:

- `make format`
- `make screenshot-verify`
- `make test`
- `make lint`
- `make konsist`

Device-dependent checks were attempted but could not provide reliable evidence in this environment:

- `make ui-test` encountered emulator/DDMLIB device-recognition and root-window-focus failures.
- `make benchmark-check` found no compatible benchmark device, so no physical-device startup timing is claimed.
