### PR TITLE
chore: govern design-system API and visual review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,8 @@
 # nastiest bugs came from here (ADR 0009 records both - a generated Paparazzi runner leaking into
 # androidTest, and a test runner naming a class only :app contained).
 /build-logic/                   @simtop
+/core/designsystem/             @simtop
+/catalog/                       @simtop
 /gradle/libs.versions.toml      @simtop
 
 # Supply chain: the dependency ledger and the resolved-graph baseline. A careless regeneration here

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/ComposeExtensions.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/ComposeExtensions.kt
@@ -8,6 +8,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 
+/**
+ * Clickable modifier without a visual indication.
+ *
+ * The caller remains responsible for supplying a meaningful label and role through surrounding
+ * semantics. Prefer a Material interactive component when it provides the required behavior.
+ */
 fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier = composed {
   this.clickable(
     interactionSource = remember { MutableInteractionSource() },
@@ -16,6 +22,7 @@ fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier = composed {
   )
 }
 
+/** Shows a short-lived platform toast; preview environments may not support it. */
 fun showToast(context: Context, message: String) {
   try {
     Toast.makeText(context, message, Toast.LENGTH_SHORT).show()

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/DesignAnnotations.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/DesignAnnotations.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.tooling.preview.Devices.PIXEL_FOLD
 import androidx.compose.ui.tooling.preview.Devices.PIXEL_TABLET
 import androidx.compose.ui.tooling.preview.Preview
 
+/** Generates light and dark previews for a composable. */
 @Preview(
   name = "Light Mode",
   group = "Themes",
@@ -18,18 +19,25 @@ import androidx.compose.ui.tooling.preview.Preview
   uiMode = Configuration.UI_MODE_NIGHT_YES,
   showBackground = true,
 )
+@Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.BINARY)
 annotation class PreviewLightDark
 
+/** Generates the standard font-scale previews for a composable. */
 @Preview(name = "Small Font", group = "Font Scales", fontScale = 0.85f, showBackground = true)
 @Preview(name = "Normal Font", group = "Font Scales", fontScale = 1.0f, showBackground = true)
 @Preview(name = "Large Font", group = "Font Scales", fontScale = 1.5f, showBackground = true)
 @Preview(name = "Extra Large Font", group = "Font Scales", fontScale = 2.0f, showBackground = true)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
 annotation class PreviewFontScales
 
+/** Generates representative phone, foldable, and tablet previews for a composable. */
 @Preview(name = "Phone", group = "Devices", device = PIXEL_7, showBackground = true)
 @Preview(name = "Foldable", group = "Devices", device = PIXEL_FOLD, showBackground = true)
 @Preview(name = "Tablet", group = "Devices", device = PIXEL_TABLET, showBackground = true)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.BINARY)
 annotation class PreviewDevices
 
 /**

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/DialogWithProgressBar.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/DialogWithProgressBar.kt
@@ -31,6 +31,7 @@ import com.simtop.billionbeers.catalog_annotations.CatalogComponent
 import com.simtop.billionbeers.core.designsystem.theme.BillionBeersTheme
 import kotlinx.coroutines.delay
 
+/** Configuration exposed to the catalog and consumers of [DialogWithProgressBar]. */
 data class CatalogSettings(val dismissOnClickOutside: Boolean = false)
 
 @CatalogComponent(
@@ -38,6 +39,12 @@ data class CatalogSettings(val dismissOnClickOutside: Boolean = false)
   name = "Progress Dialog",
   demoContainer = "DialogWithProgressBarDemo",
 )
+/**
+ * Displays modal progress content.
+ *
+ * This component supports loading/progress and long-text states. Disabled, selected, and error
+ * states do not apply; callers should model those states outside the progress dialog.
+ */
 @Composable
 fun DialogWithProgressBar(
   setShowDialog: (Boolean) -> Unit = {},
@@ -57,6 +64,7 @@ fun DialogWithProgressBar(
   }
 }
 
+/** Catalog-only interactive demo for [DialogWithProgressBar]. */
 @Composable
 fun DialogWithProgressBarDemo(number: Float, text: String) {
   var showDialog by remember { mutableStateOf(false) }
@@ -113,6 +121,7 @@ fun DialogWithProgressBarDemo(number: Float, text: String) {
   }
 }
 
+/** Renders the reusable progress surface used by [DialogWithProgressBar]. */
 @Composable
 fun DialogContent(number: Float, text: String, modifier: Modifier = Modifier) {
   Surface(
@@ -133,6 +142,7 @@ fun DialogContent(number: Float, text: String, modifier: Modifier = Modifier) {
   }
 }
 
+/** Preview-only progress values for the dialog's supported loading states. */
 class DialogProgressProvider : PreviewParameterProvider<Float> {
   override val values = sequenceOf(0f, 0.5f, 1f)
 }

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/ShimmerEffect.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/component/ShimmerEffect.kt
@@ -11,6 +11,12 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 
+/**
+ * Creates the loading brush used by skeleton content.
+ *
+ * The caller should apply this only to loading content and provide a non-animated state when
+ * reduced motion is required.
+ */
 @Composable
 fun shimmerBrush(showShimmer: Boolean = true, targetValue: Float = SHIMMER_TARGET_VALUE): Brush {
   return if (showShimmer) {

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/theme/Color.kt
@@ -1,5 +1,6 @@
 package com.simtop.billionbeers.core.designsystem.theme
 
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 
@@ -62,6 +63,8 @@ internal val BillionBeersDarkColors =
     onError = Error20,
   )
 
+/** Semantic color roles exposed by [BillionBeersTheme]. */
+@Immutable
 data class BillionBeersColors(
   val primary: Color,
   val onPrimary: Color,
@@ -77,4 +80,5 @@ data class BillionBeersColors(
   val onError: Color,
 )
 
+/** Composition-local override for the current semantic color roles. */
 val LocalColors = staticCompositionLocalOf { BillionBeersLightColors }

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/theme/Spacing.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/theme/Spacing.kt
@@ -5,7 +5,11 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
-/** BillionBeers Spacing Tokens Using a standard 4dp/8dp grid system. */
+/**
+ * Semantic spacing tokens for reusable design-system components.
+ *
+ * Use these roles instead of adding one-off dimensions to a governed component.
+ */
 @Immutable
 data class BillionBeersSpacing(
   val default: Dp = 0.dp,
@@ -18,4 +22,7 @@ data class BillionBeersSpacing(
   val extraHuge: Dp = 64.dp,
 )
 
+/**
+ * Composition-local override for the current spacing tokens. Prefer [BillionBeersTheme.spacing].
+ */
 val LocalSpacing = staticCompositionLocalOf { BillionBeersSpacing() }

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/theme/Theme.kt
@@ -11,8 +11,10 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 
 /**
- * BillionBeers Design System Theme wrapper. This integrates our custom tiered tokens with the
- * standard Material3 system.
+ * Applies the BillionBeers semantic tokens and maps them to the standard Material3 theme.
+ *
+ * This is the supported entry point for application and feature UI. Reusable components should read
+ * colors, spacing, and typography through [BillionBeersTheme] inside this scope.
  */
 @Composable
 fun BillionBeersTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
@@ -30,14 +32,22 @@ fun BillionBeersTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Comp
   }
 }
 
-/** Convenience object to access tokens within Composable functions. */
+/**
+ * Supported composable accessors for the BillionBeers design-system tokens.
+ *
+ * These accessors intentionally hide the underlying composition locals so consumers depend on
+ * semantic roles rather than primitive palette values.
+ */
 object BillionBeersTheme {
+  /** Current semantic spacing tokens. */
   val spacing: BillionBeersSpacing
     @Composable @ReadOnlyComposable get() = LocalSpacing.current
 
+  /** Current semantic color roles. */
   val colors: BillionBeersColors
     @Composable @ReadOnlyComposable get() = LocalColors.current
 
+  /** Current typography tokens. */
   val typography: Typography
     @Composable @ReadOnlyComposable get() = LocalTypography.current
 }

--- a/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/theme/Type.kt
+++ b/core/designsystem/src/main/java/com/simtop/billionbeers/core/designsystem/theme/Type.kt
@@ -7,7 +7,12 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-/** BillionBeers Typography Tokens Standardizing text styles across the app. */
+/**
+ * Typography tokens for reusable design-system components.
+ *
+ * Use the semantic styles exposed through [BillionBeersTheme.typography] instead of defining
+ * component-local text styles.
+ */
 val BillionBeersTypography =
   Typography(
     headlineLarge =
@@ -60,4 +65,5 @@ val BillionBeersTypography =
       ),
   )
 
+/** Composition-local override for the current typography tokens. */
 val LocalTypography = staticCompositionLocalOf { BillionBeersTypography }

--- a/docs/design-system-governance.md
+++ b/docs/design-system-governance.md
@@ -1,0 +1,108 @@
+# Design-system governance
+
+This document defines the supported surface and review contract for `:core:designsystem`. It is the
+working agreement for this repository today; it is not a promise that the module is a published
+binary library.
+
+## Ownership
+
+- `:core:designsystem` owns the theme wrapper, semantic color/spacing/typography tokens, reusable
+  components, and preview annotations.
+- `:catalog` owns the interactive catalog shell. Catalog demos remain owned by the module that
+  declares them, while `:catalog-processor` owns discovery and generated providers.
+- Changes to either surface should be reviewed as design-system changes, even when the code diff is
+  small. CODEOWNERS names the current repository owner explicitly so that ownership remains visible
+  if the catch-all rule changes.
+
+## API categories
+
+### Supported runtime API
+
+These declarations are safe for application and feature modules to consume:
+
+- `BillionBeersTheme` and its `colors`, `spacing`, and `typography` accessors;
+- semantic token value types and their composition locals when a consumer has a documented reason to
+  provide a theme override;
+- reusable components and helpers whose KDoc describes their behavior and accessibility contract.
+
+A public declaration is not automatically supported API. Before adding one, decide whether a
+consumer should be allowed to depend on it and document the decision in the declaration's KDoc.
+
+### Implementation API
+
+Primitive color values, light/dark token instances, Material color-scheme mapping, and private
+layout helpers are implementation details. Keep them `internal` or `private`; consumers should use
+semantic roles rather than raw palette values.
+
+### Preview and catalog API
+
+Preview annotations and catalog entry points are tooling APIs. They may be public because generated
+KSP code or another module needs to load them, but they are not runtime design-system components.
+Keep demo containers and preview-only providers out of the supported runtime API unless a consumer
+actually needs them.
+
+## Token governance
+
+- Add semantic roles before adding a raw color or dimension.
+- Reuse `BillionBeersTheme.colors`, `.spacing`, and `.typography` in reusable components. A raw value
+  is acceptable only when it is intrinsic to a platform/material contract or is explained in review.
+- Token changes must include the affected light/dark previews and a screenshot review. A rename or
+  removal needs a migration note and a deprecation period when an in-repository consumer exists.
+- Token value holders must remain immutable so Compose can reason about stability safely.
+- Do not enable strict explicit-API or binary-compatibility tooling solely for this internal module.
+  Revisit that decision when the design system gains an external consumer, a published artifact, or a
+  separately versioned template.
+
+## Component contract
+
+A component is governed when it is intended for reuse outside its defining source file. Its API and
+previews should make the following states explicit where the component supports them:
+
+- loading/progress;
+- error or retry;
+- disabled;
+- selected/unselected;
+- long or translated text.
+
+Not every component supports every state. The preview or KDoc should say which states do not apply
+rather than inventing fake variants. Screen-level state previews are valuable but do not replace a
+contract for a reusable design-system component.
+
+Interactive components must:
+
+- expose a meaningful label, role, and state through Compose semantics;
+- keep the complete target at least 48dp when the design system owns the interaction;
+- preserve keyboard and screen-reader activation; and
+- avoid hiding an interaction behind an unlabeled generic click helper.
+
+Screenshots prove layout and visual states. Semantics tests prove behavior. Use both when a governed
+component owns interaction; do not treat a passing screenshot as accessibility evidence.
+
+## Preview and visual review
+
+- Use the shared preview annotations in `DesignAnnotations.kt` rather than one-off copies.
+- Apply `AccessibilityMatrixPreview` to a small representative set: it expands to light/dark,
+  1.0/1.5/2.0 font scale, English/long-text locale/RTL, and compact/expanded widths.
+- Keep ordinary state previews focused. Add loading, error, disabled, selected, and long-text cases
+  only where the component supports them.
+- `make screenshot-record MODULE=:core:designsystem` updates goldens through the normal review PR.
+  `make screenshot-verify MODULE=:core:designsystem` must pass before merging visual changes.
+- The Paparazzi HTML report at
+  `core/designsystem/build/reports/paparazzi/debug/index.html` is the local/CI visual review
+  surface. CI already archives `**/build/reports/paparazzi/`; a custom gallery site is not required
+  for this module.
+
+## Deprecation and review checklist
+
+For a design-system change, reviewers should be able to answer yes to these questions:
+
+1. Is the declaration intentionally supported runtime API, implementation API, or tooling API?
+2. Does the change use semantic tokens and preserve light/dark behavior?
+3. Are the applicable component states represented by previews?
+4. Do interactive semantics, labels, roles, and minimum target sizes remain correct?
+5. Were screenshot goldens verified and the Paparazzi report inspected when visuals changed?
+6. If an API is removed or renamed, is there a migration path and a deprecation period for current
+   consumers?
+
+When the module becomes independently published or consumed by another repository, add an API dump
+or binary-compatibility check in the same change that establishes that external boundary.


### PR DESCRIPTION
## What changed

- Add a committed governance contract for the design-system API, token evolution, component states, accessibility expectations, and Paparazzi review.
- Clarify preview, catalog, runtime, and implementation API boundaries with KDoc and annotation targets.
- Mark semantic color tokens immutable and add explicit CODEOWNERS coverage for the design-system and catalog.

## Verification

- `make test`
- `make screenshot-verify MODULE=:core:designsystem`
- `make lint MODULE=:core:designsystem`
- `make format`
- `git diff --check`

No runtime behavior or screenshot goldens changed.