### PR TITLE
chore(ci): tighten dependency update automation

### DIFF
--- a/.github/scripts/check-verification-metadata-update.py
+++ b/.github/scripts/check-verification-metadata-update.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Reject unsafe changes made while Gradle writes verification metadata."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+CHECKSUM_MISMATCH = 10
+CONFIGURATION_CHANGED = 11
+INVALID_METADATA = 12
+NOT_EQUIVALENT = 13
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def canonical(element: ET.Element) -> tuple:
+    return (
+        local_name(element.tag),
+        tuple(sorted(element.attrib.items())),
+        (element.text or "").strip(),
+        tuple(canonical(child) for child in element),
+    )
+
+
+def child_named(element: ET.Element, name: str) -> ET.Element | None:
+    return next((child for child in element if local_name(child.tag) == name), None)
+
+
+def artifact_checksums(root: ET.Element) -> dict[tuple[str, str, str, str], frozenset[str]]:
+    components = child_named(root, "components")
+    if components is None:
+        raise ValueError("metadata has no <components> element")
+
+    checksums: dict[tuple[str, str, str, str], set[str]] = {}
+    for component in components:
+        if local_name(component.tag) != "component":
+            continue
+        coordinate = (
+            component.attrib.get("group", ""),
+            component.attrib.get("name", ""),
+            component.attrib.get("version", ""),
+        )
+        for artifact in component:
+            if local_name(artifact.tag) != "artifact":
+                continue
+            key = (*coordinate, artifact.attrib.get("name", ""))
+            values = checksums.setdefault(key, set())
+            for checksum in artifact:
+                if local_name(checksum.tag) != "sha256" or "value" not in checksum.attrib:
+                    continue
+                values.add(checksum.attrib["value"])
+                values.update(
+                    alternative.attrib["value"]
+                    for alternative in checksum
+                    if local_name(alternative.tag) == "also-trust"
+                    and "value" in alternative.attrib
+                )
+    return {key: frozenset(values) for key, values in checksums.items()}
+
+
+def load(path: Path) -> ET.Element:
+    try:
+        return ET.parse(path).getroot()
+    except (OSError, ET.ParseError) as error:
+        raise ValueError(f"cannot read {path}: {error}") from error
+
+
+def verify(before_path: Path, after_path: Path, require_equivalent: bool = False) -> int:
+    try:
+        before = load(before_path)
+        after = load(after_path)
+        before_configuration = child_named(before, "configuration")
+        after_configuration = child_named(after, "configuration")
+        if before_configuration is None or after_configuration is None:
+            raise ValueError("metadata has no <configuration> element")
+
+        if canonical(before_configuration) != canonical(after_configuration):
+            print(
+                "::error::Dependency-verification configuration changed during regeneration. "
+                "Review trusted-artifact policy by hand.",
+                file=sys.stderr,
+            )
+            return CONFIGURATION_CHANGED
+
+        before_checksums = artifact_checksums(before)
+        after_checksums = artifact_checksums(after)
+    except ValueError as error:
+        print(f"::error::{error}", file=sys.stderr)
+        return INVALID_METADATA
+
+    keys = set(before_checksums) | set(after_checksums) if require_equivalent else set(before_checksums)
+    changed = [
+        (key, before_checksums.get(key, frozenset()), after_checksums.get(key, frozenset()))
+        for key in sorted(keys)
+        if before_checksums.get(key, frozenset()) != after_checksums.get(key, frozenset())
+    ]
+
+    if changed:
+        if require_equivalent:
+            message = "Reference and candidate ledgers resolve different artifacts or checksums."
+            failure = NOT_EQUIVALENT
+            labels = ("reference", "candidate")
+        else:
+            message = "Regeneration changed checksums for artifacts already present in the ledger."
+            failure = CHECKSUM_MISMATCH
+            labels = ("before", "after")
+        print(f"::error::{message}", file=sys.stderr)
+        for (group, name, version, artifact), expected, actual in changed:
+            coordinate = f"{group}:{name}:{version}:{artifact}"
+            print(f"  {coordinate}", file=sys.stderr)
+            print(f"    {labels[0]}: {', '.join(sorted(expected)) or '<none>'}", file=sys.stderr)
+            print(f"    {labels[1]}: {', '.join(sorted(actual)) or '<none>'}", file=sys.stderr)
+        if not require_equivalent:
+            print(
+                "Verify the artifacts independently; do not commit the generated alternatives.",
+                file=sys.stderr,
+            )
+        return failure
+
+    if require_equivalent:
+        print(f"Verification metadata graphs are equivalent: {len(before_checksums)} artifacts.")
+    else:
+        new_artifacts = len(set(after_checksums) - set(before_checksums))
+        print(
+            f"Verification metadata update is safe: {new_artifacts} new artifact(s), "
+            "no changed hashes."
+        )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--require-equivalent",
+        action="store_true",
+        help="require both ledgers to contain exactly the same artifacts and checksums",
+    )
+    parser.add_argument("before", type=Path)
+    parser.add_argument("after", type=Path)
+    args = parser.parse_args()
+    return verify(args.before, args.after, require_equivalent=args.require_equivalent)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test_check_verification_metadata_update.py
+++ b/.github/scripts/test_check_verification_metadata_update.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("check-verification-metadata-update.py")
+SPEC = importlib.util.spec_from_file_location("verification_update", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def metadata(components: str, configuration: str = '<verify-metadata>true</verify-metadata>') -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<verification-metadata>
+  <configuration>{configuration}</configuration>
+  <components>{components}</components>
+</verification-metadata>
+"""
+
+
+def component(version: str, artifact: str, checksum: str) -> str:
+    return f"""
+    <component group="example" name="library" version="{version}">
+      <artifact name="{artifact}"><sha256 value="{checksum}"/></artifact>
+    </component>
+"""
+
+
+class VerificationMetadataUpdateTest(unittest.TestCase):
+    def verify(self, before: str, after: str) -> int:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            before_path = root / "before.xml"
+            after_path = root / "after.xml"
+            before_path.write_text(before)
+            after_path.write_text(after)
+            return MODULE.verify(before_path, after_path)
+
+    def test_allows_new_component_version(self) -> None:
+        before = metadata(component("1.0", "library-1.0.jar", "old"))
+        after = metadata(
+            component("1.0", "library-1.0.jar", "old")
+            + component("1.1", "library-1.1.jar", "new")
+        )
+        self.assertEqual(0, self.verify(before, after))
+
+    def test_rejects_alternative_checksum_for_existing_artifact(self) -> None:
+        before = metadata(component("1.0", "library-1.0.jar", "expected"))
+        after = before.replace(
+            '<sha256 value="expected"/>',
+            '<sha256 value="expected"><also-trust value="unexpected"/></sha256>',
+        )
+        self.assertEqual(MODULE.CHECKSUM_MISMATCH, self.verify(before, after))
+
+    def test_rejects_removed_existing_artifact(self) -> None:
+        before = metadata(component("1.0", "library-1.0.jar", "expected"))
+        after = metadata("")
+        self.assertEqual(MODULE.CHECKSUM_MISMATCH, self.verify(before, after))
+
+    def test_rejects_configuration_change(self) -> None:
+        before = metadata(component("1.0", "library-1.0.jar", "expected"))
+        after = metadata(
+            component("1.0", "library-1.0.jar", "expected"),
+            '<verify-metadata>false</verify-metadata>',
+        )
+        self.assertEqual(MODULE.CONFIGURATION_CHANGED, self.verify(before, after))
+
+    def test_equivalence_accepts_identical_graphs(self) -> None:
+        ledger = metadata(component("1.0", "library-1.0.jar", "expected"))
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ledger.xml"
+            path.write_text(ledger)
+            self.assertEqual(0, MODULE.verify(path, path, require_equivalent=True))
+
+    def test_equivalence_rejects_new_artifact(self) -> None:
+        before = metadata(component("1.0", "library-1.0.jar", "expected"))
+        after = metadata(
+            component("1.0", "library-1.0.jar", "expected")
+            + component("1.1", "library-1.1.jar", "new")
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            before_path = root / "reference.xml"
+            after_path = root / "candidate.xml"
+            before_path.write_text(before)
+            after_path.write_text(after)
+            self.assertEqual(
+                MODULE.NOT_EQUIVALENT,
+                MODULE.verify(before_path, after_path, require_equivalent=True),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,21 +40,6 @@ jobs:
         id: spotless-check
         run: ./gradlew spotlessCheck
 
-      # Detekt had never run in ANY workflow - it was a local-only, advisory tool, and with
-      # `ignoreFailures = true` it could not fail even there. Both halves are fixed now, so it
-      # belongs on the lane that already has Gradle set up and always runs.
-      #
-      # `success() || failure()` rather than plain ordering: a Spotless failure must not hide a
-      # Detekt failure, or fixing one just uncovers the other on the next push.
-      #
-      # Added as a step on an existing job, deliberately. "CI Gate" lists jobs, not steps, so this
-      # needs no branch-protection change (AGENTS.md: add new lanes to ci-gate needs, not to the
-      # protection rule).
-      - name: Run Detekt
-        id: detekt-check
-        if: success() || failure()
-        run: ./gradlew detekt
-
       # Lives here because this lane always runs and already has Gradle set up. Guards the one
       # verification gap CI is otherwise blind to: artifacts only Android Studio's sync resolves.
       # Without it a stale ledger is invisible until a human hits it in the IDE (ADR 0007).
@@ -88,32 +73,6 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Or trigger it manually from the Actions tab (pick this branch in the \"Run workflow\" dropdown)." >> $GITHUB_STEP_SUMMARY
-
-      # Deliberately worded differently from the Format Fix hint above. Spotless output is a
-      # mechanical transform, so "run the fixer" is always the right advice. A Detekt baseline is a
-      # suppression, so the right advice is "fix the code", and the workflow is the exception.
-      - name: Detekt Hint
-        if: always() && steps.detekt-check.outcome == 'failure'
-        run: |
-          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-          echo "### 🔍 Detekt Found New Issues" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The backlog that existed when this gate was adopted is already baselined, so a failure here means **new** findings. Fix them." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Reproduce locally:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "make lint" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "If — and only if — the finding is pre-existing or a deliberate exception, re-baseline it. **This suppresses the rule, so the diff is the review**:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "make detekt-baseline MODULE=:the:module   # locally, then commit the diff" >> $GITHUB_STEP_SUMMARY
-          echo "gh workflow run detekt_baseline.yml --ref $BRANCH_NAME   # or on the branch" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Never re-baseline to silence a finding you just introduced — that is how the gate stops working." >> $GITHUB_STEP_SUMMARY
 
   # Change-scope detector with per-lane verdict adoption. The heavy test lanes (unit / screenshot
   # / instrumented) key their `if:` off one output each. Two levels:
@@ -216,7 +175,34 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run Detekt
+        id: detekt-check
         run: make lint
+
+      # Spotless output is a mechanical transform, so its always-run lane recommends the fixer.
+      # A Detekt baseline is a suppression, so this dedicated lane recommends fixing the code and
+      # presents re-baselining only as the reviewed exception.
+      - name: Detekt Hint
+        if: always() && steps.detekt-check.outcome == 'failure'
+        run: |
+          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+          echo "### 🔍 Detekt Found New Issues" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The backlog that existed when this gate was adopted is already baselined, so a failure here means **new** findings. Fix them." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Reproduce locally:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "make lint" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "If — and only if — the finding is pre-existing or a deliberate exception, re-baseline it. **This suppresses the rule, so the diff is the review**:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "make detekt-baseline MODULE=:the:module   # locally, then commit the diff" >> $GITHUB_STEP_SUMMARY
+          echo "gh workflow run detekt_baseline.yml --ref $BRANCH_NAME   # or on the branch" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Never re-baseline to silence a finding you just introduced — that is how the gate stops working." >> $GITHUB_STEP_SUMMARY
 
   android-lint:
     name: Android Lint

--- a/.github/workflows/regen-verification-metadata.yml
+++ b/.github/workflows/regen-verification-metadata.yml
@@ -18,7 +18,25 @@ name: Regenerate Verification Metadata
 on:
   pull_request:
     branches: [main, master]
-  workflow_dispatch: {}
+    paths:
+      - 'gradle/libs.versions.toml'
+      - 'gradle/wrapper/**'
+      - 'gradle.properties'
+      - 'settings.gradle.kts'
+      - 'build.gradle.kts'
+      - '**/build.gradle.kts'
+      - 'build-logic/**'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Write the reference ledger, or upload a non-pushing experiment ledger
+        required: true
+        default: write
+        type: choice
+        options:
+          - write
+          - reference
+          - candidate
 
 # The deploy key gives push access; the token needs nothing beyond checkout.
 permissions:
@@ -47,10 +65,23 @@ jobs:
           # files and Paparazzi NPEs on them.
           lfs: true
 
+      - name: Select writer mode
+        id: mode
+        env:
+          REQUESTED_MODE: ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'write' }}
+        run: |
+          echo "value=$REQUESTED_MODE" >> "$GITHUB_OUTPUT"
+          if [ "$REQUESTED_MODE" = "candidate" ]; then
+            echo "graph=candidate" >> "$GITHUB_OUTPUT"
+          else
+            echo "graph=reference" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Skip if HEAD is already a regen commit
         id: guard
         run: |
-          if [ "$(git log -1 --pretty=%s)" = "chore: regenerate dependency verification metadata" ]; then
+          if [ "${{ steps.mode.outputs.value }}" = "write" ] \
+              && [ "$(git log -1 --pretty=%s)" = "chore: regenerate dependency verification metadata" ]; then
             echo "HEAD is this workflow's own commit - nothing new to resolve."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
@@ -93,9 +124,11 @@ jobs:
       # Gradle records checksums instead of enforcing them, so the bump's not-yet-listed
       # artifacts don't block the very resolution needed to list them.
       - name: Re-baseline dependency guard
+        id: guard_baseline
         if: steps.guard.outputs.skip != 'true'
         run: |
           cp app/dependencies/releaseRuntimeClasspath.txt "$RUNNER_TEMP/guard-before.txt"
+          cp gradle/verification-metadata.xml "$RUNNER_TEMP/verification-metadata-before.xml"
           ./gradlew --write-verification-metadata sha256 --no-configuration-cache \
             "-Dorg.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8" \
             :app:dependencyGuardBaseline
@@ -108,11 +141,13 @@ jobs:
       # new or dropped transitive dependency - the signal the guard is actually for - so that
       # stops here, red, and the auto-merge never resolves.
       - name: Fail if the bump added or removed a coordinate
+        id: coordinate_check
         if: steps.guard.outputs.skip != 'true'
         run: |
           coords() { sed 's/:[^:]*$//' "$1" | sort -u; }
           if ! delta=$(diff <(coords "$RUNNER_TEMP/guard-before.txt") \
                             <(coords app/dependencies/releaseRuntimeClasspath.txt)); then
+            echo "classification=coordinate_change" >> "$GITHUB_OUTPUT"
             echo "::error::This bump adds or removes dependency coordinates, not just versions."
             echo "$delta"
             echo
@@ -124,23 +159,175 @@ jobs:
             echo "Once the coordinate sets match again, this workflow re-runs and finishes the job."
             exit 1
           fi
+          echo "classification=version_only" >> "$GITHUB_OUTPUT"
           echo "Release classpath drift is version-only - safe to re-baseline automatically."
 
       # Strict on purpose (no continue-on-error): if the task graph fails, the bump needs a
-      # human anyway, and committing a partially-resolved ledger would only mask that.
+      # human anyway, and committing a partially-resolved ledger would only mask that. Capture the
+      # log only to classify the failure in the job summary; the original exit status still fails.
       - name: Regenerate verification metadata
+        id: regenerate
         if: steps.guard.outputs.skip != 'true'
-        run: make verification-metadata
+        run: |
+          set +e
+          make "verification-metadata-${{ steps.mode.outputs.graph }}" 2>&1 \
+            | tee "$RUNNER_TEMP/verification-metadata.log"
+          status=${PIPESTATUS[0]}
+          set -e
 
-      - name: Commit and push if the ledger changed
+          classification=success
+          if [ "$status" -ne 0 ]; then
+            if grep -Fq "is not verified because it is not listed in the verification metadata" \
+                "$RUNNER_TEMP/verification-metadata.log"; then
+              classification=unlisted_artifact
+            elif grep -Eiq "checksum.*(failed|mismatch|expected)|expected.*checksum|has been compromised" \
+                "$RUNNER_TEMP/verification-metadata.log"; then
+              classification=checksum_mismatch
+            elif [ "$status" -eq 143 ] || [ "$status" -eq 130 ] \
+                || grep -Eq "(^|[[:space:]])Terminated$" "$RUNNER_TEMP/verification-metadata.log"; then
+              classification=operational_termination
+            else
+              classification=build_test_or_policy_failure
+            fi
+          fi
+          echo "classification=$classification" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
+      # Write mode records new coordinates, but it can also append a second checksum when bytes for
+      # an already-recorded artifact change. Reject that before the generated ledger can be pushed.
+      - name: Reject changed checksums and verification policy
+        id: verify_update
         if: steps.guard.outputs.skip != 'true'
+        run: |
+          set +e
+          python3 .github/scripts/check-verification-metadata-update.py \
+            "$RUNNER_TEMP/verification-metadata-before.xml" \
+            gradle/verification-metadata.xml
+          status=$?
+          set -e
+
+          case "$status" in
+            0) classification=safe ;;
+            10) classification=checksum_mismatch ;;
+            11) classification=verification_policy_change ;;
+            *) classification=metadata_validation_failure ;;
+          esac
+          echo "classification=$classification" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
+      - name: Update generated documentation
+        id: update_docs
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.value == 'write'
+        run: make update-docs
+
+      - name: Upload experiment ledger
+        id: upload_experiment
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.value != 'write'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: verification-metadata-${{ steps.mode.outputs.value }}-${{ github.sha }}
+          path: |
+            gradle/verification-metadata.xml
+            app/dependencies/releaseRuntimeClasspath.txt
+          retention-days: 14
+
+      - name: Commit and push if generated files changed
+        id: commit
+        if: steps.guard.outputs.skip != 'true' && steps.mode.outputs.value == 'write'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add gradle/verification-metadata.xml app/dependencies/releaseRuntimeClasspath.txt
+          git add gradle/verification-metadata.xml app/dependencies/releaseRuntimeClasspath.txt README.md
           if git diff --cached --quiet; then
-            echo "Ledger already current - nothing to commit."
+            echo "result=no_diff" >> "$GITHUB_OUTPUT"
+            echo "Generated files are already current - nothing to commit."
           else
             git commit -m "chore: regenerate dependency verification metadata"
             git push
+            echo "result=pushed" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Summarize result
+        if: always()
+        env:
+          MODE: ${{ steps.mode.outputs.value }}
+          SKIPPED: ${{ steps.guard.outputs.skip }}
+          GUARD_BASELINE_OUTCOME: ${{ steps.guard_baseline.outcome }}
+          COORDINATE_OUTCOME: ${{ steps.coordinate_check.outcome }}
+          COORDINATE_CLASSIFICATION: ${{ steps.coordinate_check.outputs.classification }}
+          REGENERATE_OUTCOME: ${{ steps.regenerate.outcome }}
+          REGENERATE_CLASSIFICATION: ${{ steps.regenerate.outputs.classification }}
+          VERIFY_UPDATE_OUTCOME: ${{ steps.verify_update.outcome }}
+          VERIFY_UPDATE_CLASSIFICATION: ${{ steps.verify_update.outputs.classification }}
+          UPDATE_DOCS_OUTCOME: ${{ steps.update_docs.outcome }}
+          UPLOAD_OUTCOME: ${{ steps.upload_experiment.outcome }}
+          COMMIT_OUTCOME: ${{ steps.commit.outcome }}
+          COMMIT_RESULT: ${{ steps.commit.outputs.result }}
+        run: |
+          result="unknown failure"
+          action="Inspect the first failed step; no generated files were pushed."
+
+          if [ "$SKIPPED" = "true" ]; then
+            result="skipped: HEAD is already the workflow's regeneration commit"
+            action="No action needed."
+          elif [ "$GUARD_BASELINE_OUTCOME" = "failure" ]; then
+            result="dependency-guard re-baseline failed"
+          elif [ "$COORDINATE_CLASSIFICATION" = "coordinate_change" ]; then
+            result="rejected: dependency coordinates were added or removed"
+            action="Review the transitive graph and re-baseline manually if the change is intended."
+          elif [ "$REGENERATE_OUTCOME" = "failure" ]; then
+            case "$REGENERATE_CLASSIFICATION" in
+              unlisted_artifact)
+                result="failed: an artifact is still absent from the generated ledger"
+                action="Extend the reference task graph; do not retry blindly."
+                ;;
+              checksum_mismatch)
+                result="ALARM: a recorded artifact checksum does not match"
+                action="Verify the artifact independently. Do not regenerate over the mismatch."
+                ;;
+              operational_termination)
+                result="cancelled or terminated while resolving the reference graph"
+                action="Check the run conclusion and runner logs before deciding whether one retry is justified."
+                ;;
+              *)
+                result="failed: build, test, or policy task rejected the generated graph"
+                ;;
+            esac
+          elif [ "$VERIFY_UPDATE_OUTCOME" = "failure" ]; then
+            case "$VERIFY_UPDATE_CLASSIFICATION" in
+              checksum_mismatch)
+                result="ALARM: regeneration found changed bytes for a recorded artifact"
+                action="Verify the artifact independently. Do not commit the generated checksum."
+                ;;
+              verification_policy_change)
+                result="rejected: regeneration changed dependency-verification policy"
+                action="Review changes to trusted-artifact rules by hand."
+                ;;
+              *)
+                result="failed: generated verification metadata could not be validated"
+                ;;
+            esac
+          elif [ "$MODE" != "write" ] && [ "$UPLOAD_OUTCOME" = "failure" ]; then
+            result="the $MODE experiment completed but its ledger artifact upload failed"
+          elif [ "$MODE" != "write" ]; then
+            result="uploaded the non-pushing $MODE experiment ledger"
+            action="Run the other mode on this SHA, then compare the downloaded XML files with --require-equivalent."
+          elif [ "$UPDATE_DOCS_OUTCOME" = "failure" ]; then
+            result="README version generation failed"
+          elif [ "$COMMIT_OUTCOME" = "failure" ]; then
+            result="generated files were ready but the commit or push failed"
+          elif [ "$COMMIT_RESULT" = "pushed" ]; then
+            result="pushed regenerated ledger, dependency baseline, and README"
+            action="CI will rerun on the new PR head."
+          elif [ "$COMMIT_RESULT" = "no_diff" ]; then
+            result="completed: generated files already match the branch"
+            action="No action needed."
+          fi
+
+          {
+            echo "### Dependency verification metadata"
+            echo
+            echo "**Result:** $result"
+            echo
+            echo "**Next step:** $action"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -237,16 +237,29 @@ dependency-guard: ## Verify the app's release runtime dependency graph against i
 dependency-guard-baseline: ## Re-baseline the dependency graph after an intentional change (review the diff before committing).
 	$(GRADLE_RUNNER) :app:dependencyGuardBaseline
 
-# The task set mirrors what CI executes (ci.yml) plus assembleDebug for local builds - the ledger
-# only covers configurations a build actually resolves, so anything CI runs must be resolved here
-# or CI fails verification. Two passes on purpose, mirroring CI's separate lanes: writes merge
-# into the existing file, and combining :app:lintDebug with verifyPaparazziDebug in ONE invocation
-# trips Gradle's implicit-dependency validation on generatePaparazziTest outputs (a combination CI
-# never runs). Don't add broader tasks (e.g. root assembleDebugAndroidTest) for the same reason.
+# The task set mirrors every root-build task CI executes plus assembleDebug for local builds - the
+# ledger only covers configurations a build actually resolves, so anything CI runs must be resolved
+# here or CI fails verification. This includes the pure-JVM snapshot processor, architecture
+# classpath checks, and the standalone minified-app smoke test; naming them explicitly keeps this
+# reference graph auditable even when another task currently resolves the same artifacts.
+#
+# Two passes on purpose, mirroring CI's separate lanes: writes merge into the existing file, and
+# combining :app:lintDebug with verifyPaparazziDebug in ONE invocation trips Gradle's
+# implicit-dependency validation on generatePaparazziTest outputs (a combination CI never runs).
+# Don't add broader tasks (e.g. root assembleDebugAndroidTest) for the same reason.
+#
+# build-logic's convention tests run as a separate Gradle build (`-p build-logic`). That build has no
+# verification-metadata.xml of its own, so it is not governed by this root ledger; invoking it here
+# would execute tests without adding root-ledger coverage. ADR 0007 records that boundary.
+#
+# The reference target is the production writer. The candidate is deliberately an experiment: it
+# assembles each supported test APK without booting a device, then its cold-Linux ledger is compared
+# with the reference. Do not switch the alias until that comparison proves equivalent.
+#
 # ideSyncArtifacts is the deliberate exception to "mirrors what CI executes": it resolves what
-# Android Studio's sync needs and no build does, which the CI graph by definition cannot cover.
-# It reads the bundled Groovy version off the running distribution, so a Gradle upgrade re-records
-# the right coordinates instead of leaving the ledger pinned to the old ones (ADR 0007).
+# Android Studio's sync needs and no build does, which the CI graph by definition cannot cover. It
+# reads the bundled Groovy version off the running distribution, so a Gradle upgrade re-records the
+# right coordinates instead of leaving the ledger pinned to the old ones (ADR 0007).
 # The jvmargs override is needed because these are no-configuration-cache builds of the whole
 # graph; the default 2g heap GC-thrashes.
 # ORDER MATTERS after a dependency bump: :app:dependencyGuard below fails on a stale baseline and
@@ -254,12 +267,35 @@ dependency-guard-baseline: ## Re-baseline the dependency graph after an intentio
 # regen workflow does this automatically on Dependabot branches - ADR 0007).
 VERIFICATION_WRITE_FLAGS := --write-verification-metadata sha256 --no-configuration-cache --continue \
 	"-Dorg.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
-verification-metadata: ## Regenerate gradle/verification-metadata.xml over the full CI task graph (ADR 0007).
+VERIFICATION_METADATA_PASS_ONE := \
+	help spotlessCheck detekt :app:lintDebug :app:dependencyGuard ideSyncArtifacts
+VERIFICATION_METADATA_PASS_TWO := \
+	assembleDebug testDebugUnitTest :konsist:test :core-common:test :testing-utils:test \
+	:snapshot-processor:test checkDataLayerClasspathBoundary verifyArchitectureGraph \
+	verifyPaparazziDebug jacocoRootReport
+VERIFICATION_METADATA_REFERENCE_DEVICE_TASKS := \
+	ciGroupDebugAndroidTest :app-release-smoke:atdApi35ReleaseSmokeAndroidTest
+VERIFICATION_METADATA_CANDIDATE_DEVICE_TASKS := \
+	:app:assembleDebugAndroidTest \
+	:beer_database:assembleDebugAndroidTest \
+	:feature:beerbrowse:assembleDebugAndroidTest \
+	:feature:beerdetail:assembleDebugAndroidTest \
+	:feature:beerslist:assembleDebugAndroidTest \
+	:feature:beersearch:assembleDebugAndroidTest \
+	:app:assembleReleaseSmoke \
+	:app-release-smoke:assembleReleaseSmoke
+
+verification-metadata: verification-metadata-reference ## Regenerate verification metadata with the proven reference graph (ADR 0007).
+
+verification-metadata-reference: ## Run the complete reference metadata graph, including managed-device execution.
+	$(GRADLE_RUNNER) $(VERIFICATION_WRITE_FLAGS) $(VERIFICATION_METADATA_PASS_ONE)
 	$(GRADLE_RUNNER) $(VERIFICATION_WRITE_FLAGS) \
-		help spotlessCheck detekt :app:lintDebug :app:dependencyGuard ideSyncArtifacts
+		$(VERIFICATION_METADATA_PASS_TWO) $(VERIFICATION_METADATA_REFERENCE_DEVICE_TASKS)
+
+verification-metadata-candidate: ## Experiment: replace managed-device execution with explicit test APK assembly.
+	$(GRADLE_RUNNER) $(VERIFICATION_WRITE_FLAGS) $(VERIFICATION_METADATA_PASS_ONE)
 	$(GRADLE_RUNNER) $(VERIFICATION_WRITE_FLAGS) \
-		assembleDebug testDebugUnitTest :konsist:test :core-common:test :testing-utils:test \
-		verifyPaparazziDebug jacocoRootReport ciGroupDebugAndroidTest
+		$(VERIFICATION_METADATA_PASS_TWO) $(VERIFICATION_METADATA_CANDIDATE_DEVICE_TASKS)
 
 health: ## Generate current Markdown and JSON health reports under build/reports/health.
 	@bash scripts/health-report.sh --run --json build/reports/health/health.json build/reports/health/report.md

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
@@ -35,6 +35,9 @@ fun ManagedDevices.configureBillionBeersDevices() {
     val fastLane = localDevices.create("atdApi35") {
         device = "Pixel 6"
         sdkVersion = 35
+        // AGP 10 changes the tested-APK default to arm64-v8a. The ATD lane resolves an x86_64
+        // image on Linux, so pin the APK ABI rather than inheriting a future incompatible default.
+        testedAbi = "x86_64"
         // google_atd, not aosp_atd: the app depends on Play Core (SplitInstall) and needs the
         // Google APIs present. ATD images have Google APIs but no Play Store - fine here, since
         // dynamic features are staged by bundletool local-testing rather than fetched from Play.

--- a/build-logic/convention/src/test/kotlin/com/simtop/billionbeers/buildlogic/ConventionPluginFunctionalTest.kt
+++ b/build-logic/convention/src/test/kotlin/com/simtop/billionbeers/buildlogic/ConventionPluginFunctionalTest.kt
@@ -178,11 +178,21 @@ class ConventionPluginFunctionalTest {
         namespace = "com.simtop.conventiontest"
         compileSdk = 37
       }
+
+      tasks.register("assertManagedDeviceContract") {
+        doLast {
+          val devices = android.testOptions.managedDevices.localDevices
+          check(devices.getByName("atdApi35").testedAbi == "x86_64")
+          println("MANAGED_DEVICE_CONTRACT_OK")
+        }
+      }
       """.trimIndent(),
     )
 
-    val result = runner().withArguments("tasks", "--all", "--stacktrace").build()
+    val result =
+      runner().withArguments("assertManagedDeviceContract", "tasks", "--all", "--stacktrace").build()
 
+    assertTrue(result.output.contains("MANAGED_DEVICE_CONTRACT_OK"), result.output)
     assertTrue(result.output.contains("atdApi35Setup"))
     assertTrue(result.output.contains("pixel9Api37Setup"))
     assertTrue(result.output.contains("ciGroupDebugAndroidTest"))

--- a/docs/adr/0007-gradle-dependency-verification.md
+++ b/docs/adr/0007-gradle-dependency-verification.md
@@ -24,15 +24,19 @@ that are easy to get wrong.
    every Gradle invocation (local and CI) verifies sha256 checksums automatically from then on.
    No CI change is needed for enforcement — the file's existence is the switch.
 2. **Regenerate via `make verification-metadata`.** The target runs
-   `--write-verification-metadata sha256` **attached to the full CI task graph** (build, unit,
-   paparazzi, lint, dependency-guard, jacoco, and the GMD instrumented lane). A bare
+   `--write-verification-metadata sha256` **attached to the full root-build CI task graph**: build,
+   Android and pure-JVM unit tests, Konsist and resolved architecture checks, Paparazzi, lint,
+   dependency-guard, Jacoco, the GMD debug lane, and the standalone minified-app smoke test. A bare
    `--write-verification-metadata` invocation only runs `help` and resolves almost nothing —
    the ledger only covers configurations a build actually resolves, so the regen must execute
    what CI executes. `--no-configuration-cache` because the flag is incompatible with it.
-3. **A regen workflow keeps Dependabot auto-merge alive**
-   (`.github/workflows/regen-verification-metadata.yml`). On Dependabot PRs it regenerates the
-   ledger and pushes the diff back to the branch; CI re-runs on the new head and the existing
-   `--auto` merge gate resolves normally.
+3. **A narrowly triggered regen workflow keeps Dependabot auto-merge alive**
+   (`.github/workflows/regen-verification-metadata.yml`). On Dependabot PRs that change a Gradle
+   dependency input, it regenerates the ledger and pushes the diff back to the branch; CI re-runs
+   on the new head and the existing `--auto` merge gate resolves normally. GitHub Actions-only
+   bumps do not resolve Gradle artifacts and therefore do not pay for this workflow. A successful
+   run also executes `make update-docs` and includes the generated README version table in the same
+   commit, so a catalog bump does not need a second formatting-fix commit.
 4. **The workflow re-baselines dependency-guard first, and only for version-only drift.** See
    below — this is what makes (3) actually complete on a real bump.
 
@@ -93,10 +97,66 @@ since patch/minor Dependabot PRs auto-merge unread. The workflow therefore compa
   `./gradlew --dependency-verification off :app:dependencyGuardBaseline`, commit, push — the
   coordinate sets then match and the workflow finishes the ledger itself.
 
+### Complete task coverage is explicit
+
+The reference writer names CI tasks even when another task currently resolves the same artifacts.
+That includes `:snapshot-processor:test`, `checkDataLayerClasspathBoundary`,
+`verifyArchitectureGraph`, and `:app-release-smoke:atdApi35ReleaseSmokeAndroidTest`. The redundancy
+is deliberate: if task internals diverge later, the ledger still follows the CI contract instead of
+silently relying on incidental overlap.
+
+The convention-plugin tests are the one apparent omission. CI runs them through
+`./gradlew -p build-logic :convention:test`, which is a separate Gradle build with no
+`build-logic/gradle/verification-metadata.xml`; the root ledger does not govern that invocation.
+Executing it from this target would add runtime without adding entries to the root ledger. The
+included build is still resolved while configuring the root build, so the convention plugins needed
+by root tasks remain covered.
+
+### Resolution-only writer is an experiment, not an assumption
+
+`verification-metadata-reference` retains actual GMD and release-smoke execution and remains the
+production writer behind `make verification-metadata`. `verification-metadata-candidate` replaces
+those two executions with explicit assembly of the six opted-in debug test APKs, the minified
+`releaseSmoke` app, and its standalone test APK. It intentionally names each supported module rather
+than calling a broad root `assembleDebugAndroidTest`, which would pull unsupported benchmark or
+container variants into the graph.
+
+Manual dispatch accepts `reference` and `candidate` modes. Both regenerate on a clean Linux runner,
+run the pre-write safety check, upload the ledger and dependency-guard baseline, and never commit or
+push. After downloading artifacts from runs on the same SHA, compare them with:
+
+```bash
+python3 .github/scripts/check-verification-metadata-update.py --require-equivalent \
+  reference/verification-metadata.xml candidate/verification-metadata.xml
+```
+
+The comparison canonicalizes the verification policy and compares every component, artifact, and
+accepted checksum, including Gradle's nested `<also-trust>` alternatives. The default writer must
+not switch until cold-Linux runs are equivalent or every missing candidate artifact is understood
+and resolved by a narrowly scoped task. Assembly alone is only the first candidate; GMD/UTP tooling
+may be resolved lazily during device tasks.
+
 ### Loop termination
 
 The bot's own push re-triggers the workflow. A guard step exits early when HEAD is already the
 regen commit; even without it, the second run would produce no diff and commit nothing.
+
+### Write mode must not bless changed bytes
+
+`--write-verification-metadata` is necessary to record a bumped version, but it also changes normal
+mismatch behavior: Gradle can append the newly observed hash as an alternative instead of failing.
+The workflow therefore snapshots the ledger before its first write-mode invocation and compares it
+to the final generated XML. New components and artifacts are allowed; any checksum-set change for
+an artifact already in the snapshot is rejected before commit. The same check rejects changes to
+the `<configuration>` block, so regeneration cannot silently weaken trusted-artifact policy.
+
+### Failure classification is diagnostic, not recovery
+
+The workflow summary separates coordinate-set rejection, a still-unlisted artifact, changed bytes
+for a recorded artifact, verification-policy drift, build/test/policy failure, and an operational
+termination such as exit 143. It never retries automatically. In particular, a checksum mismatch
+remains an alarm: classification only makes the next human action clear and never writes over the
+evidence.
 
 ## Operational notes
 
@@ -178,9 +238,10 @@ regen commit; even without it, the second run would produce no diff and commit n
 
 ## Cost accepted
 
-- The regen workflow runs a full CI-sized task graph on each Dependabot PR head (monthly,
-  grouped) — roughly doubling CI cost for those PRs. That is the price of a complete ledger;
-  resolution cannot be faked without executing the resolving tasks.
+- The regen workflow runs a full CI-sized task graph on each Gradle-related Dependabot PR head
+  (monthly, grouped) — roughly doubling CI cost for those PRs. Actions-only bumps are path-filtered
+  out. The remaining cost is the price of the reference ledger until a smaller resolution graph is
+  proven equivalent; resolution coverage must not be assumed.
 - A ~1000+ line generated XML file lives in the repo and churns with every bump. Reviewers should
   treat its diffs as machine output: sanity-check *which* coordinates changed, not the hashes.
 - Verification trusts the ledger's first write (trust-on-first-resolution). It defends against


### PR DESCRIPTION
## What changed

- narrow Dependabot verification-metadata regeneration to Gradle dependency inputs, update generated README versions in the same bot commit, and add actionable failure summaries
- prevent write mode from accepting changed bytes for an already-recorded artifact or changing trusted-artifact policy
- add non-pushing reference/candidate Linux experiments for replacing managed-device execution with explicit test-APK assembly; the proven reference graph remains the production default
- remove the duplicate Detekt invocation while preserving its dedicated failing lane and remediation summary
- pin the ATD tested APK ABI to `x86_64` before AGP 10 changes the default

## Verification

- `make test`
- `make konsist`
- `make architecture-policy`
- `make lint`
- `make format`
- `./gradlew spotlessCheck --console=plain`
- metadata checker/comparison unit tests and workflow YAML contract checks
- focused convention-plugin TestKit test
- `:beer_database:atdApi35DebugAndroidTest` on Apple Silicon (6/6 passed)

Heavy-lane sharding and merge-queue activation remain follow-up work so this verified slice can land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
