### PR TITLE
docs: consolidate ADR roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,11 +119,10 @@ The original thirteen are enforced by `:konsist`; the wording here is from the t
 13. **Feature modules never declare a data-layer module.** No `feature/*` build script may name
     `:beer_data`, `:beer_database` or `:beer_network`; a feature reaches persistence and the network
     through the `:beerdomain:api` repository interfaces, whose implementations `:app` binds. This is
-    the edge the neighbouring rules leave open: invariant 2 reads *imports* and only for the
-    beerslist/beerdetail pair, invariant 4 fires only when a **ViewModel** imports a data type (a
-    mapper or composable in the same module passes), and invariant 6 covers `app-dev-*` only. So
-    the dependency could be declared and used with nothing firing. `:app` is exempt — assembling the
-    graph is its job. (`FeatureDataLayerBoundaryTest` — reads the build scripts.)
+    a different concern from invariant 2, which discovers all feature siblings and rejects their
+    cross-feature imports and declarations. Invariant 4 covers ViewModel imports, and invariant 6
+    covers `app-dev-*`; neither replaces this feature-wide data dependency check. `:app` is exempt
+    — assembling the graph is its job. (`FeatureDataLayerBoundaryTest` — reads the build scripts.)
 
     `FeatureDataLayerBoundaryTest` only sees a data-layer module named in the feature's *own* build
     script. It cannot see one arriving through an intermediate dependency's `api(...)` declaration —
@@ -324,6 +323,8 @@ is vendored (each carries a `.android-skill-source` marker): `android-cli`, `nav
 ## 8. Docs & planning
 
 - **`docs/`** — committed, load-bearing docs only. `docs/adr/` is the decision record.
+- **`docs/ROADMAP_ASTRA.md`** — consolidated next steps and dated implementation evidence. Keep
+  completed work out of its active queue; ADRs remain authoritative for decisions and non-goals.
 - **Planning notes are local-only and gitignored**, so nothing in a clone points at them and no
   committed file should cite one. **They also have no git history, so deleting one is permanent** —
   never delete or overwrite a file in an ignored notes directory without being asked to.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ ADRs instead of argued twice.
 Compose UI · Metro DI · Room as SSOT · hand-rolled paging · two on-demand dynamic feature modules ·
 architecture rules enforced by Konsist · JVM screenshot tests · dependency verification.
 
+For the current priorities, completed-work ledger and explicit deferrals, see
+[ROADMAP_ASTRA](docs/ROADMAP_ASTRA.md). This is a reference application, not a supported
+domain-neutral project generator.
+
 [![Google Play](https://img.shields.io/badge/Google%20Play-Get%20it%20now-green?logo=google-play)](https://play.google.com/store/apps/details?id=com.simtop.billionbeers)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/simtop/BillionBeers)
 
@@ -134,8 +138,9 @@ sequenceDiagram
 ## 🛡 Enforced Architecture
 
 The point of this repository is that **the conventions are enforced by tooling, not by memory**. A
-diagram that only lives in a README rots; these rules fail the build. They run as
-[Konsist](https://github.com/LemonAppDev/konsist) tests in the `:konsist` module, on every push.
+diagram that only lives in a README rots; these rules are build checks. The source rules run as
+[Konsist](https://github.com/LemonAppDev/konsist) tests in `:konsist`, complemented by resolved
+Gradle classpath checks. CI runs or adopts the applicable lane verdict under ADR 0008.
 
 | Rule | Test |
 |---|---|
@@ -143,7 +148,7 @@ diagram that only lives in a README rots; these rules fail the build. They run a
 | Feature modules never depend on other feature modules — cross-feature nav goes through `:navigation` | `FeatureModuleBoundaryTest` |
 | The domain layer has zero Android imports | `DomainLayerPurityTest` |
 | ViewModels depend only on domain types (the precondition that makes "no use cases" safe) | `ViewModelBoundaryTest` |
-| Dynamic features declare no resources of their own — they crash instrumented tests | `DynamicFeatureResourceBoundaryTest` |
+| Dynamic-feature code uses shared user-facing resources rather than importing its own module `R` | `DynamicFeatureResourceBoundaryTest` |
 | Dev-app sandboxes depend only on `api` + `fakes` modules, which is what keeps them fast | `DevAppDependencyBoundaryTest` |
 | No module applies `java-test-fixtures` — fixtures live in sibling `:fakes` modules (ADR 0001) | `TestFixturesPluginBoundaryTest` |
 | ViewModels never use `MutableSharedFlow` — it drops one-shot events when nothing is collecting | `OneShotEventBoundaryTest` |
@@ -151,17 +156,19 @@ diagram that only lives in a README rots; these rules fail the build. They run a
 | A module with `src/androidTest/` opts into the managed device — otherwise its tests compile, read as coverage, and never run | `InstrumentedTestOptInBoundaryTest` |
 | Every `src/` directory has a build script beside it — an orphaned source tree is invisible to Gradle but still found by grep | `OrphanedSourceTreeTest` |
 | Test-only libraries never sit on `implementation`/`api` — they ship in the release APK | `TestLibraryBoundaryTest` |
+| Features never declare data-layer modules; resolved compile classpaths also reject transitive leakage | `FeatureDataLayerBoundaryTest` + `checkDataLayerClasspathBoundary` |
+| Production project dependencies and intentional project `api` exposures follow the checked-in role policy | `verifyArchitectureGraph` + architecture-policy fixtures |
 
 Reinforced by:
 
-- **Supply chain** — Gradle dependency verification with a checked-in ledger (211 locked deps),
+- **Supply chain** — Gradle dependency verification with a checked-in ledger,
   `dependency-guard` on the resolved graph, GitHub Actions pinned to SHAs, and gitleaks on every PR
   range. See [ADR 0006](docs/adr/0006-ci-supply-chain-hardening.md) and
   [ADR 0007](docs/adr/0007-gradle-dependency-verification.md).
 - **Convention plugins** — module setup lives in `build-logic`, so a new feature module is a plugin
   id and a namespace, not a copied 80-line build script.
-- **Decision record** — twelve [ADRs](docs/adr/) covering the choices that are easy to second-guess:
-  no Paging3, no `java-test-fixtures`, no use-case layer — and
+- **Decision record** — [ADRs](docs/adr/) covering the choices that are easy to second-guess:
+  hand-rolled paging, sibling fixtures, use cases only when they add behavior — and
   [ADR 0010](docs/adr/0010-non-goals.md), which records the capabilities this project deliberately
   *doesn't* have (auth, pinning, push, background sync) and the premise each one is waiting on, so
   a deliberate absence never has to be mistaken for an oversight.

--- a/docs/ROADMAP_ASTRA.md
+++ b/docs/ROADMAP_ASTRA.md
@@ -1,0 +1,249 @@
+# ROADMAP_ASTRA — what to do next
+
+**Reviewed:** 2026-09-05. **Source baseline:** `97bef93` (PR #207).
+
+This is the consolidated work queue for BillionBeers, not another architecture redesign. The
+[ADRs](adr/) remain authoritative for decisions. This roadmap separates verified implementation,
+specific remaining gaps, optional learning/product work, and ideas that should no longer be treated
+as obligations.
+
+**Recommendation:** finish a few concrete confidence gaps, then choose one product or learning
+milestone. Do not keep extending the base to chase a subjective “10/10.” Today this is a reference
+application; a supported domain-neutral generator would be a separate product commitment.
+
+## Evidence and limits
+
+- Reviewed the ADRs, accumulated planning material, current source/tests, build conventions,
+  workflows, quality baselines and recent local Git history. Historical plans are not proof that a
+  task is still open; a test name is not proof of the behavior its assertions cover.
+- “Implemented” below means present in this checkout, not that its full verification suite was
+  rerun during this documentation audit. No device, full build, benchmark or hosted CI run was
+  performed for this review.
+- Repository settings, external service behavior and sibling tool/template repositories were not
+  revalidated. Their earlier publication/setup claims must not become checked-off work here.
+- Existing local planning notes are preserved. This document is self-contained for a fresh clone
+  and does not depend on those notes.
+
+## 1. Recommended execution order
+
+### N1 — Fix tests that can pass without proving behavior
+
+**Priority: first. Two small changes, not a test-framework migration.**
+
+- Move and rewrite [EitherTest](../app/src/test/java/com/simtop/billionbeers/core/EitherTest.kt)
+  beside `Either` in `:core-common`. The `mapRight`/`mapLeft` assertions currently sit inside the
+  callback: skipping that callback can leave a green test. Assert transformed return values,
+  preservation of the opposite branch and callback invocation/non-invocation as appropriate.
+- Consolidate [LocalDataSourceTest](../app/src/androidTest/java/com/simtop/billionbeers/LocalDataSourceTest.kt)
+  and [LocalDataSourceTest2](../app/src/androidTest/java/com/simtop/billionbeers/di/LocalDataSourceTest2.kt)
+  into `:beer_database`'s existing device tier. Preserve CRUD, duplicate insertion, constraint
+  failure and the unique local-availability-preservation test. Remove duplicates only after the
+  owning module runs the replacement suite.
+- Add focused [BeerDetailViewModelTest](../feature/beerdetail/src/test/java/com/simtop/feature/beerdetail/BeerDetailViewModelTest.kt)
+  cases for restored state, overlapping availability updates and no error event on success. Define
+  the intended overlapping-update behavior before encoding an assertion; the present three tests
+  do not settle it.
+
+**Done when:** a deliberately broken mapping implementation fails the new JVM tests; each unique
+database behavior exists once in its owning tier; detail tests assert values/events, not only state
+types. Use explicit `:core-common:test`, the narrow feature unit task and the project Android skill
+for device verification. No mutation-testing product is required to prove these fixes.
+
+### N2 — Extend release confidence beyond “a window appeared”
+
+**Priority: next. Keep the existing black-box, debug-signed minified target.**
+
+[ReleaseLaunchSmokeTest](../app-release-smoke/src/main/java/com/simtop/billionbeers/releasesmoke/ReleaseLaunchSmokeTest.kt)
+already checks launch/package visibility, and [CI](../.github/workflows/ci.yml) executes it. It does
+not assert a successful data load, persisted data, mapping correctness or a navigation result.
+
+1. Add a deterministic public-behavior journey through the minified app: known catalog data,
+   navigation and a local availability edit that survives relaunch. If it uses a dynamic feature,
+   explicitly provide the required split-install setup rather than assuming it is installed.
+2. Keep this independent of the public backend's availability. Design a narrow test input/server
+   seam that retains production repository, mapper, database and DI implementations. Do not replace
+   the graph with fakes or loosen shipping keep rules merely to make the smoke pass.
+3. Verify expected mapping and baseline-profile artifacts from a documented release build; archive
+   them with revision and artifact hashes. Confirm release environment validation is reached from
+   the assembled graph, not just from `EnvironmentConfigTest`.
+
+**Done when:** a targeted R8/route/data-wiring regression fails deterministically, artifacts are
+checked rather than merely uploaded, and neither store signing secrets nor live network access are
+required. Keep existing Room migration tests; add a minified upgrade fixture only for a distinct
+release-specific risk, not to duplicate the complete migration matrix.
+
+**Later, not prerequisites:** report the size of one precisely defined APK/AAB before setting a
+budget. Add SBOM/release attestation when there is a named consumer and provenance contract;
+artifact hashes alone are not an attestation. Store upload and staged rollout stay separate.
+
+### N3 — Make the existing observability seam typed and privacy-bounded
+
+**Priority: next independent slice. No shipped vendor SDK.**
+
+[AnalyticsTracker](../core-common/src/main/kotlin/com/simtop/core/core/AnalyticsTracker.kt) accepts a
+free-form event name and string map. [CrashReporter](../core-common/src/main/kotlin/com/simtop/core/core/CrashReporter.kt)
+accepts unrestricted messages, throwables and keys. [ObservabilityModule](../core/src/main/java/com/simtop/core/di/ObservabilityModule.kt)
+binds no-op analytics/crash reporters but a real Logcat logger; privacy review must include that
+logger rather than assuming the whole seam is inert.
+
+- Define a small catalog for events already emitted, typed allowed parameters and a bounded
+  diagnostic/error classification. Do not build a generic event platform.
+- Specify what cannot leave the boundary: credentials, raw search text, URL query/fragment data and
+  uncontrolled exception messages. Test the actual emission path with an in-memory recorder.
+- Keep default bindings account-free and document the point where a future adapter supplies
+  consent/provider policy. Add sampling or breadcrumb storage only if something consumes them.
+
+**Done when:** existing call sites use the typed contract, unsafe payload examples are rejected or
+redacted by tested behavior, and cloning/building still requires no provider account or private
+configuration. [ADR 0010](adr/0010-non-goals.md) continues to decline a shipped analytics/crash SDK.
+
+### N4 — Finish narrow build-maintenance gaps, not another TestKit program
+
+**Priority: maintenance alongside relevant dependency/build changes.**
+
+- Add rationale, owner and a concrete removal probe for the remaining compatibility flags in
+  [gradle.properties](../gradle.properties): the built-in-Kotlin suppressions,
+  `android.uniquePackageNames=false`, `android.dependency.useConstraints=false` and
+  `android.r8.strictFullModeForKeepRules=false`. The [weekly build-tool check](../.github/workflows/weekly-build-tool-compat.yml)
+  already exists, but running with a flag still enabled does not prove it is still necessary.
+- Extend an existing TestKit fixture only for a demonstrated gap. Current configuration-cache
+  coverage proves managed-device **task discovery** reuses a cache; current screenshot wiring uses
+  a dry-run; current coverage assertions check dependencies/input paths. Do not describe these as
+  proof of every real execution path or Kotlin/AGP combination.
+- Re-measure `make build-budget` after material toolchain/build changes on a quiet local machine.
+  The ADR's dated baseline is not a September measurement and CI wall time is not a substitute.
+- Record an explicit trust decision for standalone `build-logic` tests: [ADR 0007](adr/0007-gradle-dependency-verification.md)
+  correctly notes that `./gradlew -p build-logic :convention:test` has no independent verification
+  ledger. If protection is added, include a sustainable regeneration path for its test fixtures;
+  do not assume the root ledger already protects that invocation.
+
+**Done when:** compatibility exceptions have reproducible removal checks, each new fixture closes a
+named risk, and measurement/security claims state which build and task graph they cover.
+
+### N5 — Retire quality debt selectively and prevent documentation drift
+
+**Priority: continuous, with bounded scope.**
+
+- The checked-in Android Lint baseline contains **zero issues**. Detekt has **75 baseline entries**
+  across 18 files at the reviewed revision, including 26 in `:core:designsystem`. These are source
+  counts, not fresh lint results. Fix behavioral/Compose findings first; named color literals do
+  not need artificial abstractions just to reduce a number. Deliberate exceptions need a narrow
+  rationale, not a regenerated baseline hiding new findings.
+- Add a small offline documentation check for repository-relative links and deliberately generated
+  indexes. Avoid brittle checks for incidental numbers or external link availability. The existing
+  README version generator remains the version-table authority.
+- Keep this roadmap's active queue current and preserve ADR measurement history as dated evidence.
+  Do not create another audit scorecard or duplicate the accepted coverage denominator.
+- `ACCESS_NETWORK_STATE` is still explicitly declared in the app manifest. The cleanup mentioned
+  in ADR 0010 is genuinely unfinished, but small: inspect merged manifests, remove the explicit
+  line only if redundant, then verify lint and dynamic-feature installation. This review does not
+  claim the merged app can dispense with it.
+
+**Done when:** each cleanup removes or explains a concrete exception, local documentation links are
+checked, and published claims do not exceed their enforcement. Do not block useful feature work on
+achieving an arbitrary zero-Detekt score.
+
+## 2. Implemented — remove from the active backlog
+
+These capabilities should be maintained, not rebuilt under older task names.
+
+| Historical request | Current evidence / important limit |
+|---|---|
+| A real agent onboarding map and verification ladder | [AGENTS.md](../AGENTS.md); the “63-line tooling-only file” description is obsolete |
+| Paging 2.0, search/browse reuse, append retry and no N+1 image request | [ADR 0002](adr/0002-hand-rolled-paging.md), `BeersPagerFactoryImpl`, `PagedListReducer`, storage contract tests; bookmark-miss fallback still exists |
+| Debug controls, feature flags, standalone dev-app generator and robot tier | `:app-dev-beerslist`, `scripts/new-dev-app.sh`, debug graph and feature test sources; remote flags and dynamic-feature dev-apps are not thereby implemented |
+| All-feature isolation and discovered dynamic-feature resource boundaries | [FeatureModuleBoundaryTest](../konsist/src/test/kotlin/com/simtop/konsist/FeatureModuleBoundaryTest.kt) and [DynamicFeatureResourceBoundaryTest](../konsist/src/test/kotlin/com/simtop/konsist/DynamicFeatureResourceBoundaryTest.kt); no longer limited to a historical package pair |
+| Resolved architecture policy, negative fixtures and intentional project `api` edges | [Architecture policy](../config/architecture/project-dependency-policy.json), `verifyArchitectureGraph`, `ArchitecturePolicyFunctionalTest` and `ArchitecturePolicyTest`; this is a project-graph policy, not a published binary-API checker |
+| Gradle and DI graph viewers | [Architecture reports](architecture-reports.md); report generation and policy enforcement are different tools |
+| Representative convention-plugin tests | [ConventionPluginFunctionalTest](../build-logic/convention/src/test/kotlin/com/simtop/billionbeers/buildlogic/ConventionPluginFunctionalTest.kt); includes transitive boundaries, signing diagnostics and coverage inputs |
+| Gradle warning inventory and scheduled forward-compatibility work | [Compatibility inventory](gradle-compatibility.md) and weekly workflow; remaining flag expiry/ownership is N4, not a missing workflow |
+| Pure-JVM participation and honest selected-coverage labeling | [Root report](../build.gradle.kts) and [health script](../scripts/health-report.sh); explicit project/class exclusions remain intentional, not whole-repository coverage |
+| Feature-owned browse/detail UI tests, accessibility journey and test-tier inventory | Feature `androidTest` sources, app journey and `scripts/test-tier-inventory.sh`; preserve the division in [ADR 0009](adr/0009-feature-module-ui-test-tier.md) |
+| Accessibility screenshot matrix, design-system governance and manual release QA | [Governance](design-system-governance.md), [release QA](accessibility-release-qa.md), `:snapshot-testing`; expanded-width previews are not a two-pane feature |
+| Repaired KSP discovery and CPS/KSP comparison | [ADR 0014](adr/0014-screenshot-preview-discovery.md): 272 discovered cases plus one manual catalog canary at the comparison revision; no backend migration is pending |
+| Minified release launch smoke | `:app-release-smoke` in CI; deeper behavior/artifacts remain N2 |
+| Typed endpoint/timeouts and release endpoint validation | [EnvironmentConfig](../core-common/src/main/kotlin/com/simtop/core/core/EnvironmentConfig.kt), its tests and app `EnvironmentModule`; assembled-graph assertion remains N2 |
+| Read-only repository doctor and durable health artifacts | [Repository setup](repository-setup.md), `scripts/repo-doctor.sh`, weekly Markdown/JSON artifacts with deltas and historical [SAMPLE](health/SAMPLE.md); scheduled settings checks remain optional |
+| Dependency-update automation and actionable CI failures | [ADR 0007](adr/0007-gradle-dependency-verification.md), verification-update safety tests and `.github/scripts/summarize-test-failures.py`; faster regeneration is still an experiment |
+| Splash screen and ordinary deep-link plumbing | App theme/launcher, navigation code and tests; do not confuse these with missing billing or verified HTTPS App Links |
+
+The catalog's handwritten screenshot is a harness canary in the accepted discovery comparison.
+Do not delete it as “filler” without intentionally replacing that signal and updating the inventory.
+Likewise, reflection-provider name tests protect install-time contracts despite their small size.
+
+## 3. Park, reject or move to a separate track
+
+“Optional” does not mean unimportant: an explicit learning objective is a valid reason to choose one
+of these. It does mean that none is required to finish the reference app's current architecture.
+
+| Idea | Disposition and reopen condition |
+|---|---|
+| Auth, token refresh, encrypted storage, integrity, push, server sync and offline write queue | **Out of the present base.** Apply ADR 0010's real backend/data/entitlement triggers. A local boolean update does not justify a server delivery queue |
+| Remote flags, kill switch and force-update | **Optional operational milestone.** Name a real remotely controlled feature or a bounded learning goal; define offline defaults, expiry and recovery before choosing a provider |
+| Favorites + widget, adaptive two-pane layout, richer filters | **Optional product milestone.** Choose one user-facing behavior with acceptance tests; do not change paging internals unless that behavior actually requires it |
+| KMP / Compose Multiplatform | **Separate migration track.** Pick the first non-Android target and prove a thin compile/test slice. `EnvironmentConfig` uses `java.net.URI`, so pure-JVM does not already mean `commonMain`-ready. Preserve a shippable Android app at each step |
+| Domain-neutral instantiation / monetization template | **Separate product decision.** Do not build a large rename/generation framework to earn a template-readiness score. If selected, require clean-output generation, identity-residue checks, CI validation and a support/update policy before advertising support |
+| RevenueCat, ads, licensed SDK and backend business experiments | **Separate learning/product track.** Start with entitlement/backend requirements, not speculative security infrastructure in this public catalog |
+| OSS publication of catalog/duplicate-class tooling | **External follow-up.** Inspect the actual sibling repos, publishing identity and release state first; earlier notes are not evidence of current readiness or publication |
+| Publishing unused-dependency tooling, MutantForge or a generic screenshot processor | **Not a base prerequisite.** Require a differentiated consumer and a small validated prototype; existing local mutation probes do not need a new product |
+| KSP member previews, exclusion annotations and similarity-based deduplication | **Conditional.** First add precise unsupported-shape diagnostics if needed by contributors. Add object/companion support for a real preview or publishing requirement. Similar images are not proof of redundant coverage; no automatic golden removal |
+| Firebase Test Lab / Flank | **Not the default test lane.** Managed-device ownership already exists. Reopen only for required device coverage the current lane cannot provide |
+| Mandatory assertion-library migration, more modules, binary convention rewrite, graph-depth limits | **Reject as generic cleanup.** Fix weak assertions directly; keep ADRs 0003, 0009, 0011 and 0013. No new invariant just to enforce taste |
+| Checked-in agent permission settings or another knowledge system | **Do not revive by default.** Local permissions are deliberately ignored; accurate onboarding and this consolidated queue address the demonstrated drift |
+| SLOs, error budgets, build scans and remote build cache | **Premise/measurement-gated.** Name a consumer or a bottleneck first; neither a service-level program nor another cache is missing merely because the interface could exist |
+
+### CI performance: preserve the negative results
+
+- **Do not retry two-way screenshot/device sharding, splitting architecture out of the unit lane,
+  or a system-image-only cache unchanged.** ADRs 0008/0009 record the measured rejection. Unit
+  sharding is not justified while the managed-device lane remains the measured critical path.
+- A **coherent SDK/created-AVD cache** is a bounded optional experiment, not an accepted speedup.
+  Preserve the current profile baseline, exclude locks and invalidate the full device/runner
+  definition. Require a real cold miss and warm hit, unchanged test/report coverage, and the
+  existing normalized whole-job improvement threshold before keeping it.
+- A **resolution-only verification writer** already has reference/candidate modes. Compare
+  artifacts from cold Linux runs on the same source SHA using
+  `.github/scripts/check-verification-metadata-update.py --require-equivalent`; do not switch the
+  production writer based on “assembly should resolve everything.”
+- **Native merge-queue activation is externally constrained**, as recorded in ADR 0005. Do not
+  transfer repository ownership or build a home-grown queue as incidental cleanup. A scheduled
+  read-only repo-doctor run is optional after checking the credentials/scopes its APIs require;
+  “unreadable” must remain distinct from “configured correctly.”
+
+## 4. ADR review outcome
+
+The decisions mostly hold. The problems were stale present-tense consequences, overbroad technical
+claims and treating optional ambitions as required work. This documentation change corrects the
+identified drift without changing the selected architecture.
+
+| ADR | Review outcome |
+|---|---|
+| [0001](adr/0001-test-fixtures-via-sibling-modules.md) | Corrected the manual `settings.gradle.kts` entry claim; modules are auto-discovered. Preserve the fixture decision; future performance reevaluation needs a reproducible measurement, not the unsized historical assertion alone |
+| [0002](adr/0002-hand-rolled-paging.md) | Corrected missing-retry/reuse claims and described exact bookmarks plus the actual legacy fallback. Removed categorical Paging3 testing/target claims and “KMP for free”; the plain-value contract remains the reason |
+| [0003](adr/0003-use-case-policy.md) | Removed stale surviving-use-case/audit references and described build enforcement rather than compiler enforcement; the boundary test already exists |
+| [0004](adr/0004-dev-apps-dont-support-dynamic-features.md) | Corrected the typo and one-dynamic-feature claim. A second feature exists, but extraction still needs demonstrated dev-loop pain |
+| [0005](adr/0005-dependabot-over-renovate.md) | Keep Dependabot and the documented ownership-dependent merge-queue constraint. Source review does not revalidate live GitHub settings |
+| [0006](adr/0006-ci-supply-chain-hardening.md) | Keep as historical rationale; its verification deferral is explicitly superseded by 0007. Old workflow/action counts describe adoption, not today's inventory |
+| [0007](adr/0007-gradle-dependency-verification.md) | Keep safety checks and full reference writer. Candidate equivalence and standalone build-logic ledger scope remain explicit boundaries, not completed optimizations |
+| [0008](adr/0008-per-lane-ci-test-selection.md) | Keep fail-open selection, one-run verdict adoption and recorded sharding/unit-lane rejection; no new orchestration plan needed |
+| [0009](adr/0009-feature-module-ui-test-tier.md) | Keep feature ownership, existing minified smoke and the measured caching/sharding limits; don't repeat experiments without changed inputs |
+| [0010](adr/0010-non-goals.md) | Fixed the contradiction that called a server-write queue merely deferred despite no server write path. Marked release smoke implemented and separated optional remote/KMP/product work from missing necessities |
+| [0011](adr/0011-build-time-budget.md) | Removed the unresolved historical module-count claim and outdated startup-budget reference; ratios reduce rather than eliminate measurement variance. Preserve the dated local table |
+| [0012](adr/0012-dispatcher-placement.md) | Scoped `setMain` reasoning to this app's default-scope ViewModels instead of claiming scopes cannot be supplied; removed the fixed IO-pool-size rationale. Dispatcher placement is unchanged |
+| [0013](adr/0013-convention-plugin-form.md) | Corrected “build logic remains untested” and the claim that precompiled scripts need conversion to be testable. Distinguish plugin compilation from consumer configuration; representative tests now exist |
+| [0014](adr/0014-screenshot-preview-discovery.md) | Keep the measured KSP decision and explicit publishing compatibility gaps. Older “migrate to CPS” plans are superseded, not parallel work |
+
+The README now includes the feature/data and resolved-graph checks without hard-coded ADR/dependency
+counts. Onboarding no longer describes feature isolation as limited to beerslist/beerdetail.
+
+## 5. Keep one queue current
+
+1. Start with **N1**, then **N2** and **N3** in separate reviewable changes; do N4/N5 when the relevant
+   build or documentation surface is touched. No large “complete the base” branch is needed.
+2. When an item lands, remove it from the active queue and retain only a short evidence entry if
+   useful. A checkbox must not stand in for assertions or a measured result.
+3. Choose at most one optional product/learning milestone next. Write its success criterion and
+   non-goals before adding provider SDKs, targets, modules or CI lanes.
+4. Verification follows [AGENTS.md](../AGENTS.md): narrow compile/tests first, then the applicable
+   architecture, screenshot and static-analysis gates; resources also require Android Lint.
+   Device work uses the project Android skill, and timing claims require local measurements.

--- a/docs/adr/0001-test-fixtures-via-sibling-modules.md
+++ b/docs/adr/0001-test-fixtures-via-sibling-modules.md
@@ -36,8 +36,9 @@ consumption story (`testImplementation(project(":beer_network:fixtures"))`) with
 ## Consequences
 
 - Every module that owns types needing fixtures gets a small sibling module (`:x:fakes` or
-  `:x:fixtures`) rather than a `testFixtures` source set inside `:x` itself. One more entry in
-  `settings.gradle.kts` per fixture set, but a simpler, cheaper build graph.
+  `:x:fixtures`) rather than a `testFixtures` source set inside `:x` itself. The root
+  `settings.gradle.kts` auto-discovers directories with build scripts, so a new fixture module
+  needs no manual `include(...)` entry. The separate `build-logic` composite remains explicit.
 - Revisit if a future Gradle/AGP release closes the performance gap — re-benchmark before
   reverting this decision, don't assume it's fixed.
 - The sibling module must use the same plugin (`billionbeers.android.library` vs.

--- a/docs/adr/0002-hand-rolled-paging.md
+++ b/docs/adr/0002-hand-rolled-paging.md
@@ -27,21 +27,20 @@ Keep the hand-rolled `PagingMediator<Key, Value>` (a small state machine over `c
 
 ## Why
 
-Paging3's `PagingData<T>` type is designed to flow, unmodified, from repository to UI:
+The evaluated Paging3 integration exposed `Flow<PagingData<Beer>>` across the repository/UI
+boundary. This project instead chooses plain data and explicit paging state as its contract:
 
-- The repository would have to return `Flow<PagingData<Beer>>` instead of `Flow<List<Beer>>`.
-  `PagingData` is not a value type you can inspect, transform, or compare - it's a bespoke
-  stream of load/insert/drop events consumed only by `AsyncPagingDataDiffer` or a
-  `LazyPagingItems` composable. That means the domain layer can't meaningfully sit between the
-  repository and the UI: any use case wrapping `PagingData` becomes a pass-through, and the "no
-  data-layer types past the repository boundary" rule this project follows everywhere else
-  breaks specifically for paging.
-- ViewModel tests lose the plain-fake pattern used everywhere else in this codebase
-  (`FakeBeersRepository` + Turbine on a `StateFlow`). Asserting on `PagingData` requires
-  `AsyncPagingDataDiffer` with a real or fake `ListUpdateCallback`, a different and heavier test
-  setup than the rest of the suite.
+- A `List<Beer>` and a `PagingState` are ordinary values that our domain fakes, reducers and
+  ViewModel tests can inspect directly. Adopting a paging-library-specific stream would change
+  that contract or require an adapter whose complexity would need to earn its place.
+- The existing `FakeBeersRepository`/pager fakes and Turbine assertions share one testing model
+  across paged and unpaged screens. Keeping that model is a project preference, not a claim that
+  Paging3 cannot be transformed or tested without a UI differ.
 
-`PagingMediator` avoids both: it exposes a plain `StateFlow<PagingState>` and a `Flow<List<Value>>`
+The decision does not prohibit domain logic around a paging library. A pass-through use case is
+unnecessary under ADR 0003 regardless of which paging implementation is behind the repository.
+
+`PagingMediator` preserves this contract: it exposes a plain `StateFlow<PagingState>` and a `Flow<List<Value>>`
 for data, so the repository, domain layer, and ViewModel tests all stay in the same
 plain-Flow-and-fakes style as the rest of the codebase.
 
@@ -61,31 +60,30 @@ already retry-safe) - a mistake that wouldn't have been possible to make inside 
 
 ## Bonus
 
-`PagingMediator` is pure Kotlin with no Android dependency, so it ports to a future Kotlin
-Multiplatform migration for free. Paging3 is an AndroidX library with no multiplatform target as
-of this writing, so keeping paging logic in Paging3 would have blocked that migration path
-entirely.
+`PagingMediator` has no Android dependency, which reduces one migration constraint. This does not
+make the whole `:core-common` module multiplatform for free: its build, platform-specific APIs and
+tests still need a target-by-target audit. Do not infer an alternative library's target support
+from its AndroidX name; verify the artifacts and test APIs available when a migration is proposed.
 
 ## Consequences
 
-- Mid-list pagination errors (`PagingState.Error` for page N > 1) are the app's responsibility to
-  surface - today they're silently swallowed while keeping the existing list on screen. A
-  snackbar or footer-retry affordance for this case is follow-up work, not solved by this
-  decision.
-- Any future paged screen (favorites, search) needs to either reuse `PagingMediator` or accept
-  writing its own equivalent - there's no `RemoteMediator`-style reusable framework backing this,
-  by design.
+- Mid-list pagination errors remain the app's responsibility. This follow-up is complete:
+  `PagedListReducer` keeps existing items visible with `PagedListFooter.Retry`, and the shared
+  `LoadMoreRetryFooter` provides explicit retry. Do not reopen it as missing error UI.
+- Future paged screens reuse the screen-scoped `Pager`/`PagingStorage` and `BeersPagerFactory`
+  contracts. Search and browse already exercise that reuse; a new filtered surface is not a
+  reason to build a second paging framework.
 - (Update, July 2026) `PagingMediator` now implements a small `Pager` interface and delegates
   writes to a `PagingStorage` strategy - `InMemoryPagingStorage` for network-only paging, or a
   DB-backed implementation for SSOT (the beers one upserts and never deletes, so the local-only
   `availability` field survives pull-to-refresh). Screens get their own instance from a factory
   (`BeersPagerFactory`), keeping paging state screen-scoped instead of living on the AppScope
   repository. Because such a cache outlives any single pager (warm
-  launches) and survives refresh (upsert, no delete), a storage-derived key
-  (`nextKeyFromStorage`, e.g. `rowCount / pageSize + 1`) keeps the pager's position reconciled
-  with the data. Note the scoping boundary: the pager *position* is screen-scoped, but the beers
-  *data* is one shared table - fine for a single paged surface; a second filtered surface
-  (search, favorites) needs its own storage with parameter-scoped queries.
+  launches) and survives refresh (upsert, no delete), `nextKeyFromStorage` reads an exact
+  surface-scoped bookmark from `paging_state`, written transactionally with the page. The bookmark
+  is authoritative when present. On a miss, `BeersPagerFactoryImpl` restarts at page 1 for a
+  language mismatch and retains the row-count estimate for a fresh/legacy cache; the heuristic
+  has not been removed entirely. Search and browse use per-query in-memory storage instead.
 - (Update, July 2026) The repository's per-beer image fetch (a `GET
   /images/{id}` for every item in a page — an N+1, one list request plus 25 image requests) is
   removed. A live audit showed the `brewbuddy.dev` list response embeds `image.url` directly
@@ -104,5 +102,7 @@ entirely.
   styles (17 rows) and breweries (38 rows) are plain unpaged fetches, because a pager for a list
   that small is machinery without a customer. Pagers are per-query values (a changed query is a
   new pager, never a mutation), which is what keeps invalidation out of the mediator.
-- Revisit if Paging3 ships a multiplatform target and a `PagingData`-free consumption API; until
-  then this is the right trade for a KMP-bound clean-architecture codebase.
+- Revisit if a concrete product requirement exceeds this pager's supported behavior, or a measured
+  alternative reduces its correctness/maintenance cost while preserving the required boundaries.
+  Neither a hypothetical KMP migration nor an old claim about library target support is a trigger
+  by itself.

--- a/docs/adr/0003-use-case-policy.md
+++ b/docs/adr/0003-use-case-policy.md
@@ -68,7 +68,7 @@ Adopt policy 2, **coupled to mechanical boundary enforcement**:
   Retrofit services, or DAOs.
 
 The Konsist rule is not optional hardening; it is the load-bearing half of this decision. Deleting
-the pass-throughs is only safe because the invariant they represented is now compiler-enforced
+the pass-throughs is only safe because the invariant they represented is now build-enforced
 instead of convention-enforced.
 
 ## Why
@@ -103,11 +103,11 @@ instead of convention-enforced.
 
 - `LoadNextPageUseCase`, `RefreshBeersUseCase`, `ObservePagingStateUseCase`, and
   `UpdateAvailabilityUseCase` are deleted; `BeersListViewModel` / `BeerDetailViewModel` inject
-  `BeersRepository`. `GetAllBeersUseCase` survives only if it grows behaviour (per §2.4 of the
-  audit).
-- The Konsist suite (`konsist/`) must gain the ViewModel-boundary rule **in the same change** that
-  deletes the pass-throughs. A PR that does the deletion without the rule reintroduces the
-  unenforced-floor situation this ADR exists to prevent.
+  `BeersRepository`. No use-case implementation survives today; add one only when it owns real
+  behavior rather than mirroring a repository method.
+- The Konsist suite (`konsist/`) contains `ViewModelBoundaryTest`. Keep this check and the resolved
+  architecture policy active whenever removing or changing a layer: deleting pass-throughs without
+  equivalent enforcement would reintroduce the unenforced-floor situation this ADR prevents.
 - **Revisit trigger:** if this codebase is ever worked on by multiple teams *without* Konsist (or
   equivalent) in CI, flip to policy 1. "Use case always" is the correct rule for
   convention-enforced codebases; this ADR's choice is strictly conditional on mechanical

--- a/docs/adr/0004-dev-apps-dont-support-dynamic-features.md
+++ b/docs/adr/0004-dev-apps-dont-support-dynamic-features.md
@@ -6,7 +6,7 @@ Accepted
 
 ## Context
 
-Ffor `app-dev-<feature>` modules: standalone applications that
+`app-dev-<feature>` modules are standalone applications that
 compile only one feature module + fakes, for a seconds-scale build/install loop instead of the
 full `:app`. `app-dev-beerslist` (`:feature:beerslist`, a regular feature module) proved this out
 successfully. `scripts/new-dev-app.sh` and `.claude/skills/new-dev-app/SKILL.md` generalized the
@@ -50,10 +50,10 @@ seconds-scale build this pattern exists for.
 
 ## Cost accepted
 
-No fast dev-loop for dynamic features. Today that's exactly one screen
-(`:feature:beerdetail`) - iterating on it still requires the full `:app` build/install (or
-Paparazzi screenshot tests, which already cover this screen's layout without needing a running
-app at all).
+No standalone dev-app loop for dynamic features. Both `:feature:beerdetail` and
+`:feature:beerbrowse` are now on-demand features. App-assembly and install-flow iteration still
+uses `:app`; Paparazzi covers static rendering, and feature-owned instrumented tests cover
+single-screen device behavior under ADR 0009. Neither test path is a standalone dev-app.
 
 ## Consequences
 
@@ -62,5 +62,6 @@ app at all).
   module both the dynamic feature and a dev-app could depend on (the structurally correct fix,
   real module-boundary work), or source-duplicating the composable into the dev-app (works
   immediately, drifts out of sync silently, should stay a last resort).
-- If a second dynamic feature is ever added and the same need comes up twice, that's the signal
-  to actually do the module-extraction fix rather than route around it per-feature again.
+- The second dynamic feature now exists, but module count alone does not justify extracting UI
+  modules. Revisit extraction when repeated, measured dev-loop pain warrants it; the unsupported
+  direct dev-app dependency remains unsupported meanwhile.

--- a/docs/adr/0010-non-goals.md
+++ b/docs/adr/0010-non-goals.md
@@ -27,10 +27,10 @@ it once is how it survives.
 
 **A capability is a non-goal when the premise it serves is absent — not when it is merely unbuilt.**
 
-Auth is a non-goal because there is no credential anywhere in the system. An offline write queue is
-*deferred*, not declined, because its premise already exists: `available` is a real local write with
-optimistic UI, and the queue simply hasn't been built. The distinction matters because it makes the
-revisit trigger fall out for free — for a non-goal, the trigger is always "the premise arrives."
+Auth is a non-goal because there is no credential anywhere in the system. An offline server-write
+queue is also a non-goal: `available` is already persisted locally, but there is no remote write
+destination to queue it for. Optimistic UI alone does not create a synchronization requirement.
+For a non-goal, the trigger is always "the premise arrives."
 
 The two lists below are therefore kept separate on purpose. Mistaking a deferral for a decline is
 how a plan quietly loses items.
@@ -45,24 +45,24 @@ how a plan quietly loses items.
 | **Play Integrity / SafetyNet, root or tamper detection** | No entitlement, no revenue, no server trust decision. Nothing is gated on the client being honest | A paid or licensed artifact ships |
 | **Push notifications (FCM)** | No server we control, so nothing to send | A backend of ours exists |
 | **Server-side sync of `available`** | The backend isn't ours, so a sync could only ever one-way-overwrite the user's edit. The server value seeds a row on first insert and is local-only thereafter | We own the write path |
-| **A shipped analytics or crash SDK** | The *seam* is built and deliberate — `AnalyticsTracker` / `CrashReporter` / `Logger` with no-op bindings in `ObservabilityModule`, swappable one binding at a time. Declining the *dependency* is the separate call: no `google-services.json` exists anywhere, so this repo clones and builds with zero external account setup. That property is worth more to a public template than a wired-up dashboard | A real distribution needs the data, or one integration lands behind a flag to prove the seam |
+| **Offline server-write queue**, WorkManager sync, conflict resolution, idempotency | A Room write already works offline. There is no server mutation to deliver or reconcile | A real remote write contract exists, with an explicit conflict/idempotency policy |
+| **A shipped analytics or crash SDK** | The *seam* is built and deliberate — `ObservabilityModule` binds no-op `AnalyticsTracker` / `CrashReporter` implementations and a real Logcat `Logger`, swappable one binding at a time. Declining the vendor *dependency* is the separate call: no `google-services.json` exists anywhere, so this repo clones and builds with zero external account setup. Log output still needs its own privacy review; the no-op reporters do not make every diagnostic path inert | A real distribution needs the data, or one integration lands behind a flag to prove the seam |
 | **Consent, GDPR, and ad-ID flows** | Falls out of the row above: no SDK ships, no personal data is collected, no advertising ID is read. Play's Data Safety declaration is trivially satisfied because the honest answer is "nothing" | The row above changes |
 | **Automatic network retry and backoff** | Failure is surfaced to the user and retried explicitly (`PagedListFooter.Retry`, `LoadMoreRetryFooter`) rather than silently re-attempted. On a read-only catalog a silent retry buys little and hides the failure the paging tests are written against. OkHttp's connection-level `retryOnConnectionFailure` default is left on; nothing sits above it | A write path exists, where transparent retry is load-bearing rather than cosmetic |
 | **Multi-process** | Nothing declares `android:process`. No component needs isolation, and the second process would cost a second graph | A component needs its own lifetime or crash domain |
 
 ## Deferred, not declined
 
-Planned for the future and simply not built yet. Recorded here only so nothing in this file is
-mistaken for a closed question — none of these is waiting on a missing premise, so none of them
-belongs in the table above.
+These are candidates, not prerequisites for a complete reference app. Their scope and priority
+live in [ROADMAP_ASTRA](../ROADMAP_ASTRA.md); an existing abstraction or a useful learning topic is
+not by itself a commitment to ship an integration.
 
-| Deferred | Why it is a deferral, not a decline |
+| Candidate | Current boundary |
 |---|---|
-| Offline write queue (WorkManager, conflict resolution, idempotency) | The local write it would queue already exists — `available`, with optimistic UI |
-| Remote config, kill switch, staged rollout, force-update | The premise is present, unlike push: `FeatureFlagProvider` already exists with a local implementation, and a remote source needs no backend of ours. Only the remote half is unbuilt — and the certificate-pinning row above is blocked behind it |
-| Release-build health in CI, APK size budget, diffuse-on-PR | `make bundle-release` already runs R8 and regenerates the baseline profile locally; only the CI gate is missing |
-| Adaptive two-pane layout; favorites + Glance widget | Ordinary feature work. The `adaptive` and `navigation-3` skills are already vendored |
-| Kotlin Multiplatform | The domain and `:core-common` are already pure-JVM and Metro is KMP-capable, so the groundwork is in place |
+| Remote config, kill switch, staged rollout, force-update | Local `FeatureFlagProvider` exists; a remote adapter does not. Start only for a named operational use or an explicitly chosen learning milestone, with offline defaults and recovery policy |
+| Deeper release-build health, artifact verification and a size budget | The debug-signed, minified `releaseSmoke` target already launches in CI. Remaining work is deterministic behavior and mapping/profile artifact verification; size reporting needs a defined artifact before any threshold |
+| Adaptive two-pane layout; favorites + Glance widget | Accessibility/expanded-width previews and release QA already exist. A real two-pane navigation layout and a local favorites/widget product remain separate feature choices |
+| Kotlin Multiplatform | Pure-JVM domain/core boundaries are useful groundwork, not proof of common-source compatibility. Choose a target and validate platform APIs, DI, persistence and tests before committing to migration |
 
 The implementation choices named in the Context above — plus dev-apps for dynamic features (0004) —
 keep their own ADRs and are not reopened here.
@@ -97,11 +97,10 @@ declines is a better signal than a token-refresh interceptor with no token behin
 
 Concrete triggers, in the order the rows actually unlock:
 
-1. **A write path to a server we own.** This does not reopen one row, it reopens five — auth,
-   encrypted storage, server-side `available` sync, automatic retry, and (only afterwards)
-   certificate pinning. Pinning is last on purpose: shipping a pin without a remote kill switch is
-   how a fleet gets bricked by a certificate rotation, so it depends on the remote-config work in
-   the deferred table.
+1. **A write path to a server we own.** Reassess identity, sensitive storage, `available` sync,
+   offline delivery and retry against that contract rather than enabling them automatically.
+   Certificate pinning remains a separate threat-model and recovery-policy decision; it is not a
+   prerequisite for demonstrating a local write.
 2. **A paid or licensed artifact ships** — planned, but not scheduled. Integrity/anti-tamper and a
    real observability backend both acquire a premise the day one does.
 3. **The app collects anything about a person** — consent and Data Safety stop being trivial the

--- a/docs/adr/0011-build-time-budget.md
+++ b/docs/adr/0011-build-time-budget.md
@@ -25,9 +25,9 @@ That matters more here than in most projects, because the repository's central c
 a deliberately modular graph, convention plugins, ten enforced invariants. The question a reviewer is
 entitled to ask is whether the split pays for itself, and the only honest answer is a number.
 
-(Deliberately no module count here. ADR 0009 quotes 27 for `:app`'s build; `./gradlew projects`
-reports a different figure for the whole build. The two are probably measuring different things, but
-until someone confirms which, a third number in a third document helps nobody.)
+(Deliberately no current module count here. ADR 0009's dated correction distinguishes the app's
+dependency closure from the whole configured build. Neither number substitutes for measuring build
+cost, and neither is a permanent property of a changing graph.)
 
 ## Decision
 
@@ -117,10 +117,10 @@ Recording these because the symptom in every case was a number that looked fine.
 
 **The absolute budgets are machine-specific.** They are calibrated on one laptop and a slower
 machine can fail them with nothing wrong. Mitigated two ways, not solved: budgets sit at roughly
-3–4x the measured median and comfortably above the worst of ten iterations, following the precedent
-in `check-benchmark-budget.sh` (3000 ms against an ~890 ms measurement, with its reasoning in the
-comment); and the `ratio` check between two scenarios in the same run cancels the hardware out
-entirely, which is why it is the line worth arguing from.
+3–4x the measured median and comfortably above the worst of ten iterations; and the `ratio` check
+between two scenarios in the same run reduces shared hardware variance. It does not eliminate all
+hardware or workload effects. The separate startup budget is now 500 ms on physical devices, as
+documented in `scripts/check-benchmark-budget.sh`, not the earlier emulator-derived 3000 ms policy.
 
 **A local gate depends on someone running it.** Unlike the coverage floor, nothing forces this
 before a merge. Accepted for the same reason `make benchmark-check` is accepted: a number that is

--- a/docs/adr/0012-dispatcher-placement.md
+++ b/docs/adr/0012-dispatcher-placement.md
@@ -26,10 +26,11 @@ exists because answering them properly changed the shape of the fix.
 
 Half true, and the half that is false is the load-bearing one.
 
-`viewModelScope` is `SupervisorJob() + Dispatchers.Main.immediate`. **No injection can reach it** —
-`Dispatchers.setMain` is the only override. So a test needs `setMain` whether or not a dispatcher is
-injected, and every ViewModel test here already called it. The injected provider was a *second*
-control surface for something the first one already covered.
+These ViewModels use the default `viewModelScope`; they do not supply a custom scope. Injecting a
+`CoroutineDispatcherProvider` does not replace that scope's Main dispatcher. Their tests therefore
+use `Dispatchers.setMain`, which already controls the bare `launch` path. The injected provider was
+a *second* control surface for something the first one already covered, not evidence that custom
+ViewModel scopes are impossible.
 
 Settled empirically rather than by argument: `BeerDetailViewModel` was converted to a bare
 `viewModelScope.launch { }`, its `mockk` dispatcher stubs deleted, and its test still passed with
@@ -67,7 +68,7 @@ The argument is answerable only with a detector, so this ADR ships one — see *
 | Repository wrapping a **blocking** library or vendor SDK | that class | `withContext(io)` | **Yes** |
 | CPU-heavy transform in the data layer (parsing, crypto, large sorts) | that class | `withContext(default)` | **Yes** |
 | Direct disk, file or `SharedPreferences` access | that class | `withContext(io)` | **Yes** |
-| Testing a ViewModel | the test | `Dispatchers.setMain` | **N/A** — `viewModelScope` is not injectable |
+| Testing these default-scope ViewModels | the test | `Dispatchers.setMain` | **No** extra provider just to control `launch` |
 | Testing a class that selects a dispatcher | the test | pass `runTest`'s dispatcher | **Yes** — same scheduler |
 
 Applied here: three ViewModels lost the parameter entirely. Two kept it, because they genuinely
@@ -75,9 +76,8 @@ select a dispatcher — `combine(pager.data, pager.pagingState, reducer::reduce)
 growing list on every emission, real CPU work that would otherwise run on Main under
 `stateIn(viewModelScope)`.
 
-Those two moved from `io` to `default`. `Dispatchers.IO` is a 64-thread pool sized for threads
-parked on blocking waits; using it for computation oversubscribes the CPU. `Default` is sized to the
-core count, which is what CPU-bound work wants.
+Those two moved from `io` to `default`: choose the dispatcher intended for CPU work, not the one
+intended for blocking waits. This policy does not depend on a fixed thread-count claim.
 
 **`CoroutineDispatcherProvider` stays.** It is the right seam for every "Yes" row above. The change
 is where it is injected, not whether it exists.

--- a/docs/adr/0013-convention-plugin-form.md
+++ b/docs/adr/0013-convention-plugin-form.md
@@ -24,11 +24,13 @@ The case for converting back is real but narrower than it first appears:
   `apply(plugin = "billionbeers.…")` instead of a `plugins { }` block, to route around an
   accessor-generation bug. Binary plugins generate no accessors, so the bug cannot apply and the
   workaround could be deleted.
-- **Build logic would become unit-testable** with `ProjectBuilder`/TestKit. In a repo that
-  mechanically enforces thirteen architecture invariants on application code, the build logic is
-  the only substantial untested part.
-- **Configuration time.** Gradle generates a precompiled script plugin's class at configuration
-  time, and the widely-cited Now in Android figure is 12.7s → 0.76s on conversion.
+- **Testing ergonomics can differ.** Binary classes offer a direct unit-test surface, but consumer
+  behavior can be tested with TestKit in either form. The lack of a suite when this ADR was first
+  written was a coverage gap, not a limitation of precompiled scripts.
+- **Build/configuration cost needs a local measurement.** Precompiled script classes are build
+  outputs of the convention build, not classes regenerated on every consumer configuration.
+  Accessor generation, compilation and consumer configuration must be measured separately;
+  another project's conversion benchmark does not establish the cost here.
 
 Two things weaken that third point specifically, which is the one usually used to justify the
 migration:
@@ -73,12 +75,14 @@ should measure it on this repo rather than argue from another project's numbers:
 - The `apply(plugin = "billionbeers.…")` workaround stays, and stays commented, until either the
   Gradle bug is confirmed fixed or the measurement above justifies conversion. Flipping one back to
   a `plugins { }` block and running `./gradlew help` is the cheap way to test the former.
-- Build logic remains untested. That is a real cost and the strongest argument on the other side;
-  it is accepted for now because the conventions are small and heavily commented, and because the
-  invariants in `:konsist` cover the *outcomes* the conventions produce.
+- **Update, 2026-09-05:** build logic now has behavioral TestKit coverage without changing plugin
+  form. `ConventionPluginFunctionalTest` covers convention application, managed-device task
+  discovery and configuration-cache reuse, screenshot unit-test wiring, transitive feature/data
+  boundaries, coverage inputs and missing signing credentials. Architecture-policy and module-graph
+  fixtures complement it. This is representative coverage, not proof of every task execution or
+  toolchain combination; extend it for a concrete missing contract, not to justify conversion.
 - **Reopen triggers:** a measured configuration-time difference that matters at this repo's scale;
-  a decision to publish a convention (Gradle's docs recommend converting to binary before
-  publishing — note the two artifacts currently earmarked for extraction are already binary); or a
+  an actual publishing requirement that the current form cannot satisfy; or a
   Gradle release that makes precompiled scripts materially worse.
 
 ## Related


### PR DESCRIPTION
## Summary
- consolidate the ADR review into the repository’s local roadmap notes under ignored `rod/`
- correct stale ADR claims around paging, dynamic features, build logic, dispatchers, non-goals, and build budgets
- align README and AGENTS.md with the current architecture enforcement and reference-app scope

## Verification
- `git diff --check`
- relative Markdown link check passed before moving local notes
- docs-only change; application test gates were not run