### PR TITLE
feat: type observability boundary

### DIFF
--- a/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
+++ b/beer_data/src/main/java/com/simtop/beer_data/mappers/BeersMapper.kt
@@ -10,7 +10,12 @@ import com.simtop.beer_network.network.BeersService
 import com.simtop.beerdomain.domain.models.Beer
 import com.simtop.beerdomain.domain.models.BeerStyle
 import com.simtop.beerdomain.domain.models.Brewery
+import com.simtop.core.core.Diagnostic
+import com.simtop.core.core.DiagnosticArea
+import com.simtop.core.core.DiagnosticCode
+import com.simtop.core.core.DiagnosticLevel
 import com.simtop.core.core.LanguageProvider
+import com.simtop.core.core.LogTag
 import com.simtop.core.core.Logger
 import dev.zacsweers.metro.Inject
 
@@ -23,9 +28,9 @@ constructor(private val languageProvider: LanguageProvider, private val logger: 
     val translation =
       response?.translations?.find { it.language.code == languageCode }
         ?: response?.translations?.find { it.language.code == BeersService.DEFAULT_LANGUAGE_CODE }
-    if (response?.id == null) logMissingField("id", response)
-    if (response?.name == null) logMissingField("name", response)
-    if (translation == null) logMissingField("translations (matching language)", response)
+    if (response?.id == null) logger.warn(LogTag.BEERS_MAPPER, MISSING_BEER_ID)
+    if (response?.name == null) logger.warn(LogTag.BEERS_MAPPER, MISSING_BEER_NAME)
+    if (translation == null) logger.warn(LogTag.BEERS_MAPPER, MISSING_BEER_TRANSLATION)
 
     return Beer(
       id = response?.id ?: "",
@@ -67,20 +72,16 @@ constructor(private val languageProvider: LanguageProvider, private val logger: 
   private fun List<NamedEntity>?.localizedNames(languageCode: String): List<String> =
     orEmpty().map { it.localizedName(languageCode) }.filter { it.isNotEmpty() }
 
-  private fun logMissingField(field: String, response: BeersApiResponseItem?) {
-    logger.warn(TAG, "missing $field for beer id=${response?.id}, defaulting")
-  }
-
   fun fromTypologyToBeerStyle(response: TypologyApiResponseItem): BeerStyle {
     if (response.id == null || response.name == null) {
-      logger.warn(TAG, "missing id or name for typology id=${response.id}, defaulting")
+      logger.warn(LogTag.BEERS_MAPPER, MISSING_STYLE_ID_OR_NAME)
     }
     return BeerStyle(id = response.id ?: "", name = response.name ?: "")
   }
 
   fun fromBreweryApiResponseItemToBrewery(response: BreweryApiResponseItem): Brewery {
     if (response.id == null || response.name == null) {
-      logger.warn(TAG, "missing id or name for brewery id=${response.id}, defaulting")
+      logger.warn(LogTag.BEERS_MAPPER, MISSING_BREWERY_ID_OR_NAME)
     }
     return Brewery(
       id = response.id ?: "",
@@ -136,6 +137,35 @@ constructor(private val languageProvider: LanguageProvider, private val logger: 
     )
 
   private companion object {
-    const val TAG = "BeersMapper"
+    val MISSING_BEER_ID =
+      Diagnostic(
+        DiagnosticArea.DATA_MAPPING,
+        DiagnosticCode.MISSING_BEER_ID,
+        DiagnosticLevel.WARNING,
+      )
+    val MISSING_BEER_NAME =
+      Diagnostic(
+        DiagnosticArea.DATA_MAPPING,
+        DiagnosticCode.MISSING_BEER_NAME,
+        DiagnosticLevel.WARNING,
+      )
+    val MISSING_BEER_TRANSLATION =
+      Diagnostic(
+        DiagnosticArea.DATA_MAPPING,
+        DiagnosticCode.MISSING_BEER_TRANSLATION,
+        DiagnosticLevel.WARNING,
+      )
+    val MISSING_STYLE_ID_OR_NAME =
+      Diagnostic(
+        DiagnosticArea.DATA_MAPPING,
+        DiagnosticCode.MISSING_STYLE_ID_OR_NAME,
+        DiagnosticLevel.WARNING,
+      )
+    val MISSING_BREWERY_ID_OR_NAME =
+      Diagnostic(
+        DiagnosticArea.DATA_MAPPING,
+        DiagnosticCode.MISSING_BREWERY_ID_OR_NAME,
+        DiagnosticLevel.WARNING,
+      )
   }
 }

--- a/core-common/src/main/kotlin/com/simtop/core/core/AnalyticsTracker.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/AnalyticsTracker.kt
@@ -1,11 +1,9 @@
 package com.simtop.core.core
 
 fun interface AnalyticsTracker {
-  fun logEvent(name: String, params: Map<String, String>)
+  fun logEvent(event: AnalyticsEvent)
 }
 
-fun AnalyticsTracker.logEvent(name: String) = logEvent(name, emptyMap())
-
 class NoOpAnalyticsTracker : AnalyticsTracker {
-  override fun logEvent(name: String, params: Map<String, String>) = Unit
+  override fun logEvent(event: AnalyticsEvent) = Unit
 }

--- a/core-common/src/main/kotlin/com/simtop/core/core/CrashReporter.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/CrashReporter.kt
@@ -1,17 +1,17 @@
 package com.simtop.core.core
 
 interface CrashReporter {
-  fun recordException(throwable: Throwable)
+  fun record(diagnostic: Diagnostic)
 
-  fun log(message: String)
+  fun log(diagnostic: Diagnostic)
 
-  fun setCustomKey(key: String, value: String)
+  fun setContext(context: CrashContext)
 }
 
 class NoOpCrashReporter : CrashReporter {
-  override fun recordException(throwable: Throwable) = Unit
+  override fun record(diagnostic: Diagnostic) = Unit
 
-  override fun log(message: String) = Unit
+  override fun log(diagnostic: Diagnostic) = Unit
 
-  override fun setCustomKey(key: String, value: String) = Unit
+  override fun setContext(context: CrashContext) = Unit
 }

--- a/core-common/src/main/kotlin/com/simtop/core/core/Logger.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/Logger.kt
@@ -8,20 +8,21 @@ enum class LogPriority {
 }
 
 fun interface Logger {
-  fun log(priority: LogPriority, tag: String, message: String, throwable: Throwable?)
+  fun log(priority: LogPriority, tag: LogTag, diagnostic: Diagnostic)
 
-  fun debug(tag: String, message: String) = log(LogPriority.DEBUG, tag, message, null)
+  fun debug(tag: LogTag, diagnostic: Diagnostic) = log(LogPriority.DEBUG, tag, diagnostic)
 
-  fun info(tag: String, message: String) = log(LogPriority.INFO, tag, message, null)
+  fun info(tag: LogTag, diagnostic: Diagnostic) = log(LogPriority.INFO, tag, diagnostic)
 
-  fun warn(tag: String, message: String, throwable: Throwable? = null) =
-    log(LogPriority.WARN, tag, message, throwable)
+  fun warn(tag: LogTag, diagnostic: Diagnostic) = log(LogPriority.WARN, tag, diagnostic)
 
-  fun error(tag: String, message: String, throwable: Throwable? = null) =
-    log(LogPriority.ERROR, tag, message, throwable)
+  fun error(tag: LogTag, diagnostic: Diagnostic) = log(LogPriority.ERROR, tag, diagnostic)
+}
+
+enum class LogTag(val value: String) {
+  BEERS_MAPPER("BeersMapper")
 }
 
 class NoOpLogger : Logger {
-  override fun log(priority: LogPriority, tag: String, message: String, throwable: Throwable?) =
-    Unit
+  override fun log(priority: LogPriority, tag: LogTag, diagnostic: Diagnostic) = Unit
 }

--- a/core-common/src/main/kotlin/com/simtop/core/core/Observability.kt
+++ b/core-common/src/main/kotlin/com/simtop/core/core/Observability.kt
@@ -1,0 +1,121 @@
+package com.simtop.core.core
+
+/**
+ * The only analytics events the application is allowed to emit.
+ *
+ * There is intentionally no free-form event name or parameter map here. In particular, search text,
+ * URLs and exception messages have no representation in this contract.
+ */
+sealed interface AnalyticsEvent {
+  val name: Name
+
+  enum class Name {
+    APP_OPENED,
+    SEARCH_OPENED,
+    SEARCH_SUBMITTED,
+    BEER_DETAIL_OPENED,
+    AVAILABILITY_CHANGED,
+  }
+
+  data object AppOpened : AnalyticsEvent {
+    override val name = Name.APP_OPENED
+  }
+
+  data object SearchOpened : AnalyticsEvent {
+    override val name = Name.SEARCH_OPENED
+  }
+
+  /** Search text is deliberately absent; only the bounded result count may be reported. */
+  data class SearchSubmitted(val resultCount: Int) : AnalyticsEvent {
+    init {
+      require(resultCount >= 0) { "resultCount must not be negative" }
+    }
+
+    override val name = Name.SEARCH_SUBMITTED
+  }
+
+  data class BeerDetailOpened(val beerId: CatalogId) : AnalyticsEvent {
+    override val name = Name.BEER_DETAIL_OPENED
+  }
+
+  data class AvailabilityChanged(val beerId: CatalogId, val available: Boolean) : AnalyticsEvent {
+    override val name = Name.AVAILABILITY_CHANGED
+  }
+}
+
+/** A bounded identifier for a public catalog item, never an arbitrary user or URL string. */
+@JvmInline
+value class CatalogId private constructor(val value: String) {
+  companion object {
+    private val SAFE_ID = Regex("[A-Za-z0-9_-]{1,64}")
+
+    /** Returns null for values that could contain a URL, query, fragment or free-form text. */
+    fun from(raw: String): CatalogId? = raw.takeIf(SAFE_ID::matches)?.let(::CatalogId)
+  }
+}
+
+enum class DiagnosticArea {
+  DATA_MAPPING,
+  NETWORK,
+  DATABASE,
+  NAVIGATION,
+  DYNAMIC_FEATURE,
+}
+
+enum class DiagnosticCode {
+  MISSING_BEER_ID,
+  MISSING_BEER_NAME,
+  MISSING_BEER_TRANSLATION,
+  MISSING_STYLE_ID_OR_NAME,
+  MISSING_BREWERY_ID_OR_NAME,
+  NETWORK_UNAVAILABLE,
+  HTTP_NOT_FOUND,
+  HTTP_FORBIDDEN,
+  RATE_LIMITED,
+  SERVER_FAILURE,
+  LOCAL_STORAGE_FAILURE,
+  UNKNOWN,
+}
+
+enum class DiagnosticLevel {
+  INFO,
+  WARNING,
+  ERROR,
+}
+
+/**
+ * A deliberately closed diagnostic vocabulary. It carries no message, throwable, URL or user input,
+ * so adapters cannot accidentally forward those values to a logging/crash provider.
+ */
+data class Diagnostic(
+  val area: DiagnosticArea,
+  val code: DiagnosticCode,
+  val level: DiagnosticLevel,
+)
+
+enum class ObservabilityScreen {
+  BEERS_LIST,
+  BEER_SEARCH,
+  BEER_DETAIL,
+  BEER_BROWSE,
+}
+
+enum class ObservabilityFeature {
+  BEER_DETAIL,
+  BEER_BROWSE,
+}
+
+enum class ObservabilityOperation {
+  LOAD_BEERS,
+  SEARCH_BEERS,
+  LOAD_BEER_DETAIL,
+  UPDATE_AVAILABILITY,
+  INSTALL_DYNAMIC_FEATURE,
+}
+
+/** Only bounded, non-user context may be attached to a crash report. */
+data class CrashContext(
+  val screen: ObservabilityScreen? = null,
+  val feature: ObservabilityFeature? = null,
+  val operation: ObservabilityOperation? = null,
+)

--- a/core-common/src/test/kotlin/com/simtop/core/core/ObservabilityTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/ObservabilityTest.kt
@@ -1,0 +1,109 @@
+package com.simtop.core.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ObservabilityTest {
+
+  @Test
+  fun `typed analytics event reaches the in-memory recorder`() {
+    val tracker = RecordingAnalyticsTracker()
+    val event = AnalyticsEvent.SearchSubmitted(resultCount = 12)
+
+    tracker.logEvent(event)
+
+    assertEquals(listOf(event), tracker.events)
+  }
+
+  @Test
+  fun `analytics rejects negative result counts`() {
+    assertThrows(IllegalArgumentException::class.java) {
+      AnalyticsEvent.SearchSubmitted(resultCount = -1)
+    }
+  }
+
+  @Test
+  fun `catalog ids reject URLs queries fragments and free-form text`() {
+    assertEquals("42", CatalogId.from("42")?.value)
+    assertNull(CatalogId.from("https://brewbuddy.dev/beers/42"))
+    assertNull(CatalogId.from("42?query=secret"))
+    assertNull(CatalogId.from("search text"))
+  }
+
+  @Test
+  fun `typed diagnostic and context reach the crash recorder`() {
+    val reporter = RecordingCrashReporter()
+    val diagnostic =
+      Diagnostic(
+        area = DiagnosticArea.NETWORK,
+        code = DiagnosticCode.NETWORK_UNAVAILABLE,
+        level = DiagnosticLevel.ERROR,
+      )
+    val context = CrashContext(operation = ObservabilityOperation.LOAD_BEERS)
+
+    reporter.record(diagnostic)
+    reporter.log(diagnostic)
+    reporter.setContext(context)
+
+    assertEquals(listOf(diagnostic), reporter.recorded)
+    assertEquals(listOf(diagnostic), reporter.logged)
+    assertEquals(listOf(context), reporter.contexts)
+  }
+
+  @Test
+  fun `logger records only structured diagnostics`() {
+    val logger = RecordingLogger()
+    val diagnostic =
+      Diagnostic(
+        area = DiagnosticArea.DATA_MAPPING,
+        code = DiagnosticCode.MISSING_BEER_ID,
+        level = DiagnosticLevel.WARNING,
+      )
+
+    logger.warn(LogTag.BEERS_MAPPER, diagnostic)
+
+    assertEquals(LogPriority.WARN, logger.priority)
+    assertEquals(LogTag.BEERS_MAPPER, logger.tag)
+    assertEquals(diagnostic, logger.diagnostic)
+  }
+
+  private class RecordingAnalyticsTracker : AnalyticsTracker {
+    val events = mutableListOf<AnalyticsEvent>()
+
+    override fun logEvent(event: AnalyticsEvent) {
+      events += event
+    }
+  }
+
+  private class RecordingCrashReporter : CrashReporter {
+    val recorded = mutableListOf<Diagnostic>()
+    val logged = mutableListOf<Diagnostic>()
+    val contexts = mutableListOf<CrashContext>()
+
+    override fun record(diagnostic: Diagnostic) {
+      recorded += diagnostic
+    }
+
+    override fun log(diagnostic: Diagnostic) {
+      logged += diagnostic
+    }
+
+    override fun setContext(context: CrashContext) {
+      contexts += context
+    }
+  }
+
+  private class RecordingLogger : Logger {
+    var priority: LogPriority? = null
+    var tag: LogTag? = null
+    var diagnostic: Diagnostic? = null
+
+    override fun log(priority: LogPriority, tag: LogTag, diagnostic: Diagnostic) {
+      this.priority = priority
+      this.tag = tag
+      this.diagnostic = diagnostic
+    }
+  }
+}

--- a/core/src/main/java/com/simtop/core/di/ObservabilityModule.kt
+++ b/core/src/main/java/com/simtop/core/di/ObservabilityModule.kt
@@ -12,9 +12,10 @@ import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 
 /**
- * The observability seam: swap [NoOpAnalyticsTracker] / [NoOpCrashReporter] for real backends
- * (Firebase Analytics, Crashlytics, Sentry, ...) here, one binding at a time, without touching any
- * call site.
+ * The account-free observability seam. The default bindings do nothing for analytics and crash
+ * reporting; the logger only receives the closed [com.simtop.core.core.Diagnostic] vocabulary. A
+ * future adapter may be bound here after a real provider and consent policy exist, without changing
+ * call sites or widening the data contract.
  */
 @ContributesTo(AppScope::class)
 interface ObservabilityModule {

--- a/core/src/main/java/com/simtop/core/observability/AndroidLogcatLogger.kt
+++ b/core/src/main/java/com/simtop/core/observability/AndroidLogcatLogger.kt
@@ -1,20 +1,23 @@
 package com.simtop.core.observability
 
 import android.util.Log
+import com.simtop.core.core.Diagnostic
 import com.simtop.core.core.LogPriority
+import com.simtop.core.core.LogTag
 import com.simtop.core.core.Logger
 
 /**
- * Only reached through DI in the running app - unit tests inject [com.simtop.core.core.NoOpLogger]
- * or a fake instead, so android.util.Log's unmocked-by-default JVM stub is never on the call path.
+ * Only reached through DI in the running app. The structured diagnostic is rendered from its closed
+ * vocabulary; no caller-controlled message or throwable reaches Logcat.
  */
 class AndroidLogcatLogger : Logger {
-  override fun log(priority: LogPriority, tag: String, message: String, throwable: Throwable?) {
+  override fun log(priority: LogPriority, tag: LogTag, diagnostic: Diagnostic) {
+    val message = "${diagnostic.area}:${diagnostic.code}:${diagnostic.level}"
     when (priority) {
-      LogPriority.DEBUG -> Log.d(tag, message, throwable)
-      LogPriority.INFO -> Log.i(tag, message, throwable)
-      LogPriority.WARN -> Log.w(tag, message, throwable)
-      LogPriority.ERROR -> Log.e(tag, message, throwable)
+      LogPriority.DEBUG -> Log.d(tag.value, message)
+      LogPriority.INFO -> Log.i(tag.value, message)
+      LogPriority.WARN -> Log.w(tag.value, message)
+      LogPriority.ERROR -> Log.e(tag.value, message)
     }
   }
 }


### PR DESCRIPTION
Adds the N3 observability slice from the roadmap.

Replaces free-form analytics, crash, and logger payloads with typed events, bounded diagnostics/context, and privacy tests. Keeps default DI bindings no-op and account-free, and migrates BeersMapper warnings.

Stacked on feature/release-confidence-smoke (#214). Verified with make test, make konsist, Detekt, architecture policy, and Android Lint.