### PR TITLE
chore(ci): add merge queue readiness

### DIFF
--- a/.github/scripts/detect-change-scope.sh
+++ b/.github/scripts/detect-change-scope.sh
@@ -26,9 +26,11 @@
 #   from the second push onward every unaffected lane rerun, which is the exact case (a PR being
 #   fixed over several pushes) the mechanism exists to speed up. A cancelled run is still handled:
 #   its unstarted lanes are `cancelled`, not `skipped`, so they fail open.
-# - Every uncertainty fails open to running everything: non-PR events, first run of a PR,
-#   unreachable BEFORE, no or unreadable previous run, renamed jobs, a previous run still in
-#   flight. Skipping a real test is the costly mistake; an extra run is just minutes.
+# - Every uncertainty fails open to running everything: non-PR events (including merge-group
+#   candidates), first run of a PR, unreachable BEFORE, no or unreadable previous run, renamed
+#   jobs, a previous run still in flight. Skipping a real test is the costly mistake; an extra run
+#   is just minutes. Merge groups must validate their synthetic base-plus-queue SHA from scratch,
+#   never inherit a verdict from the PR head.
 # - The unit/screenshot split mirrors the test filter in
 #   build-logic/convention/src/main/kotlin/billionbeers.android.screenshot.gradle.kts: plain test
 #   runs exclude com.simtop.billionbeers.screenshot.*, Paparazzi runs include only it, and the
@@ -112,7 +114,7 @@ classify_all() {
 }
 
 if [ "$EVENT_NAME" != "pull_request" ]; then
-  emit true true true "not a PR - post-merge validation is always complete"
+  emit true true true "non-PR event - complete validation"
   exit 0
 fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+  merge_group:
+    types: [checks_requested]
 
 # Cancel superseded runs on the same ref. Scoped to PRs only: a new push to a PR makes the
 # in-flight run obsolete, so killing it saves a full emulator boot + 29-module test pass. Master

--- a/docs/adr/0005-dependabot-over-renovate.md
+++ b/docs/adr/0005-dependabot-over-renovate.md
@@ -12,7 +12,9 @@ Mend Renovate GitHub App. Both handle Gradle version catalogs adequately as of t
 
 ## Decision
 
-Use Dependabot (`.github/dependabot.yml`), not Renovate.
+Use Dependabot (`.github/dependabot.yml`), not Renovate. Use GitHub's native merge queue to
+sequence eligible updates when repository ownership makes that feature available; do not maintain a
+home-grown queue script in parallel with GitHub's required-check model.
 
 ## Why
 
@@ -44,6 +46,16 @@ Renovate's real advantages are given up deliberately:
   status checks, and enabling the repo's `allow_auto_merge` setting. Both are now in place. Major
   version bumps are never auto-merged (checked independently of `dependabot.yml`'s own
   `update-types` group filter, as a second gate in the auto-merge workflow itself).
-- Revisit if the ~130-entry catalog's monthly PR volume becomes unmanageable even with grouping,
-  or if this ever grows into a multi-repo/team setup where Renovate's dashboard earns its third-
-  party-trust cost.
+- `gh pr merge --auto --squash` remains the enrollment command. With a required merge queue, GitHub
+  makes it queue-aware: an eligible PR enters the queue, while a PR still waiting on requirements
+  keeps auto-merge armed and enters when eligible. The required workflow subscribes to
+  `merge_group`, and those synthetic candidates run complete validation rather than adopting a
+  verdict from the PR head.
+- The repository is currently personal-account-owned, so GitHub's native merge queue is unavailable
+  and activation is deferred. `scripts/repo-doctor.sh` reports this as an informational external
+  constraint. Transfer to organization ownership is the reopen trigger; after a transfer, configure
+  and validate the native queue before considering a custom sequencer. A transfer is not implied by
+  this ADR because it changes repository ownership and URLs.
+- Revisit Dependabot versus Renovate if the ~130-entry catalog's monthly PR volume becomes
+  unmanageable even with grouping, or if this ever grows into a multi-repo/team setup where
+  Renovate's dashboard earns its third-party-trust cost.

--- a/docs/adr/0008-per-lane-ci-test-selection.md
+++ b/docs/adr/0008-per-lane-ci-test-selection.md
@@ -81,6 +81,13 @@ the orphaned commit is never fetched), no or unreadable previous run, a non-nume
 renamed job, and a previous run still in flight all run the full suite. Skipping a real test is the
 costly mistake; an extra run is minutes.
 
+### 6. Merge-group candidates always run complete validation
+
+The required workflow subscribes to GitHub's `merge_group: checks_requested` event. A merge-group
+SHA represents the latest base plus the queued entries, not the already-tested pull-request head, so
+it goes through the existing non-PR fail-open branch and runs all three heavy lanes. It never adopts
+a PR-head verdict. The same stable `CI Gate` is then reported for branch protection.
+
 ## Consequences
 
 Validated live rather than by argument. A docs-only push skipped all three lanes with the gate

--- a/docs/repository-setup.md
+++ b/docs/repository-setup.md
@@ -17,10 +17,11 @@ REPO=owner/name BRANCH=master make repo-doctor
 
 The doctor verifies:
 
-- `master` is the default branch and its protection requires the strict `CI Gate` check;
+- `master` is the default branch and its protection requires only the strict `CI Gate` check;
 - force-pushes and branch deletion are blocked;
 - pull-request auto-merge and squash merge are enabled;
-- `ci.yml` contains the `CI Gate` aggregate job;
+- `ci.yml` contains the `CI Gate` aggregate job and subscribes to `merge_group` checks;
+- the native merge queue is active when the repository is organization-owned;
 - Dependabot covers Gradle and GitHub Actions and its auto-merge workflow is present;
 - `VERIFICATION_METADATA_DEPLOY_KEY` exists by name in both Actions and Dependabot secret stores;
 - GitHub reports no CODEOWNERS parser errors and critical repository paths have owners; and
@@ -31,5 +32,20 @@ The command only reads GitHub metadata. It never requests, prints or compares se
 expected branch, check and deploy-key names can be overridden with `REPO_DOCTOR_DEFAULT_BRANCH`,
 `REPO_DOCTOR_REQUIRED_CHECK` and `REPO_DOCTOR_REQUIRED_SECRET` when adapting the repository.
 
+## Merge queue availability
+
+Android CI is queue-ready: GitHub's `merge_group` event runs the complete heavy test set against the
+synthetic queue commit and reports the same stable `CI Gate` required check as a pull request. The
+repository itself is currently owned by a personal account, for which GitHub does not expose a
+native merge queue. The doctor reports that state as informational rather than pretending the queue
+is active or failing an otherwise-correct personal repository.
+
+If the repository moves to an organization, configure a native merge queue for `master` before
+relying on queued merges, then run the doctor again. In an organization-owned repository, a missing
+queue is a failure. Recovery is deliberately small: disable the queue rule if queue validation
+fails; keep `merge_group` support because it is harmless until GitHub creates a queue candidate.
+Repository transfer itself is outside this setup procedure because it changes ownership and URLs.
+
 The doctor does not replace branch protection or organization policy. Run it after creating a fork,
-changing required checks, moving the verification workflow, or changing release ownership.
+changing required checks, moving the verification workflow, changing ownership, configuring a merge
+queue, or changing release ownership.

--- a/scripts/repo-doctor.sh
+++ b/scripts/repo-doctor.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# This script only calls GET endpoints through gh. It checks names and metadata, never secret
-# values. The defaults describe BillionBeers; REPO_DOCTOR_* overrides let an adopting repository
-# keep the same doctor while it changes its branch/check/secret names.
+# This script only reads metadata through gh: REST GETs plus a read-only GraphQL query. It checks
+# names and metadata, never secret values. The defaults describe BillionBeers; REPO_DOCTOR_*
+# overrides let an adopting repository keep the same doctor while it changes its branch/check/secret
+# names.
 repo="${REPO:-${1:-}}"
 requested_branch="${BRANCH:-${2:-}}"
 expected_default_branch="${REPO_DOCTOR_DEFAULT_BRANCH:-master}"
@@ -77,11 +78,11 @@ else
   if jq -e --arg check "$required_check" '
       .required_status_checks != null and
       .required_status_checks.strict == true and
-      ((.required_status_checks.contexts // []) | index($check) != null)
+      (.required_status_checks.contexts // []) == [$check]
     ' >/dev/null <<<"$protection_json"; then
-    pass "branch protection requires strict status check: $required_check"
+    pass "branch protection requires only the strict status check: $required_check"
   else
-    fail "branch protection does not require strict status check: $required_check"
+    fail "branch protection does not require exactly one strict status check: $required_check"
   fi
 
   if jq -e '.allow_force_pushes.enabled == false and .allow_deletions.enabled == false' \
@@ -97,6 +98,30 @@ if [[ -f .github/workflows/ci.yml ]] && rg -q '^  ci-gate:' .github/workflows/ci
   pass 'ci.yml defines the CI Gate aggregate job'
 else
   fail 'ci.yml does not define the expected CI Gate aggregate job'
+fi
+
+if [[ -f .github/workflows/ci.yml ]] && rg -q '^  merge_group:' .github/workflows/ci.yml; then
+  pass 'ci.yml subscribes to merge-group checks'
+else
+  fail 'ci.yml does not subscribe to merge-group checks'
+fi
+
+repo_owner="${repo%%/*}"
+repo_name="${repo#*/}"
+merge_queue_json="$(gh api graphql \
+  -f query='query($owner: String!, $name: String!, $branch: String!) { repository(owner: $owner, name: $name) { owner { __typename } mergeQueue(branch: $branch) { id } } }' \
+  -F owner="$repo_owner" -F name="$repo_name" -F branch="$branch" 2>/dev/null || true)"
+if [[ -z "$merge_queue_json" ]] || jq -e '.errors | length > 0' >/dev/null 2>&1 <<<"$merge_queue_json"; then
+  fail "merge queue state could not be read for $branch"
+else
+  owner_type="$(jq -r '.data.repository.owner.__typename // empty' <<<"$merge_queue_json")"
+  if jq -e '.data.repository.mergeQueue != null' >/dev/null <<<"$merge_queue_json"; then
+    pass "native merge queue is active for $branch"
+  elif [[ "$owner_type" == 'User' ]]; then
+    note "native merge queue is unavailable while $repo is owned by a personal account"
+  else
+    fail "native merge queue is not active for $branch"
+  fi
 fi
 
 if [[ -f .github/dependabot.yml ]] \


### PR DESCRIPTION
## Summary

- subscribe the required Android CI workflow to `merge_group: checks_requested`
- make merge-group candidates fail open to complete unit, screenshot, and managed-device validation instead of adopting pull-request verdicts
- extend the repository doctor to require only the strict `CI Gate`, verify workflow readiness, and inspect native queue availability
- document that the repository is queue-ready but the native queue remains unavailable under personal-account ownership

## Verification

- `make test`
- `make format`
- `make repo-doctor`
- `bash -n .github/scripts/detect-change-scope.sh scripts/repo-doctor.sh`
- simulated `merge_group` selection emits all three heavy lanes as `true`
- workflow contract check confirms single heavy jobs and seven-day artifact retention remain intact

The native merge queue is not activated or claimed as active. GitHub currently reports personal-account ownership and no merge queue for `master`; the doctor treats that external limitation as informational.
