### PR TITLE
chore: profile managed device test phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,13 +509,59 @@ jobs:
         # The `ci` group is the ATD fast lane. The slower API 37 lane is the `compat` group and
         # runs weekly (.github/workflows/weekly-compat.yml). Which devices those mean is defined
         # in build-logic, not here.
-        run: ./gradlew ciGroupDebugAndroidTest
+        # --profile is timing-only and keeps the configuration cache enabled. Its task-level report
+        # separates device setup, APK assembly, and managed-device execution so the next
+        # optimization is chosen from the actual critical path rather than module counts.
+        run: >-
+          bash .github/scripts/run-timed-command.sh
+          ./gradlew ciGroupDebugAndroidTest --profile
 
       # Debug UI tests prove screen behavior; this black-box lane proves the minified target launches
       # and shows its production activity without requiring a Play signing identity.
       - name: Run minified release launch smoke test
         id: release_smoke_tests
-        run: ./gradlew :app-release-smoke:atdApi35ReleaseSmokeAndroidTest
+        run: >-
+          bash .github/scripts/run-timed-command.sh
+          ./gradlew :app-release-smoke:atdApi35ReleaseSmokeAndroidTest --profile
+
+      - name: Summarize instrumented lane timings
+        if: always()
+        env:
+          MANAGED_DEVICE_OUTCOME: ${{ steps.managed_device_tests.outcome }}
+          MANAGED_DEVICE_SECONDS: ${{ steps.managed_device_tests.outputs.elapsed_seconds }}
+          RELEASE_SMOKE_OUTCOME: ${{ steps.release_smoke_tests.outcome }}
+          RELEASE_SMOKE_SECONDS: ${{ steps.release_smoke_tests.outputs.elapsed_seconds }}
+        run: |
+          format_duration() {
+            local seconds="${1:-}"
+            if [[ ! "$seconds" =~ ^[0-9]+$ ]]; then
+              printf '—'
+              return
+            fi
+            printf '%dm %02ds' "$((seconds / 60))" "$((seconds % 60))"
+          }
+
+          phase_total=0
+          for seconds in "$MANAGED_DEVICE_SECONDS" "$RELEASE_SMOKE_SECONDS"; do
+            if [[ "$seconds" =~ ^[0-9]+$ ]]; then
+              phase_total=$((phase_total + seconds))
+            fi
+          done
+
+          {
+            echo "### Instrumented lane phase timings"
+            echo ""
+            echo "| Phase | Outcome | Elapsed |"
+            echo "|---|---|---:|"
+            printf '| Debug managed-device tests | `%s` | %s |\n' \
+              "$MANAGED_DEVICE_OUTCOME" "$(format_duration "$MANAGED_DEVICE_SECONDS")"
+            printf '| Minified release smoke | `%s` | %s |\n' \
+              "$RELEASE_SMOKE_OUTCOME" "$(format_duration "$RELEASE_SMOKE_SECONDS")"
+            echo ""
+            echo "Measured phase total: **$(format_duration "$phase_total")**"
+            echo ""
+            echo "_Task-level Gradle profiles are attached as a separate artifact._"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Summarize instrumented test failures
         if: >-
@@ -533,6 +579,17 @@ jobs:
             **/build/reports/androidTests/managedDevice/
             **/build/outputs/androidTest-results/managedDevice/
           if-no-files-found: error
+          retention-days: 7
+
+      - name: Archive managed-device Gradle profiles
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: managed-device-gradle-profiles
+          path: build/reports/profile/
+          # A failure before Gradle starts should preserve the original test verdict rather than
+          # replacing it with an artifact error. A green live run must still prove this is present.
+          if-no-files-found: warn
           retention-days: 7
 
   # Single aggregate gate - make THIS the only required status check in branch protection, not the


### PR DESCRIPTION
Adds timing-only measurement around the two existing instrumented commands and archives Gradle task profiles. The test tasks, order, reports, and CI Gate contract are unchanged. This exposes device setup, APK assembly, test execution, and release-smoke costs before considering a complete SDK/AVD cache.

Validation: make format; workflow YAML parse; timing-wrapper success/failure exit-code and output checks.