### PR TITLE
chore(ci): archive rejected heavy-lane sharding experiment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -330,10 +330,29 @@ jobs:
             **/build/reports/tests/
             build/reports/test-tier-inventory.md
 
-  screenshot-tests:
-    name: Screenshot Tests (Paparazzi)
+  # Two profile-balanced Paparazzi shards cut the lane's wall clock while preserving one stable
+  # aggregate name for verdict adoption and CI Gate. Keep the explicit task union aligned with every
+  # module applying billionbeers.android.screenshot; the local make target remains unsharded.
+  screenshot_test_shards:
+    name: Screenshot Test Shard (${{ matrix.shard }})
     needs: [format-check, changes]
     if: needs.changes.outputs.screenshot == 'true'
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include:
+          - shard: browse-detail
+            tasks: >-
+              :feature:beerbrowse:verifyPaparazziDebug
+              :feature:beerdetail:verifyPaparazziDebug
+              :catalog:verifyPaparazziDebug
+          - shard: design-list-search
+            tasks: >-
+              :core:designsystem:verifyPaparazziDebug
+              :feature:beersearch:verifyPaparazziDebug
+              :feature:beerslist:verifyPaparazziDebug
+              :presentation_utils:verifyPaparazziDebug
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -355,68 +374,115 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x gradlew
 
-      - name: Verify Screenshot Tests
+      - name: Verify screenshot shard
         id: verify-paparazzi
-        run: make screenshot-verify
+        run: ./gradlew ${{ matrix.tasks }} --continue
         continue-on-error: true
 
-      - name: Identify Failed Modules
+      - name: Identify failed modules
         if: always() && steps.verify-paparazzi.outcome == 'failure'
         id: failed-modules
         run: |
           FAILED_MODS=$(find . -name "failures" -type d -path "*/build/paparazzi/failures" | sed 's|^./||' | sed 's|/build/paparazzi/failures||' | sed 's|/|:|g' | sed 's|^|:|' | xargs | tr ',' ' ')
-          echo "modules=$FAILED_MODS" >> $GITHUB_OUTPUT
-          echo "Failed modules detected: $FAILED_MODS"
+          echo "modules=$FAILED_MODS" >> "$GITHUB_OUTPUT"
+          echo "Failed modules detected in ${{ matrix.shard }}: $FAILED_MODS"
 
-      - name: Generate Screenshot Failure Report
-        if: always() && steps.verify-paparazzi.outcome == 'failure'
+      - name: Summarize screenshot shard
+        if: always()
         run: |
-          FAILED_MODS="${{ steps.failed-modules.outputs.modules }}"
-          BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
-          
-          echo "### 📸 Screenshot Verification Failed" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The following modules have screenshot regressions:" >> $GITHUB_STEP_SUMMARY
-          for mod in $FAILED_MODS; do
-            echo "- \`$mod\`" >> $GITHUB_STEP_SUMMARY
-          done
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "#### 🛠️ How to fix" >> $GITHUB_STEP_SUMMARY
-          echo "To update the screenshots for these modules, you can trigger the recording workflow:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "gh workflow run record_screenshots.yml --ref $BRANCH_NAME -f modules=\"$FAILED_MODS\"" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Alternatively, you can manually check the failure diffs in the artifacts below. ⬇️" >> $GITHUB_STEP_SUMMARY
+          echo "### 📸 Screenshot shard: ${{ matrix.shard }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tasks: \`${{ matrix.tasks }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Outcome: **${{ steps.verify-paparazzi.outcome }}**" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.verify-paparazzi.outcome }}" = "failure" ]; then
+            FAILED_MODS="${{ steps.failed-modules.outputs.modules }}"
+            BRANCH_NAME="${{ github.head_ref || github.ref_name }}"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Failed modules:" >> "$GITHUB_STEP_SUMMARY"
+            for mod in $FAILED_MODS; do
+              echo "- \`$mod\`" >> "$GITHUB_STEP_SUMMARY"
+            done
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Record only this shard's failures with:" >> "$GITHUB_STEP_SUMMARY"
+            echo "\`gh workflow run record_screenshots.yml --ref $BRANCH_NAME -f modules=\"$FAILED_MODS\"\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
-      - name: Upload Screenshot Failures
+      - name: Upload screenshot failures
         if: always() && steps.verify-paparazzi.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: screenshot-failures
+          name: screenshot-failures-${{ matrix.shard }}
           path: '**/build/paparazzi/failures/'
 
-      - name: Signal Failure
-        if: always() && steps.verify-paparazzi.outcome == 'failure'
-        run: exit 1
-
-      - name: Archive Screenshot Reports
+      - name: Archive screenshot test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: screenshot-test-reports
-          path: '**/build/reports/paparazzi/'
+          name: screenshot-test-results-${{ matrix.shard }}
+          path: '**/build/test-results/'
+          if-no-files-found: error
 
-  # Instrumented tests on a Gradle Managed Device. Replaces the previous Flank / Firebase Test
-  # Lab job, which never ran because it needed GCP credentials that were never set up. GMD runs
-  # the emulator on the runner itself via KVM - free, no cloud account, and the device spec lives
-  # in build-logic so CI and local runs are identical. Firebase Test Lab remains the right answer
-  # only for a *physical* device matrix, which this project does not need.
-  instrumented-tests:
-    name: Instrumented Tests (Gradle Managed Device)
+      - name: Signal screenshot failure
+        if: always() && steps.verify-paparazzi.outcome == 'failure'
+        run: exit 1
+
+  screenshot-tests:
+    name: Screenshot Tests (Paparazzi)
+    needs: [changes, screenshot_test_shards]
+    if: always() && needs.changes.result == 'success' && needs.changes.outputs.screenshot == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize screenshot shards
+        run: |
+          echo "### 📸 Screenshot shards" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Matrix result: **${{ needs.screenshot_test_shards.result }}**" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download screenshot failures
+        id: download-failures
+        if: needs.screenshot_test_shards.result != 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: screenshot-failures-*
+          path: /tmp/screenshot-failures
+          merge-multiple: true
+
+      - name: List failed screenshot modules
+        if: steps.download-failures.outcome == 'success'
+        run: |
+          FAILED_MODS=$(find /tmp/screenshot-failures -name "failures" -type d -path "*/build/paparazzi/failures" | sed 's|^/tmp/screenshot-failures/||' | sed 's|/build/paparazzi/failures||' | sed 's|/|:|g' | sed 's|^|:|' | sort -u | xargs)
+          if [ -n "$FAILED_MODS" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Failed modules: \`$FAILED_MODS\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Fail if a screenshot shard failed or was cancelled
+        if: needs.screenshot_test_shards.result != 'success'
+        run: exit 1
+
+  # GMD runs on the runner through KVM. CI splits the seven owned test tasks across two runners;
+  # local ciGroupDebugAndroidTest stays the single source of truth for the six debug modules.
+  instrumented_test_shards:
+    name: Instrumented Test Shard (${{ matrix.shard }})
     needs: [format-check, changes]
     if: needs.changes.outputs.instrumented == 'true'
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        include:
+          - shard: integration
+            tasks: >-
+              :app:atdApi35DebugAndroidTest
+              :feature:beerbrowse:atdApi35DebugAndroidTest
+              :feature:beerdetail:atdApi35DebugAndroidTest
+              :app-release-smoke:atdApi35ReleaseSmokeAndroidTest
+          - shard: standalone
+            tasks: >-
+              :beer_database:atdApi35DebugAndroidTest
+              :feature:beerslist:atdApi35DebugAndroidTest
+              :feature:beersearch:atdApi35DebugAndroidTest
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -453,23 +519,41 @@ jobs:
       # `system-images` cache - a correct re-introduction has to capture the whole SDK/AVD state
       # (licenses + package registry + the created AVD), and must be proven on a live CI run.
 
-      - name: Run instrumented tests on the managed devices
-        # The `ci` group is the ATD fast lane. The slower API 37 lane is the `compat` group and
-        # runs weekly (.github/workflows/weekly-compat.yml). Which devices those mean is defined
-        # in build-logic, not here.
-        run: ./gradlew ciGroupDebugAndroidTest
+      - name: Run instrumented shard
+        run: ./gradlew ${{ matrix.tasks }}
 
-      # Debug UI tests prove screen behavior; this black-box lane proves the minified target launches
-      # and shows its production activity without requiring a Play signing identity.
-      - name: Run minified release launch smoke test
-        run: ./gradlew :app-release-smoke:atdApi35ReleaseSmokeAndroidTest
+      - name: Summarize instrumented shard
+        if: always()
+        run: |
+          echo "### 🤖 Instrumented shard: ${{ matrix.shard }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Tasks: \`${{ matrix.tasks }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "Job status: **${{ job.status }}**" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Archive instrumented test reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: instrumented-test-reports
-          path: '**/build/reports/androidTests/managedDevice/'
+          name: instrumented-test-reports-${{ matrix.shard }}
+          path: |
+            **/build/reports/androidTests/managedDevice/
+            **/build/outputs/androidTest-results/managedDevice/
+
+  instrumented-tests:
+    name: Instrumented Tests (Gradle Managed Device)
+    needs: [changes, instrumented_test_shards]
+    if: always() && needs.changes.result == 'success' && needs.changes.outputs.instrumented == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize instrumented shards
+        run: |
+          echo "### 🤖 Instrumented shards" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Matrix result: **${{ needs.instrumented_test_shards.result }}**" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Fail if an instrumented shard failed or was cancelled
+        if: needs.instrumented_test_shards.result != 'success'
+        run: exit 1
 
   # Single aggregate gate - make THIS the only required status check in branch protection, not the
   # individual jobs. Why: a `skipped` job (secret-scan is PR-only; future path-filtered lanes will

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
         with:
           name: android-lint-reports
           path: '**/build/reports/lint-results-*.html'
+          retention-days: 7
 
   dependency-guard:
     name: Dependency Guard
@@ -329,6 +330,7 @@ jobs:
             **/build/test-results/
             **/build/reports/tests/
             build/reports/test-tier-inventory.md
+          retention-days: 7
 
   # Two profile-balanced Paparazzi shards cut the lane's wall clock while preserving one stable
   # aggregate name for verdict adoption and CI Gate. Keep the explicit task union aligned with every
@@ -413,6 +415,7 @@ jobs:
         with:
           name: screenshot-failures-${{ matrix.shard }}
           path: '**/build/paparazzi/failures/'
+          retention-days: 7
 
       - name: Archive screenshot test results
         if: always()
@@ -421,6 +424,7 @@ jobs:
           name: screenshot-test-results-${{ matrix.shard }}
           path: '**/build/test-results/'
           if-no-files-found: error
+          retention-days: 7
 
       - name: Signal screenshot failure
         if: always() && steps.verify-paparazzi.outcome == 'failure'
@@ -538,6 +542,7 @@ jobs:
           path: |
             **/build/reports/androidTests/managedDevice/
             **/build/outputs/androidTest-results/managedDevice/
+          retention-days: 7
 
   instrumented-tests:
     name: Instrumented Tests (Gradle Managed Device)

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
@@ -30,14 +30,15 @@ import com.android.build.api.dsl.ManagedVirtualDevice
  * the shared convention - only modules with an `androidTest` source set have anything to run, and
  * applying it everywhere would generate dead tasks in every module.
  */
-fun ManagedDevices.configureBillionBeersDevices() {
+fun ManagedDevices.configureBillionBeersDevices(testedAbiForHost: String) {
     // Task names derive from the device names: `atdApi35DebugAndroidTest`, `atdApi35Setup`, ...
     val fastLane = localDevices.create("atdApi35") {
         device = "Pixel 6"
         sdkVersion = 35
-        // AGP 10 changes the tested-APK default to arm64-v8a. The ATD lane resolves an x86_64
-        // image on Linux, so pin the APK ABI rather than inheriting a future incompatible default.
-        testedAbi = "x86_64"
+        // AGP 10 changes the tested-APK default to arm64-v8a. Pin the APK to the managed image's
+        // host-native ABI: x86_64 on Linux CI, arm64-v8a on Apple Silicon. An unconditional x86_64
+        // pin makes dynamic-feature split installation fail locally with NO_MATCHING_ABIS.
+        testedAbi = testedAbiForHost
         // google_atd, not aosp_atd: the app depends on Play Core (SplitInstall) and needs the
         // Google APIs present. ATD images have Google APIs but no Play Store - fine here, since
         // dynamic features are staged by bundletool local-testing rather than fetched from Play.
@@ -74,23 +75,30 @@ fun ManagedDevices.configureBillionBeersDevices() {
     }
 }
 
+val testedAbiForHost = providers.systemProperty("os.arch").map { architecture ->
+    when (architecture) {
+        "aarch64", "arm64" -> "arm64-v8a"
+        else -> "x86_64"
+    }
+}.get()
+
 pluginManager.withPlugin("com.android.application") {
     extensions.configure<ApplicationExtension> {
-        testOptions.managedDevices.configureBillionBeersDevices()
+        testOptions.managedDevices.configureBillionBeersDevices(testedAbiForHost)
     }
 }
 pluginManager.withPlugin("com.android.library") {
     extensions.configure<LibraryExtension> {
-        testOptions.managedDevices.configureBillionBeersDevices()
+        testOptions.managedDevices.configureBillionBeersDevices(testedAbiForHost)
     }
 }
 pluginManager.withPlugin("com.android.dynamic-feature") {
     extensions.configure<DynamicFeatureExtension> {
-        testOptions.managedDevices.configureBillionBeersDevices()
+        testOptions.managedDevices.configureBillionBeersDevices(testedAbiForHost)
     }
 }
 pluginManager.withPlugin("com.android.test") {
     extensions.configure<TestExtension> {
-        testOptions.managedDevices.configureBillionBeersDevices()
+        testOptions.managedDevices.configureBillionBeersDevices(testedAbiForHost)
     }
 }

--- a/build-logic/convention/src/test/kotlin/com/simtop/billionbeers/buildlogic/ConventionPluginFunctionalTest.kt
+++ b/build-logic/convention/src/test/kotlin/com/simtop/billionbeers/buildlogic/ConventionPluginFunctionalTest.kt
@@ -166,6 +166,12 @@ class ConventionPluginFunctionalTest {
 
   @Test
   fun `managed device convention creates both device lanes and their groups`() {
+    val expectedTestedAbi =
+      when (System.getProperty("os.arch")) {
+        "aarch64", "arm64" -> "arm64-v8a"
+        else -> "x86_64"
+      }
+
     writeSettings()
     writeBuildFile(
       """
@@ -182,7 +188,7 @@ class ConventionPluginFunctionalTest {
       tasks.register("assertManagedDeviceContract") {
         doLast {
           val devices = android.testOptions.managedDevices.localDevices
-          check(devices.getByName("atdApi35").testedAbi == "x86_64")
+          check(devices.getByName("atdApi35").testedAbi == "$expectedTestedAbi")
           println("MANAGED_DEVICE_CONTRACT_OK")
         }
       }

--- a/docs/adr/0008-per-lane-ci-test-selection.md
+++ b/docs/adr/0008-per-lane-ci-test-selection.md
@@ -81,6 +81,31 @@ the orphaned commit is never fetched), no or unreadable previous run, a non-nume
 renamed job, and a previous run still in flight all run the full suite. Skipping a real test is the
 costly mistake; an extra run is minutes.
 
+### 6. Shards execute behind stable aggregate jobs
+
+The screenshot and instrumented lanes each use a static two-entry matrix, but verdict adoption and
+`CI Gate` depend only on stable aggregate jobs:
+
+- `screenshot-tests` / `Screenshot Tests (Paparazzi)` wraps `screenshot_test_shards`;
+- `instrumented-tests` / `Instrumented Tests (Gradle Managed Device)` wraps
+  `instrumented_test_shards`.
+
+Matrix executor names include their shard and therefore are not a durable status-check contract.
+Each aggregate is skipped when the classifier says its lane is unaffected, succeeds only when the
+whole matrix succeeds, and fails if any shard fails or is cancelled. This preserves the induction
+rule for an adopted `skipped` verdict while letting shard count and assignments change without
+renaming the checks looked up by `detect-change-scope.sh`.
+
+The Paparazzi split is explicit and exhaustive over the seven screenshot modules:
+
+- `browse-detail`: `:feature:beerbrowse`, `:feature:beerdetail`, `:catalog`;
+- `design-list-search`: `:core:designsystem`, `:feature:beersearch`,
+  `:feature:beerslist`, `:presentation_utils`.
+
+Each shard uploads uniquely named JUnit results and failures. The aggregate downloads the available
+failure artifacts to report their module paths; it never assumes one runner can inspect another
+runner's filesystem. The local `make screenshot-verify` command remains unsharded.
+
 ## Consequences
 
 Validated live rather than by argument. A docs-only push skipped all three lanes with the gate

--- a/docs/adr/0009-feature-module-ui-test-tier.md
+++ b/docs/adr/0009-feature-module-ui-test-tier.md
@@ -106,18 +106,30 @@ the tier costs ~2s, while one more *module* costs ~49s: a factor of about 27.
 modules deliberately.** Two tests each across six feature modules would spend ~300s of overhead to
 run twelve tests worth ~23s.
 
-**Dynamic features cannot use the tier.** `:feature:beerdetail` and `:feature:beerbrowse` are
-on-demand modules, and invariant 5 exists because resources declared inside them crash instrumented
-tests — a failure this project has hit twice. Their UI coverage stays in `:app`, where the install
-gate lives anyway. This hole is permanent unless the dynamic-feature resource problem is solved.
+**Dynamic features now use the tier without owning user-facing resources.**
+`:feature:beerdetail` and `:feature:beerbrowse` have module-local screen tests, while invariant 5
+keeps the strings those tests need in `:presentation_utils`. The resource boundary, not dynamic
+feature status itself, was the constraint. Cross-feature navigation and split-install behaviour
+still stay in `:app`.
+
+**The six-module threshold for CI sharding has been reached.** CI runs two static GMD shards:
+
+- `integration`: `:app`, `:feature:beerbrowse`, `:feature:beerdetail`, and the standalone
+  `:app-release-smoke` release task;
+- `standalone`: `:beer_database`, `:feature:beerslist`, and `:feature:beersearch`.
+
+A stable `instrumented-tests` aggregate fails on any failed or cancelled shard and remains the only
+instrumented dependency of `CI Gate`. This is CI orchestration only: local
+`ciGroupDebugAndroidTest` remains the complete six-module debug command, and release smoke remains a
+separate local target.
 
 ## When to revisit
 
-- **Sharding the GMD group across matrix runners** becomes worth it at roughly five or six opted-in
-  modules. Below that, per-shard fixed cost (checkout, Gradle setup, emulator boot) exceeds the
-  serial device work it would parallelise — at three modules that work is ~161s total.
-- **If the dynamic-feature resource crash is ever fixed**, `beerdetail` and `beerbrowse` become
-  candidates and the `:app` integration tier shrinks.
+- Rebalance or remove the two-way matrix if representative CI measurements no longer clear its
+  wall-clock benefit or runner-minute cost becomes disproportionate. Correct task/report coverage
+  takes precedence over the speedup.
+- If another module joins the tier, add its task to both `ciGroupDebugAndroidTest` through the
+  managed-device convention and exactly one CI shard in the same change.
 
 ## Note on measuring any of this
 

--- a/docs/heavy-lane-sharding-experiment.md
+++ b/docs/heavy-lane-sharding-experiment.md
@@ -1,0 +1,90 @@
+# Heavy CI lane sharding experiment
+
+> Experiment archive only. This branch and pull request are deliberately not intended to merge.
+> Production keeps the single screenshot and managed-device jobs because the candidate missed its
+> performance thresholds.
+
+## What this branch preserves
+
+This branch is the exact two-way matrix topology exercised by GitHub Actions runs `33597137353` and
+`33598554628`, plus a seven-day retention policy for its reports:
+
+- static matrices with `fail-fast: false` and `max-parallel: 2`;
+- stable aggregate job IDs and names consumed by verdict adoption and `CI Gate`;
+- exhaustive explicit task assignment for seven Paparazzi modules / 273 goldens;
+- exhaustive explicit task assignment for six managed-device debug modules plus release smoke;
+- per-shard JUnit, screenshot-failure, managed-device HTML/JUnit/logcat artifacts;
+- host-native tested APK ABI (`x86_64` on Linux CI, `arm64-v8a` on Apple Silicon).
+
+Local commands remain unsharded. The matrices are CI orchestration only.
+
+## Screenshot topology
+
+| Shard | Tasks | Goldens |
+|---|---|---:|
+| `browse-detail` | `:feature:beerbrowse`, `:feature:beerdetail`, `:catalog` | 125 |
+| `design-list-search` | `:core:designsystem`, `:feature:beersearch`, `:feature:beerslist`, `:presentation_utils` | 148 |
+
+The stable aggregate is `screenshot-tests` / `Screenshot Tests (Paparazzi)`.
+
+| Run | `browse-detail` | `design-list-search` | Lane wall clock | Total job work |
+|---|---:|---:|---:|---:|
+| `33597137353` | 4m15s | 4m28s | 4m34s | 8m47s |
+| `33598554628` | 4m22s | 4m15s | 4m30s | 8m42s |
+
+Against the ten-run `master` median of 5m18s, candidate median wall clock improved about 14.5% while
+runner work increased about 65%. The default keep thresholds were at least 20% faster and less than
+50% additional work.
+
+The assignments were already within 13 seconds and then 7 seconds. A greedy repartition cannot fix
+the duplicated checkout, LFS, JDK/Gradle setup, and shared compilation cost.
+
+## Managed-device topology
+
+| Shard | Tasks |
+|---|---|
+| `integration` | `:app`, `:feature:beerbrowse`, `:feature:beerdetail`, `:app-release-smoke` |
+| `standalone` | `:beer_database`, `:feature:beerslist`, `:feature:beersearch` |
+
+The stable aggregate is `instrumented-tests` / `Instrumented Tests (Gradle Managed Device)`.
+
+| Run | `integration` | `standalone` | Lane wall clock | Total job work |
+|---|---:|---:|---:|---:|
+| `33597137353` | 11m54s | 6m37s | 11m59s | 18m34s |
+| `33598554628` | 10m33s | 6m27s | 10m38s | 17m03s |
+
+Against the ten-run `master` median of 9m36s, candidate median wall clock was about 17.8% slower and
+runner work increased about 85.5%.
+
+A basic greedy algorithm is not valid for these tasks because their costs are not independent:
+feature tasks share app assembly, while release smoke shares release/app outputs on the integration
+runner. Moving work to equalize visible durations can duplicate more of the graph.
+
+## Failure visibility
+
+- Each screenshot shard summary identifies failed modules.
+- `screenshot-failures-<shard>` preserves failure/delta PNGs whose names include the exact snapshot
+  or generated preview configuration.
+- `screenshot-test-results-<shard>` preserves JUnit class/method results.
+- `instrumented-test-reports-<shard>` preserves module-rooted HTML, JUnit, test logs, and per-test
+  logcat files.
+- The aggregate propagates failed/cancelled matrix conclusions; `CI Gate` still depends only on the
+  stable aggregate.
+
+All artifacts expire after seven days.
+
+## Reusing this experiment
+
+Before retrying:
+
+1. rebase this branch's workflow topology onto current `master`;
+2. regenerate the task-union checks from repository source trees/convention application;
+3. profile incremental cost inside the proposed shard graph rather than sorting independent task
+   durations blindly;
+4. run at least ten representative samples, or six normalized samples;
+5. keep only if wall-clock and runner-work thresholds both pass;
+6. deliberately fail one task in each matrix and cancel one shard to re-prove aggregate and artifact
+   behavior.
+
+Do not use this branch as precedent for unit-test sharding. That lane needs a JaCoCo artifact-merge
+design and a mutation proving incomplete coverage cannot remain green.


### PR DESCRIPTION
## Experiment archive — do not merge

This pull request preserves the exact two-way Paparazzi and managed-device matrix implementation measured in Actions runs `33597137353` and `33598554628`. It is intentionally left open as reusable evidence and should be closed rather than merged.

## What it preserves

- explicit, exhaustive screenshot and managed-device shard task sets
- stable aggregate checks for verdict adoption and `CI Gate`
- host-native tested APK ABI selection
- per-shard JUnit, screenshot-failure, managed-device HTML/JUnit/logcat artifacts
- seven-day artifact retention
- a self-contained record of the topology, measurements, failure visibility, rejection, and reuse criteria

## Result

- screenshot wall clock improved about 14.5%, but total runner work increased about 65%
- managed-device wall clock regressed about 17.8%, while total runner work increased about 85.5%
- both matrices were rejected; production keeps the single-job lanes
