### PR TITLE
chore(ci): reject inefficient test sharding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
         with:
           name: android-lint-reports
           path: '**/build/reports/lint-results-*.html'
+          retention-days: 7
 
   dependency-guard:
     name: Dependency Guard
@@ -329,6 +330,7 @@ jobs:
             **/build/test-results/
             **/build/reports/tests/
             build/reports/test-tier-inventory.md
+          retention-days: 7
 
   screenshot-tests:
     name: Screenshot Tests (Paparazzi)
@@ -373,7 +375,7 @@ jobs:
         run: |
           FAILED_MODS="${{ steps.failed-modules.outputs.modules }}"
           BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-          
+
           echo "### 📸 Screenshot Verification Failed" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "The following modules have screenshot regressions:" >> $GITHUB_STEP_SUMMARY
@@ -396,17 +398,22 @@ jobs:
         with:
           name: screenshot-failures
           path: '**/build/paparazzi/failures/'
+          retention-days: 7
 
       - name: Signal Failure
         if: always() && steps.verify-paparazzi.outcome == 'failure'
         run: exit 1
 
-      - name: Archive Screenshot Reports
+      - name: Archive screenshot test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: screenshot-test-reports
-          path: '**/build/reports/paparazzi/'
+          name: screenshot-test-results
+          # Paparazzi's HTML reporter is disabled for Gradle 9 compatibility; JUnit XML is the
+          # machine-readable evidence. The old reports/paparazzi path was empty on green runs.
+          path: '**/build/test-results/'
+          if-no-files-found: error
+          retention-days: 7
 
   # Instrumented tests on a Gradle Managed Device. Replaces the previous Flank / Firebase Test
   # Lab job, which never ran because it needed GCP credentials that were never set up. GMD runs
@@ -469,7 +476,11 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: instrumented-test-reports
-          path: '**/build/reports/androidTests/managedDevice/'
+          path: |
+            **/build/reports/androidTests/managedDevice/
+            **/build/outputs/androidTest-results/managedDevice/
+          if-no-files-found: error
+          retention-days: 7
 
   # Single aggregate gate - make THIS the only required status check in branch protection, not the
   # individual jobs. Why: a `skipped` job (secret-scan is PR-only; future path-filtered lanes will

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
@@ -30,14 +30,15 @@ import com.android.build.api.dsl.ManagedVirtualDevice
  * the shared convention - only modules with an `androidTest` source set have anything to run, and
  * applying it everywhere would generate dead tasks in every module.
  */
-fun ManagedDevices.configureBillionBeersDevices() {
+fun ManagedDevices.configureBillionBeersDevices(testedAbiForHost: String) {
     // Task names derive from the device names: `atdApi35DebugAndroidTest`, `atdApi35Setup`, ...
     val fastLane = localDevices.create("atdApi35") {
         device = "Pixel 6"
         sdkVersion = 35
-        // AGP 10 changes the tested-APK default to arm64-v8a. The ATD lane resolves an x86_64
-        // image on Linux, so pin the APK ABI rather than inheriting a future incompatible default.
-        testedAbi = "x86_64"
+        // AGP 10 changes the tested-APK default to arm64-v8a. Pin the APK to the managed image's
+        // host-native ABI: x86_64 on Linux CI, arm64-v8a on Apple Silicon. An unconditional x86_64
+        // pin makes dynamic-feature split installation fail locally with NO_MATCHING_ABIS.
+        testedAbi = testedAbiForHost
         // google_atd, not aosp_atd: the app depends on Play Core (SplitInstall) and needs the
         // Google APIs present. ATD images have Google APIs but no Play Store - fine here, since
         // dynamic features are staged by bundletool local-testing rather than fetched from Play.
@@ -74,23 +75,30 @@ fun ManagedDevices.configureBillionBeersDevices() {
     }
 }
 
+val testedAbiForHost = providers.systemProperty("os.arch").map { architecture ->
+    when (architecture) {
+        "aarch64", "arm64" -> "arm64-v8a"
+        else -> "x86_64"
+    }
+}.get()
+
 pluginManager.withPlugin("com.android.application") {
     extensions.configure<ApplicationExtension> {
-        testOptions.managedDevices.configureBillionBeersDevices()
+        testOptions.managedDevices.configureBillionBeersDevices(testedAbiForHost)
     }
 }
 pluginManager.withPlugin("com.android.library") {
     extensions.configure<LibraryExtension> {
-        testOptions.managedDevices.configureBillionBeersDevices()
+        testOptions.managedDevices.configureBillionBeersDevices(testedAbiForHost)
     }
 }
 pluginManager.withPlugin("com.android.dynamic-feature") {
     extensions.configure<DynamicFeatureExtension> {
-        testOptions.managedDevices.configureBillionBeersDevices()
+        testOptions.managedDevices.configureBillionBeersDevices(testedAbiForHost)
     }
 }
 pluginManager.withPlugin("com.android.test") {
     extensions.configure<TestExtension> {
-        testOptions.managedDevices.configureBillionBeersDevices()
+        testOptions.managedDevices.configureBillionBeersDevices(testedAbiForHost)
     }
 }

--- a/build-logic/convention/src/test/kotlin/com/simtop/billionbeers/buildlogic/ConventionPluginFunctionalTest.kt
+++ b/build-logic/convention/src/test/kotlin/com/simtop/billionbeers/buildlogic/ConventionPluginFunctionalTest.kt
@@ -166,6 +166,12 @@ class ConventionPluginFunctionalTest {
 
   @Test
   fun `managed device convention creates both device lanes and their groups`() {
+    val expectedTestedAbi =
+      when (System.getProperty("os.arch")) {
+        "aarch64", "arm64" -> "arm64-v8a"
+        else -> "x86_64"
+      }
+
     writeSettings()
     writeBuildFile(
       """
@@ -182,7 +188,7 @@ class ConventionPluginFunctionalTest {
       tasks.register("assertManagedDeviceContract") {
         doLast {
           val devices = android.testOptions.managedDevices.localDevices
-          check(devices.getByName("atdApi35").testedAbi == "x86_64")
+          check(devices.getByName("atdApi35").testedAbi == "$expectedTestedAbi")
           println("MANAGED_DEVICE_CONTRACT_OK")
         }
       }

--- a/docs/adr/0008-per-lane-ci-test-selection.md
+++ b/docs/adr/0008-per-lane-ci-test-selection.md
@@ -104,6 +104,28 @@ Costs and sharp edges worth knowing:
   *compilation* is still covered (a compile break fails whichever lane re-runs); shared *behaviour*
   is not.
 
+## Rejected: two-way screenshot sharding
+
+PR #200 evaluated a static two-runner split over all seven modules and 273 goldens. Stable aggregate
+semantics worked, and both assignments were already balanced:
+
+| Run | `browse-detail` | `design-list-search` | Lane wall clock | Total job work |
+|---|---:|---:|---:|---:|
+| `33597137353` | 4m15s | 4m28s | 4m34s | 8m47s |
+| `33598554628` | 4m22s | 4m15s | 4m30s | 8m42s |
+
+Against the ten-run `master` median of 5m18s, the candidate median improved wall clock by only about
+14.5% while increasing runner work by about 65%. That misses both experiment thresholds (20% faster,
+less than 50% more work). A greedy module repartition cannot fix this: the existing shards differed
+by only 13 seconds and then 7 seconds; duplicated checkout, JDK/Gradle setup, LFS, and shared
+compilation are the cost. Keep one screenshot job unless the module graph or runner setup changes
+materially.
+
+The experiment also exposed a pre-existing empty artifact: Paparazzi's HTML reporter is disabled for
+Gradle 9 compatibility, so `build/reports/paparazzi` contains no files on a green run. CI now archives
+the JUnit XML under `build/test-results` instead. Screenshot failures remain separate PNG artifacts
+whose filenames identify the failed snapshot configuration.
+
 ## Rejected: walking back more than one run
 
 When the previous run was cancelled or is still in flight, its lanes are untrusted and re-run. The

--- a/docs/adr/0009-feature-module-ui-test-tier.md
+++ b/docs/adr/0009-feature-module-ui-test-tier.md
@@ -106,24 +106,50 @@ the tier costs ~2s, while one more *module* costs ~49s: a factor of about 27.
 modules deliberately.** Two tests each across six feature modules would spend ~300s of overhead to
 run twelve tests worth ~23s.
 
-**Dynamic features cannot use the tier.** `:feature:beerdetail` and `:feature:beerbrowse` are
-on-demand modules, and invariant 5 exists because resources declared inside them crash instrumented
-tests — a failure this project has hit twice. Their UI coverage stays in `:app`, where the install
-gate lives anyway. This hole is permanent unless the dynamic-feature resource problem is solved.
+**Dynamic features now use the tier without owning user-facing resources.**
+`:feature:beerdetail` and `:feature:beerbrowse` have module-local screen tests, while invariant 5
+keeps the strings those tests need in `:presentation_utils`. The resource boundary, not dynamic
+feature status itself, was the constraint. Cross-feature navigation and split-install behaviour
+still stay in `:app`.
+
+**The six-module threshold for CI sharding was reached and evaluated, but the two-way matrix was
+rejected.** PR #200 tested this split:
+
+- `integration`: `:app`, `:feature:beerbrowse`, `:feature:beerdetail`, and the standalone
+  `:app-release-smoke` release task;
+- `standalone`: `:beer_database`, `:feature:beerslist`, and `:feature:beersearch`.
+
+Stable aggregate semantics and report coverage worked, but performance did not:
+
+| Run | `integration` | `standalone` | Lane wall clock | Total job work |
+|---|---:|---:|---:|---:|
+| `33597137353` | 11m54s | 6m37s | 11m59s | 18m34s |
+| `33598554628` | 10m33s | 6m27s | 10m38s | 17m03s |
+
+Against the ten-run `master` median of 9m36s, the candidate median was about 17.8% slower and used
+about 85.5% more runner time. Reassigning modules cannot remove the duplicated fixed costs; moving a
+dynamic feature would also duplicate more app assembly, while moving release smoke trades shared
+build outputs for nominal balance. Keep one job running `ciGroupDebugAndroidTest` followed by release
+smoke.
+
+The single instrumented artifact includes both the HTML report and raw managed-device JUnit/logcat
+outputs. Those paths preserve the owning module, and failed test cases retain their class and method,
+so a failure is diagnosable without a matrix.
 
 ## When to revisit
 
-- **Sharding the GMD group across matrix runners** becomes worth it at roughly five or six opted-in
-  modules. Below that, per-shard fixed cost (checkout, Gradle setup, emulator boot) exceeds the
-  serial device work it would parallelise — at three modules that work is ~161s total.
-- **If the dynamic-feature resource crash is ever fixed**, `beerdetail` and `beerbrowse` become
-  candidates and the `:app` integration tier shrinks.
+- Reconsider sharding only after the fixed setup/device cost falls materially or the module graph
+  grows enough that execution dominates it. Profile by task before choosing a new split.
+- If another module joins the tier, its managed-device convention opt-in automatically adds it to
+  `ciGroupDebugAndroidTest`; no CI task list should duplicate that ownership.
 
 ## Note on measuring any of this
 
-Do not evaluate a change to the instrumented lane by comparing CI run durations. Across 19 master
-runs every lane correlates r = 0.93–0.99 with Detekt, which no test change can affect: a lane's
-duration is mostly which runner the run drew. The instrumented baseline is a 3m42s median with a
-65s standard deviation and a 3m05s–7m21s range, so detecting a ~50s change needs about ten runs per
-side, and normalising against the unaffected lanes only gets that to six. Profile locally
-(`--profile --rerun`) instead — that is where the numbers above come from.
+Do not use one or two hosted runs to claim a small speedup. Earlier measurements found every lane
+correlating r = 0.93–0.99 with Detekt, which no test change can affect: runner allocation dominates
+normal variance. A performance claim still needs about ten runs per side, or six when normalized
+against unaffected lanes, plus local `--profile --rerun` evidence.
+
+The rejected matrix did not depend on a precise small regression estimate: neither candidate run beat
+the existing median, and duplicating the job increased measured runner work by roughly 85%. That is a
+stop condition even before a larger sample.


### PR DESCRIPTION
## Summary

- evaluate two-way Paparazzi and managed-device sharding through two complete live CI runs, preserving stable verdict-adoption and `CI Gate` behavior during the experiment
- reject both matrices because they miss the recorded performance thresholds: screenshot runner work grew about 65%, while instrumented wall time regressed and runner work grew about 85.5%
- keep the single-job lanes and record the measured decision in ADRs 0008 and 0009
- replace the empty Paparazzi HTML artifact with JUnit results, include raw managed-device JUnit/logcat outputs, retain CI artifacts for seven days, and select the tested APK ABI from the host architecture

## Evidence

- runs `33597137353` and `33598554628` completed with both candidate matrices and stable aggregate checks green
- screenshot shards were already balanced within 13 seconds and then 7 seconds, so a greedy repartition cannot recover the duplicated setup cost
- managed-device integration remained substantially heavier than standalone; moving work would duplicate app/release assembly without fixing total runner cost
- local repository gates and both explicit candidate task sets passed before the live experiment
