### PR TITLE
chore: run maintenance workflows monthly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,7 +507,7 @@ jobs:
       - name: Run instrumented tests on the managed devices
         id: managed_device_tests
         # The `ci` group is the ATD fast lane. The slower API 37 lane is the `compat` group and
-        # runs weekly (.github/workflows/weekly-compat.yml). Which devices those mean is defined
+        # runs monthly (.github/workflows/weekly-compat.yml). Which devices those mean is defined
         # in build-logic, not here.
         # --profile is timing-only and keeps the configuration cache enabled. Its task-level report
         # separates device setup, APK assembly, and managed-device execution so the next

--- a/.github/workflows/gitleaks-version-check.yml
+++ b/.github/workflows/gitleaks-version-check.yml
@@ -4,11 +4,12 @@ name: Weekly Gitleaks Version Check
 # Action, so Dependabot never bumps it (ADR 0006 accepts the manual two-line update as the cost of
 # closing the mutable-supply-chain surface). Without a reminder it can silently drift behind CVE
 # fixes. This lane compares the pinned version against the latest release once a week and opens an
-# issue on drift - the bump itself stays a deliberate, human-reviewed change.
+# issue on drift - the bump itself stays a deliberate, human-reviewed change. The other scheduled
+# maintenance lanes run monthly.
 
 on:
   schedule:
-    # 05:00 UTC every Saturday (before the compat lane at 06:00 and health report at 07:00).
+    # 05:00 UTC every Saturday.
     - cron: '0 5 * * 6'
   workflow_dispatch:
 

--- a/.github/workflows/health-report.yml
+++ b/.github/workflows/health-report.yml
@@ -1,4 +1,4 @@
-name: Weekly Health Report
+name: Monthly Health Report
 
 # Aggregates read-only health checks into Markdown and versioned JSON. The current report is
 # published in the run's Step Summary and retained as a downloadable artifact. The tracked
@@ -6,8 +6,8 @@ name: Weekly Health Report
 
 on:
   schedule:
-    # 07:00 UTC every Saturday (after the forward-compat lane at 06:00).
-    - cron: '0 7 * * 6'
+    # 07:00 UTC on the first day of each month (after the forward-compat lane at 06:00).
+    - cron: '0 7 1 * *'
   workflow_dispatch:
 
 permissions:
@@ -94,5 +94,5 @@ jobs:
         with:
           name: health-report
           path: build/reports/health
-          retention-days: 30
+          retention-days: 60
           if-no-files-found: error

--- a/.github/workflows/weekly-build-tool-compat.yml
+++ b/.github/workflows/weekly-build-tool-compat.yml
@@ -1,4 +1,4 @@
-name: Weekly Build-Tool Forward Compatibility
+name: Monthly Build-Tool Forward Compatibility
 
 # This is deliberately separate from ci.yml. It exercises the build platform on the supported
 # wrapper and Gradle's next distribution without becoming a required per-PR release pipeline.
@@ -6,8 +6,8 @@ name: Weekly Build-Tool Forward Compatibility
 # publishes a release candidate.
 on:
   schedule:
-    # 05:00 UTC every Saturday, before the device-compatibility and health-report workflows.
-    - cron: '0 5 * * 6'
+    # 05:00 UTC on the first day of each month.
+    - cron: '0 5 1 * *'
   workflow_dispatch:
 
 permissions:
@@ -60,6 +60,8 @@ jobs:
             --no-configuration-cache \
             --warning-mode all \
             --console=plain 2>&1 | tee -a "$WARNING_LOG"
+          GRADLE_COMMAND="$GRADLE_COMMAND" bash scripts/check-gradle-compatibility-flags.sh \
+            2>&1 | tee -a "$WARNING_LOG"
           bash scripts/check-gradle-warnings.sh "$WARNING_LOG"
 
       - name: Archive build-tool compatibility log

--- a/.github/workflows/weekly-compat.yml
+++ b/.github/workflows/weekly-compat.yml
@@ -1,4 +1,4 @@
-name: Weekly Forward-Compat Tests
+name: Monthly Forward-Compat Tests
 
 # Instrumented tests on the newest device lane (API 37, one above targetSdk). Kept off the
 # per-push path because its full system image takes ~2m28s just to boot, against ~30s for the
@@ -10,8 +10,8 @@ name: Weekly Forward-Compat Tests
 
 on:
   schedule:
-    # 06:00 UTC every Saturday.
-    - cron: '0 6 * * 6'
+    # 06:00 UTC on the first day of each month.
+    - cron: '0 6 1 * *'
   workflow_dispatch:
 
 jobs:
@@ -21,20 +21,21 @@ jobs:
     outputs:
       run: ${{ steps.check.outputs.run }}
     steps:
-      - name: Check for commits in the last week
+      - name: Check for commits in the last 35 days
         id: check
-        # The schedule is weekly, so "commits in the last 7 days" is exactly "merged since the
-        # last scheduled run". Queried through the API rather than `git log` on purpose: a
-        # checkout defaults to depth 1, which would make the window silently always-empty.
+        # The schedule is monthly, so a 35-day window covers the interval since the last scheduled
+        # run even across short months or a delayed run. Queried through the API rather than
+        # `git log` on purpose: a checkout defaults to depth 1, which would make the window silently
+        # always-empty.
         run: |
-          SINCE=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
+          SINCE=$(date -u -d '35 days ago' +%Y-%m-%dT%H:%M:%SZ)
           COUNT=$(gh api "repos/${{ github.repository }}/commits?sha=master&since=$SINCE" --jq 'length')
           echo "Commits on master since $SINCE: $COUNT"
           if [ "$COUNT" -gt 0 ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "Nothing merged in the last week - skipping the compat run."
+            echo "Nothing merged in the last 35 days - skipping the compat run."
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,7 +79,7 @@ jobs:
       # package registry, and setup fails on an unset property). This lane's one run actually HIT
       # that cache and passed - but only because the cache held the API 35 ATD image while this
       # lane provisions the API 37 image, so its install path never saw the restored dir. That
-      # protection is one eviction cycle away from gone: a weekly run on a cache miss would save
+      # protection is one eviction cycle away from gone: a monthly run on a cache miss would save
       # the API 37 image and the next hit would fail setup exactly like ci.yml's lane did. See
       # ci.yml for the conditions a correct re-introduction must meet.
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ UI_TEST_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,:app:)
 # One local output filter. Gateway sessions can export GRADLE_RUNNER=./gradlew.
 GRADLE_RUNNER ?= $(shell if command -v rtk >/dev/null 2>&1; then echo "rtk gradlew"; else echo "./gradlew"; fi)
 
-.PHONY: detekt-baseline help setup setup-ai-tools update-android-skills build bundle-release release-smoke install clean test test-tier-inventory konsist check-data-layer-boundary architecture-policy compose-metrics ui-test ui-test-local ui-test-managed ui-test-managed-newest ui-test-managed-ci ui-test-managed-all emulator-create emulator-recreate emulator-start emulator-stop emulator-status emulator-delete screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline verification-metadata health module-graph metro-graph architecture-report repo-doctor benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark build-budget build-budget-check jacoco-report coverage-check install-profiler install-diffuse new-feature-module new-dev-app play-listing-check play-listing-capture play-listing-reset store-frames
+.PHONY: detekt-baseline help setup setup-ai-tools update-android-skills build bundle-release release-smoke install clean test test-tier-inventory konsist check-data-layer-boundary architecture-policy compose-metrics ui-test ui-test-local ui-test-managed ui-test-managed-newest ui-test-managed-ci ui-test-managed-all emulator-create emulator-recreate emulator-start emulator-stop emulator-status emulator-delete screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline check-gradle-compatibility-flags verification-metadata health module-graph metro-graph architecture-report repo-doctor benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark build-budget build-budget-check jacoco-report coverage-check install-profiler install-diffuse new-feature-module new-dev-app play-listing-check play-listing-capture play-listing-reset store-frames
 
 help: ## Show this help message.
 	@echo "\n📊 BillionBeers Makefile Help"
@@ -235,6 +235,9 @@ dependency-guard: ## Verify the app's release runtime dependency graph against i
 
 dependency-guard-baseline: ## Re-baseline the dependency graph after an intentional change (review the diff before committing).
 	$(GRADLE_RUNNER) :app:dependencyGuardBaseline
+
+check-gradle-compatibility-flags: ## Probe whether AGP/Kotlin compatibility properties can be removed.
+	@bash scripts/check-gradle-compatibility-flags.sh
 
 # The task set mirrors every root-build task CI executes plus assembleDebug for local builds - the
 # ledger only covers configurations a build actually resolves, so anything CI runs must be resolved

--- a/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/billionbeers.android.managed.device.gradle.kts
@@ -18,12 +18,12 @@ import com.android.build.api.dsl.ManagedVirtualDevice
  *   It remains a separate compatibility lane because it exercises the latest platform APIs and
  *   the production target behavior; there are no ATD images for 37, so this one pays full price.
  *
- * The fast lane runs on every push; the newest lane runs weekly, because booting its full image
+ * The fast lane runs on every push; the newest lane runs monthly, because booting its full image
  * costs ~2m28s against the ATD's ~30s.
  *
  *     ./gradlew :app:atdApi35DebugAndroidTest       # one device, one module
  *     ./gradlew ciGroupDebugAndroidTest             # fast lane, every opted-in module (per push)
- *     ./gradlew compatGroupDebugAndroidTest         # newest lane, every opted-in module (weekly)
+ *     ./gradlew compatGroupDebugAndroidTest         # newest lane, every opted-in module (monthly)
  *     ./gradlew allDevicesDebugAndroidTest          # every device, every opted-in module
  *
  * Opt in per module (`id("billionbeers.android.managed.device")`) rather than applying this from
@@ -61,14 +61,14 @@ fun ManagedDevices.configureBillionBeersDevices(testedAbiForHost: String) {
 
     // Groups exist so the workflows never name devices: lanes change here, CI stays untouched.
     // Both are currently groups of one, which is deliberate - it keeps that indirection while the
-    // split is "fast lane on every push, slow lane weekly".
+    // split is "fast lane on every push, slow lane monthly".
 
     // Every push and PR. Measured on a GitHub runner: ~1m for both modules.
     groups.create("ci") {
         targetDevices.add(fastLane)
     }
 
-    // Weekly only (.github/workflows/weekly-compat.yml). Measured at ~3m45s, of which 2m28s is
+    // Monthly only (.github/workflows/weekly-compat.yml). Measured at ~3m45s, of which 2m28s is
     // just booting the full image - which is why it is not on the per-push path.
     groups.create("compat") {
         targetDevices.add(newest)

--- a/config/build-time-budget.txt
+++ b/config/build-time-budget.txt
@@ -15,14 +15,14 @@
 #   2. The `ratio` line below is the machine-independent half, and the one worth arguing from.
 #      Two scenarios measured on the same machine in the same run cancel out the hardware.
 #
-# Baseline measured 2026-08-07, 6 warm-ups + 10 iterations (ADR 0011 has the full table):
+# Baseline measured 2026-09-06, 6 warm-ups + 10 iterations (ADR 0011 has the full table):
 #
 #   scenario            median    min     max   spread
-#   clean_build_cold      37.3   29.7    59.3      79%
-#   clean_build_warm       4.3    2.5    11.5     207%
-#   incremental_leaf       2.3    1.8     3.7      81%
-#   incremental_deep       2.5    2.0     3.4      58%
-#   unit_tests             5.6    4.9     6.6      32%
+#   clean_build_cold      26.8   24.4    92.1     253%
+#   clean_build_warm       8.7    3.8    14.6     125%
+#   incremental_leaf       3.0    2.5     3.5      33%
+#   incremental_deep       2.8    2.5     3.5      35%
+#   unit_tests              4.6    4.1     6.7      56%
 
 clean_build_cold  120
 clean_build_warm   20
@@ -32,12 +32,12 @@ unit_tests         20
 
 # The modularization guard, and the only line here that survives a change of hardware.
 #
-# Measured at 1.11x: an ABI change to `Beer` in `:beerdomain:api` (ten dependent modules) costs
-# essentially the same as one to `MainActivity` in `:app` (no dependents). At ~2.4s per build, both
+# Measured at 0.95x: an ABI change to `Beer` in `:beerdomain:api` (ten dependent modules) costs
+# essentially the same as one to `MainActivity` in `:app` (no dependents). At ~2.9s per build, both
 # are dominated by Gradle's fixed per-build overhead rather than by compilation, so the fan-out is
 # not what you are paying for.
 #
-# The limit is 3x rather than something near 1.11x on purpose: the ratio of two small, noisy numbers
+# The limit is 3x rather than something near 0.95x on purpose: the ratio of two small, noisy numbers
 # is itself noisy, and this is a guard against incremental compilation breaking across module
 # boundaries - the failure where a deep change starts recompiling the world. If it ever trips,
 # the question is "what stopped being incremental", not "which module got slower".

--- a/docs/adr/0007-gradle-dependency-verification.md
+++ b/docs/adr/0007-gradle-dependency-verification.md
@@ -112,6 +112,21 @@ Executing it from this target would add runtime without adding entries to the ro
 included build is still resolved while configuring the root build, so the convention plugins needed
 by root tasks remain covered.
 
+### Trust decision for standalone build-logic tests
+
+The standalone `./gradlew -p build-logic :convention:test` invocation is intentionally **not**
+claimed to be protected by the root verification ledger. It is a separate Gradle build with its own
+settings, dependency-resolution management and user-home state; the root
+`gradle/verification-metadata.xml` is not consulted for its test-only dependencies. The test task is
+still required in the normal unit-test and monthly build-tool compatibility checks, but execution
+coverage and dependency verification are different claims.
+
+If the standalone build is later brought under verification, it must get a sustainable, explicit
+path: a `build-logic/gradle/verification-metadata.xml` ledger, a documented
+`--write-verification-metadata` regeneration target that runs the complete `:convention:test` graph,
+and a CI check that uses that ledger. Merely invoking the test from the root writer, or asserting
+that the root ledger exists, would not provide that protection.
+
 ### Resolution-only writer is an experiment, not an assumption
 
 `verification-metadata-reference` retains actual GMD and release-smoke execution and remains the

--- a/docs/adr/0011-build-time-budget.md
+++ b/docs/adr/0011-build-time-budget.md
@@ -48,7 +48,7 @@ a runner-assignment detector with a build-time label on it, and the failure mode
 having no gate — it would go red for reasons no one can act on, and be disabled within a month.
 
 The local numbers below reinforce it independently: even on one quiet machine, `clean_build_cold`
-ranged 29.7s–59.3s across ten iterations. Adding shared-runner variance on top of that is not a
+ranged 24.4s–92.1s across ten iterations. Adding shared-runner variance on top of that is not a
 signal anyone can threshold.
 
 A deterministic, machine-independent CI check was considered — executed-task count or task-graph
@@ -56,21 +56,26 @@ size for a fixed change. Rejected for this ADR: it catches "a plugin added 200 t
 to incremental compilation breaking, which is the actual risk. Graph-shape enforcement belongs in
 `:konsist`, not here.
 
-## The baseline
+## The latest baseline
 
-Measured 2026-08-07 on an Apple M1 Pro (8 cores, 16 GB, macOS 26.5, JDK 24) with the settings
-`make build-budget` uses — 6 warm-ups and 10 measured iterations per scenario.
+Measured 2026-09-06 on the same Apple M1 Pro (8 cores, 16 GB, macOS 26.5, JDK 24), using Gradle
+9.7.1 and the settings `make build-budget` uses — 6 warm-ups and 10 measured iterations per
+scenario.
 
 | Scenario | median | min | max | spread | stdev |
 |---|---|---|---|---|---|
-| `clean_build_cold` | 37.3s | 29.7s | 59.3s | 79% | 9.6 |
-| `clean_build_warm` | 4.3s | 2.5s | 11.5s | 207% | 2.8 |
-| `incremental_leaf` | 2.3s | 1.8s | 3.7s | 81% | 0.6 |
-| `incremental_deep` | 2.5s | 2.0s | 3.4s | 58% | 0.5 |
-| `unit_tests` | 5.6s | 4.9s | 6.6s | 32% | 0.6 |
+| `clean_build_cold` | 26.8s | 24.4s | 92.1s | 253% | 20.7 |
+| `clean_build_warm` | 8.7s | 3.8s | 14.6s | 125% | 4.0 |
+| `incremental_leaf` | 3.0s | 2.5s | 3.5s | 33% | 0.3 |
+| `incremental_deep` | 2.8s | 2.5s | 3.5s | 35% | 0.3 |
+| `unit_tests` | 4.6s | 4.1s | 6.7s | 56% | 0.8 |
 
-**A clean build with no caches is 37s; with warm caches it is 4s.** That is the answer to the
+**A clean build with no caches is 27s; with warm caches it is 9s.** That is the answer to the
 question this ADR exists to make answerable.
+
+The previous baseline, measured 2026-08-07, was `37.3s / 4.3s / 2.3s / 2.5s / 5.6s` for the
+same five scenarios in table order. The change is retained here as dated history rather than
+treated as a regression signal: the cold and warm samples are noisy, machine-specific measurements.
 
 ### The finding that contradicts the scenario's own premise
 
@@ -80,9 +85,9 @@ incremental build, presented as the representative one. The replacement changes 
 `:beerdomain:api`, which ten modules depend on.
 
 The expectation was that the deep change would be substantially more expensive, and that the gap
-would quantify what modularization buys. **It measured 1.11x — 2.5s against 2.3s.**
+would quantify what modularization buys. **This run measured 0.95x — 2.8s against 3.0s.**
 
-The honest reading is not "incremental compilation is extraordinarily good." It is that at ~2.4s per
+The honest reading is not "incremental compilation is extraordinarily good." It is that at ~2.9s per
 build, **fixed per-build overhead dominates and compilation is not what you are paying for.**
 Configuration, task-graph construction and up-to-date checking swamp the difference between
 recompiling one module and recompiling eleven.

--- a/docs/gradle-compatibility.md
+++ b/docs/gradle-compatibility.md
@@ -33,9 +33,29 @@ JDK and network behavior are deliberately revisited.
 This file should be updated in the same change as a Gradle/AGP/Detekt/AndroidX upgrade. A clean
 warning report is a release criterion for moving to Gradle 10, not a reason to suppress warnings.
 
+## AGP/Kotlin compatibility properties
+
+`gradle.properties` retains five AGP/Kotlin compatibility settings while the project moves through
+the AGP 9 migration: two built-in-Kotlin coexistence suppressions, `android.uniquePackageNames=false`,
+`android.dependency.useConstraints=false` and `android.r8.strictFullModeForKeepRules=false`. Each
+comment names the owning tool and the behavior that must be exercised before removing it.
+
+Run the reproducible removal probe with:
+
+```text
+make check-gradle-compatibility-flags
+```
+
+The probe copies the checkout to a temporary directory, removes one logical exception at a time,
+and exercises the relevant behavior: full-graph configuration, debug assembly, release dependency
+resolution or minified release-smoke assembly. A passing probe demonstrates build compatibility on
+the current toolchain; it does not by itself approve a changed dependency graph or prove every
+future Kotlin/AGP combination. The monthly forward-compatibility workflow runs the same probe with
+both the supported wrapper and Gradle nightly.
+
 ## Automated forward-compatibility check
 
-`.github/workflows/weekly-build-tool-compat.yml` runs every Saturday and on demand. It configures
+`.github/workflows/weekly-build-tool-compat.yml` runs monthly and on demand. It configures
 the full project with the checked-in Gradle wrapper, runs the convention-plugin contract tests, and
 repeats the same smoke check with Gradle nightly. The nightly job is intentionally outside the
 required PR gate: it is an early signal for Gradle/AGP changes, not a claim that nightly is a

--- a/docs/health/SAMPLE.md
+++ b/docs/health/SAMPLE.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > This is a historical example captured on **2026-07-23**, not the repository's current health.
 > Download the latest `health-report` artifact or read the Step Summary from the
-> [Weekly Health Report workflow](https://github.com/simtop/BillionBeers/actions/workflows/health-report.yml).
+> [Monthly Health Report workflow](https://github.com/simtop/BillionBeers/actions/workflows/health-report.yml).
 > Run `make health` to generate current local reports under `build/reports/health/`.
 
 _Generated 2026-07-23 21:26 UTC_ · retained only to show the report format that existed when health reporting was introduced.

--- a/gradle.properties
+++ b/gradle.properties
@@ -68,11 +68,18 @@ android.enableJetifier=false
 # Official Kotlin code style
 kotlin.code.style=official
 
-# Gradle 9 & AGP 9.0 Modernization Properties:
-# -------------------------------------------
-# Ignore the built-in Kotlin support check to allow manual configuration adjustments if needed
+# Gradle 9 & AGP 9.0 compatibility properties:
+# ----------------------------------------------
+# These are deliberate compatibility exceptions, not proof that the next toolchain still needs
+# them. Each has an owner and a removal probe in scripts/check-gradle-compatibility-flags.sh. Run
+# `make check-gradle-compatibility-flags` after an AGP/Kotlin/Gradle upgrade; it removes one
+# property at a time in a temporary copy and exercises the narrowest affected build behavior.
+#
+# Owner: Kotlin Gradle plugin / AGP integration. Keep while AGP's built-in Kotlin support and the
+# standalone Kotlin plugin are both applied. Removal probe: configure the full graph with `help`.
 systemProp.kotlin.ignore.agp.builtin.kotlin=true
-# Suppress the warning when AGP with built-in Kotlin is applied alongside standalone Kotlin plugin
+# Owner: Kotlin Gradle plugin / AGP integration. Suppresses the companion coexistence diagnostic.
+# Removal probe: the same full-graph `help` run, with both built-in-Kotlin properties absent.
 systemProp.kotlin.diagnostics.suppress.AgpWithBuiltInKotlinApplied=true
 ksp.useKSP2=true
 # Non-transitive R classes: each module only sees its own resources, reducing APK size.
@@ -85,16 +92,20 @@ android.r8.optimizedResourceShrinking=true
 androidx.benchmark.suppressErrors=EMULATOR,DEBUGGABLE,NOT-SELF-INSTRUMENTING
 androidx.benchmark.enabledRules=Microbenchmark,Macrobenchmark
 
-# AGP 9.0 Migration Flags:
-# --------------------------
+# AGP 9.0 compatibility exceptions:
+# ----------------------------------
 # Run unit tests for all build types, not just the tested one.
 android.onlyEnableUnitTestForTheTestedBuildType=false
-# Disable unique package name enforcement (allows multi-module projects to share package namespaces).
+# Owner: Android Gradle Plugin. Preserves the pre-AGP-9 namespace behavior while the module graph
+# is allowed to contain shared package prefixes. Removal probe: `:app:assembleDebug`.
 android.uniquePackageNames=false
-# Skip AGP's dependency constraints, which improves project import perf on large repos.
+# Owner: Android Gradle Plugin dependency resolution. Keeps the pre-AGP-9 dependency graph while
+# the effect of library constraints is reviewed. Removal probe: resolve the app's
+# `releaseRuntimeClasspath`; the minified release-smoke build is the separate R8 probe.
 # (AGP-recommended replacement for the removed excludeLibraryComponentsFromConstraints flag.)
 android.dependency.useConstraints=false
-# Relax R8 strict full-mode for keep rules (prevents crashes from overly aggressive shrinking).
+# Owner: Android Gradle Plugin / R8. Retains the permissive keep-rule interpretation until the
+# minified release graph is proven under strict full mode. Removal probe: `:app:assembleReleaseSmoke`.
 android.r8.strictFullModeForKeepRules=false
 
 # Enabled parallel sync for Gradle 9.4+

--- a/scripts/check-gradle-compatibility-flags.sh
+++ b/scripts/check-gradle-compatibility-flags.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Removal probes for the AGP/Kotlin compatibility properties in gradle.properties.
+#
+# This intentionally uses a temporary copy. A successful build with the properties present only
+# proves that the compatibility path still works; it says nothing about whether the properties can
+# be removed. Each probe starts from a fresh copy and removes one logical exception before running
+# the smallest task that exercises its owner.
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+gradle_command="${GRADLE_COMMAND:-./gradlew}"
+probe_root="$(mktemp -d "${TMPDIR:-/tmp}/billionbeers-gradle-compat.XXXXXX")"
+trap 'rm -rf "$probe_root"' EXIT
+
+if ! command -v rsync >/dev/null 2>&1; then
+  echo "error: rsync is required to create the isolated removal probe copy" >&2
+  exit 1
+fi
+
+copy_project() {
+  local destination="$1"
+  mkdir -p "$destination"
+  rsync -a \
+    --exclude '.git/' \
+    --exclude '.gradle/' \
+    --exclude 'gradle-user-home/' \
+    --exclude 'build/' \
+    --exclude 'profile-out/' \
+    --exclude 'rod/' \
+    --exclude '.claude/' \
+    --exclude '.agents/' \
+    --exclude '.idea/' \
+    --exclude '.vscode/' \
+    "$repo_root/" "$destination/"
+}
+
+remove_properties() {
+  local project_dir="$1"
+  shift
+  local property
+  local expression
+  for property in "$@"; do
+    expression="^${property//./\\.}=.*$"
+    sed -i.bak "/${expression}/d" "$project_dir/gradle.properties"
+  done
+}
+
+run_probe() {
+  local name="$1"
+  local description="$2"
+  shift 2
+  local project_dir="$probe_root/$name"
+  copy_project "$project_dir"
+
+  local -a properties=()
+  while [[ "$1" != "--" ]]; do
+    properties+=("$1")
+    shift
+  done
+  shift
+  local -a task_args=("$@")
+
+  remove_properties "$project_dir" "${properties[@]}"
+  echo "==> $name: $description"
+  if (
+    cd "$project_dir"
+    "$gradle_command" "${task_args[@]}" \
+      --no-configuration-cache \
+      --warning-mode all \
+      --console=plain
+  ); then
+    echo "PASS $name: removed ${properties[*]}"
+  else
+    echo "FAIL $name: at least one removed compatibility property is still required" >&2
+    return 1
+  fi
+}
+
+# The two Kotlin properties are one logical suppression: AGP/Kotlin coexistence is configured
+# during full-graph configuration, before any Android task is selected.
+run_probe \
+  builtin_kotlin \
+  'configure the full project without the built-in-Kotlin suppressions' \
+  systemProp.kotlin.ignore.agp.builtin.kotlin \
+  systemProp.kotlin.diagnostics.suppress.AgpWithBuiltInKotlinApplied \
+  -- \
+  help
+
+run_probe \
+  unique_package_names \
+  'assemble the debug app without legacy shared-package behavior' \
+  android.uniquePackageNames \
+  -- \
+  :app:assembleDebug
+
+run_probe \
+  dependency_constraints \
+  'resolve the release runtime graph with AGP dependency constraints enabled' \
+  android.dependency.useConstraints \
+  -- \
+  :app:dependencies \
+  --configuration \
+  releaseRuntimeClasspath
+
+run_probe \
+  r8_strict_full_mode \
+  'assemble the minified release-smoke app with strict full-mode keep rules' \
+  android.r8.strictFullModeForKeepRules \
+  -- \
+  :app:assembleReleaseSmoke


### PR DESCRIPTION
## Summary

- Move build-tool compatibility, API 37 forward-compatibility, and health-report schedules to the first day of each month.
- Keep the Gitleaks version check weekly; widen the device lookback to 35 days and health artifact retention to 60 days.
- Add N4 compatibility-flag removal probes, trust-boundary documentation, and the refreshed build-time baseline.

## Verification

- `make test`
- `make check-gradle-compatibility-flags`
- `make build-budget-check`
- All workflow YAML parses; Gradle warning allow-list passes.