### PR TITLE
chore: complete N5 quality maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Test CI failure summary parser
         run: python3 .github/scripts/test_summarize_test_failures.py
 
+      - name: Test Markdown checker
+        run: python3 scripts/test_check_markdown_links.py
+
       - name: Set up JDK 23
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v5
         with:
@@ -64,6 +67,9 @@ jobs:
             git --no-pager diff -- README.md
             exit 1
           fi
+
+      - name: Check repository Markdown links and generated indexes
+        run: make docs-check
 
       - name: Format Fix Hint
         if: always() && steps.spotless-check.outcome == 'failure'

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ UI_TEST_PREFIX = $(if $(MODULE_TRIMMED),$(MODULE_TRIMMED):,:app:)
 # One local output filter. Gateway sessions can export GRADLE_RUNNER=./gradlew.
 GRADLE_RUNNER ?= $(shell if command -v rtk >/dev/null 2>&1; then echo "rtk gradlew"; else echo "./gradlew"; fi)
 
-.PHONY: detekt-baseline help setup setup-ai-tools update-android-skills build bundle-release release-smoke install clean test test-tier-inventory konsist check-data-layer-boundary architecture-policy compose-metrics ui-test ui-test-local ui-test-managed ui-test-managed-newest ui-test-managed-ci ui-test-managed-all emulator-create emulator-recreate emulator-start emulator-stop emulator-status emulator-delete screenshot-record screenshot-verify screenshot-clean lint android-lint format check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline check-gradle-compatibility-flags verification-metadata health module-graph metro-graph architecture-report repo-doctor benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark build-budget build-budget-check jacoco-report coverage-check install-profiler install-diffuse new-feature-module new-dev-app play-listing-check play-listing-capture play-listing-reset store-frames
+.PHONY: detekt-baseline help setup setup-ai-tools update-android-skills build bundle-release release-smoke install clean test test-tier-inventory konsist check-data-layer-boundary architecture-policy compose-metrics ui-test ui-test-local ui-test-managed ui-test-managed-newest ui-test-managed-ci ui-test-managed-all emulator-create emulator-recreate emulator-start emulator-stop emulator-status emulator-delete screenshot-record screenshot-verify screenshot-clean lint android-lint format check docs-check check-duplicates check-unused-deps dependency-guard dependency-guard-baseline check-gradle-compatibility-flags verification-metadata health module-graph metro-graph architecture-report repo-doctor benchmark-micro benchmark-macro benchmark-check generate-baseline gradle-benchmark build-budget build-budget-check jacoco-report coverage-check install-profiler install-diffuse new-feature-module new-dev-app play-listing-check play-listing-capture play-listing-reset store-frames
 
 help: ## Show this help message.
 	@echo "\n📊 BillionBeers Makefile Help"
@@ -214,6 +214,9 @@ lint: ## Run static analysis (Detekt).
 
 android-lint: ## Run Android Lint over the app and its whole library graph (checkDependencies), gated by app/lint-baseline.xml.
 	$(GRADLE_RUNNER) :app:lintDebug
+
+docs-check: ## Check repository-relative Markdown links and generated README content offline.
+	python3 scripts/check_markdown_links.py
 
 detekt-baseline: ## Re-baseline Detekt (all modules, or MODULE=:foo). ALWAYS review the diff - a baseline is a suppression, and regenerating one to silence a NEW finding buries it.
 	$(GRADLE_RUNNER) $(MODULE_PREFIX)detektBaseline

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application

--- a/core/designsystem/detekt-baseline.xml
+++ b/core/designsystem/detekt-baseline.xml
@@ -24,9 +24,5 @@
     <ID>MagicNumber:DialogWithProgressBar.kt$DialogProgressProvider$0.5f</ID>
     <ID>MatchingDeclarationName:Spacing.kt$BillionBeersSpacing</ID>
     <ID>ModifierComposed:ComposeExtensions.kt$noRippleClickable</ID>
-    <ID>ModifierMissing:CatalogDemos.kt$ColorCatalogDemo</ID>
-    <ID>ModifierMissing:CatalogDemos.kt$TypographyCatalogDemo</ID>
-    <ID>ModifierMissing:DialogWithProgressBar.kt$DialogWithProgressBarDemo</ID>
-    <ID>MutableStateAutoboxing:DialogWithProgressBar.kt$mutableStateOf(number)</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/docs/adr/0010-non-goals.md
+++ b/docs/adr/0010-non-goals.md
@@ -80,12 +80,10 @@ declines is a better signal than a token-refresh interceptor with no token behin
 
 ## Consequences
 
-- **`ACCESS_NETWORK_STATE` is declared and unread by our code.** `app/src/main/AndroidManifest.xml:4`
-  requests it; no file under any `src/` touches `ConnectivityManager` or `NetworkCapabilities`. It is
-  a leftover from the connectivity-aware retry this ADR declines. Drop the explicit declaration —
-  if Play Core still needs it, its own manifest merges it in and the line was redundant; if not, the
-  app was asking for a permission it does not use, which is exactly the drift this repo otherwise
-  refuses to tolerate.
+- **`ACCESS_NETWORK_STATE` is not requested by the app.** No file under any `src/` touches
+  `ConnectivityManager` or `NetworkCapabilities`, and the explicit manifest declaration was removed
+  after manifest-merger inspection showed it came only from the app manifest. The connectivity-aware
+  retry this ADR declines therefore does not leave an unused permission in the shipped app.
 - **No `google-services.json` is a property to protect, not an accident.** Adding Firebase would
   make a public template require a private file to build. Any future integration must survive its
   absence.

--- a/feature/beerdetail/detekt-baseline.xml
+++ b/feature/beerdetail/detekt-baseline.xml
@@ -2,10 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ModifierMissing:BeerDetailScreen.kt$BeerDetailScreenImpl</ID>
-    <ID>ModifierMissing:ComposeBeerDetail.kt$ComposeBeerDetail</ID>
-    <ID>ModifierMissing:ComposeBeerDetail.kt$StatCard</ID>
-    <ID>MultipleEmitters:ComposeBeerDetail.kt$BeerDetailBulletSection</ID>
     <ID>ViewModelInjection:BeerDetailScreen.kt$viewModel</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
+++ b/feature/beerdetail/src/main/java/com/simtop/feature/beerdetail/presentation/ComposeBeerDetail.kt
@@ -301,22 +301,24 @@ private fun Beer.detailRows(): List<Pair<String, String>> = buildList {
 @Composable
 private fun BeerDetailBulletSection(title: String, items: List<String>) {
   if (items.isEmpty()) return
-  Text(
-    text = title,
-    style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-  )
-  Spacer(
-    modifier =
-      Modifier.height(BillionBeersTheme.spacing.medium - BillionBeersTheme.spacing.extraSmall)
-  )
-  items.forEach { item ->
-    Row(modifier = Modifier.padding(vertical = BillionBeersTheme.spacing.extraSmall)) {
-      Text(
-        text = "•",
-        style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
-        modifier = Modifier.padding(end = BillionBeersTheme.spacing.small),
-      )
-      Text(text = item, style = MaterialTheme.typography.bodyLarge)
+  Column {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+    )
+    Spacer(
+      modifier =
+        Modifier.height(BillionBeersTheme.spacing.medium - BillionBeersTheme.spacing.extraSmall)
+    )
+    items.forEach { item ->
+      Row(modifier = Modifier.padding(vertical = BillionBeersTheme.spacing.extraSmall)) {
+        Text(
+          text = "•",
+          style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold),
+          modifier = Modifier.padding(end = BillionBeersTheme.spacing.small),
+        )
+        Text(text = item, style = MaterialTheme.typography.bodyLarge)
+      }
     }
   }
 }

--- a/feature/beersearch/detekt-baseline.xml
+++ b/feature/beersearch/detekt-baseline.xml
@@ -2,6 +2,5 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ModifierMissing:BeersSearchScreen.kt$BeersSearchContent</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/feature/beerslist/detekt-baseline.xml
+++ b/feature/beerslist/detekt-baseline.xml
@@ -2,7 +2,5 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ModifierMissing:BeersListScreen.kt$BeersListContent</ID>
-    <ID>ModifierMissing:BeersListScreen.kt$BeersListItemSkeleton</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/presentation_utils/detekt-baseline.xml
+++ b/presentation_utils/detekt-baseline.xml
@@ -2,9 +2,6 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ComposableParamOrder:ComposeErrorView.kt$ComposeErrorView</ID>
-    <ID>LambdaParameterInRestartableEffect:DynamicFeatureLoader.kt$onCancelled</ID>
-    <ID>LambdaParameterInRestartableEffect:InfiniteListHandler.kt$onLoadMore</ID>
     <ID>LongParameterList:DynamicFeatureInstallerTest.kt$DynamicFeatureInstallerTest$( status: Int, sessionId: Int = SESSION_ID, errorCode: Int = SplitInstallErrorCode.NO_ERROR, downloaded: Long = 0, total: Long = 0, modules: List&lt;String&gt; = listOf(MODULE), )</ID>
     <ID>MatchingDeclarationName:InfiniteListHandler.kt$ListPosition</ID>
     <ID>ParameterNaming:DynamicFeatureLoader.kt$onCancelled</ID>

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/core/DynamicFeatureLoader.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/core/DynamicFeatureLoader.kt
@@ -17,6 +17,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.retain.retain
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -45,6 +47,7 @@ fun DynamicFeatureLoader(
   content: @Composable () -> Unit,
 ) {
   val installer = rememberDynamicFeatureInstaller(featureName)
+  val currentOnCancelled by rememberUpdatedState(onCancelled)
   val status = installer.status
 
   when (status) {
@@ -72,7 +75,7 @@ fun DynamicFeatureLoader(
         onCancel = installer::cancel,
       )
 
-    InstallStatus.Cancelled -> LaunchedEffect(installer) { onCancelled() }
+    InstallStatus.Cancelled -> LaunchedEffect(installer) { currentOnCancelled() }
 
     // The in-progress states render nothing here on purpose — see the single dialog call site
     // below.

--- a/presentation_utils/src/main/java/com/simtop/presentation_utils/core/InfiniteListHandler.kt
+++ b/presentation_utils/src/main/java/com/simtop/presentation_utils/core/InfiniteListHandler.kt
@@ -3,6 +3,8 @@ package com.simtop.presentation_utils.core
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -42,6 +44,7 @@ internal fun Flow<ListPosition>.loadMoreSignals(buffer: Int): Flow<Unit> =
  */
 @Composable
 fun InfiniteListHandler(listState: LazyListState, buffer: Int = 1, onLoadMore: () -> Unit) {
+  val currentOnLoadMore by rememberUpdatedState(onLoadMore)
   LaunchedEffect(listState, buffer) {
     snapshotFlow {
         val layoutInfo = listState.layoutInfo
@@ -51,6 +54,6 @@ fun InfiniteListHandler(listState: LazyListState, buffer: Int = 1, onLoadMore: (
         )
       }
       .loadMoreSignals(buffer)
-      .collect { onLoadMore() }
+      .collect { currentOnLoadMore() }
   }
 }

--- a/scripts/check_markdown_links.py
+++ b/scripts/check_markdown_links.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Check checked-in Markdown links and generated README content without network access."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import urldefrag, urlparse
+
+MARKDOWN_SUFFIXES = {".md", ".markdown"}
+LINK_RE = re.compile(r"!?(?<!\\)\[([^\]]*)\]\(([^)\s]+)(?:\s+[^)]*)?\)")
+HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*#*\s*$", re.MULTILINE)
+ANCHOR_RE = re.compile(r'<a\s+[^>]*id=["\']([^"\']+)["\']', re.IGNORECASE)
+START_MARKER = "<!-- START_VERSIONS -->"
+END_MARKER = "<!-- END_VERSIONS -->"
+
+
+def tracked_markdown_files(root: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "-C", str(root), "ls-files", "--", "*.md", "*.markdown"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [root / path for path in result.stdout.splitlines()]
+
+
+def slug_heading(value: str) -> str:
+    value = re.sub(r"<[^>]+>", "", value).lower()
+    value = re.sub(r"[^\w\s-]", "", value)
+    return re.sub(r"[\s-]+", "-", value)
+
+
+def local_anchors(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    anchors = {slug_heading(match.group(1)) for match in HEADING_RE.finditer(text)}
+    anchors.update(ANCHOR_RE.findall(text))
+    return anchors
+
+
+def check_links(root: Path, paths: list[Path]) -> list[str]:
+    errors: list[str] = []
+    anchors = {path: local_anchors(path) for path in paths}
+    for path in paths:
+        relative_source = path.relative_to(root)
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in LINK_RE.finditer(line):
+                target = match.group(2).strip("<>")
+                parsed = urlparse(target)
+                if parsed.scheme or target.startswith("//"):
+                    continue
+                target_path, fragment = urldefrag(target)
+                resolved = (path.parent / target_path).resolve() if target_path else path
+                try:
+                    resolved.relative_to(root.resolve())
+                except ValueError:
+                    errors.append(f"{relative_source}:{line_number}: link escapes repository: {target}")
+                    continue
+                if not resolved.exists():
+                    errors.append(f"{relative_source}:{line_number}: missing link target: {target}")
+                elif fragment and resolved.is_file() and resolved.suffix in MARKDOWN_SUFFIXES:
+                    if slug_heading(fragment) not in anchors.get(resolved, local_anchors(resolved)):
+                        errors.append(
+                            f"{relative_source}:{line_number}: missing link fragment: {target}"
+                        )
+    return errors
+
+
+def required_value(pattern: str, text: str, name: str) -> str:
+    match = re.search(pattern, text, re.MULTILINE)
+    if not match or not match.group(1):
+        raise ValueError(f"could not read {name}")
+    return match.group(1)
+
+
+def expected_version_block(root: Path) -> str:
+    catalog = (root / "gradle/libs.versions.toml").read_text(encoding="utf-8")
+    wrapper = (root / "gradle/wrapper/gradle-wrapper.properties").read_text(encoding="utf-8")
+    kotlin = required_value(r'^org-jetbrains-kotlin\s*=\s*"([^"]+)"', catalog, "Kotlin version")
+    compose = required_value(r'^composeBom\s*=\s*"([^"]+)"', catalog, "Compose BOM version")
+    metro = required_value(r'^dev-zacsweers-metro\s*=\s*"([^"]+)"', catalog, "Metro version")
+    room = required_value(r'^androidx-room\s*=\s*"([^"]+)"', catalog, "Room version")
+    gradle = required_value(r"distributionUrl=.*gradle-([^-]+)-(?:all|bin)\.zip", wrapper, "Gradle version")
+    return "\n".join(
+        [
+            "| Tech | Version |",
+            "| :--- | :--- |",
+            f"| **Kotlin** | {kotlin} |",
+            f"| **Gradle** | {gradle} |",
+            f"| **Compose BOM** | {compose} |",
+            f"| **Metro DI** | {metro} |",
+            f"| **Room DB** | {room} |",
+        ]
+    )
+
+
+def check_generated_indexes(root: Path) -> list[str]:
+    readme_path = root / "README.md"
+    text = readme_path.read_text(encoding="utf-8")
+    starts = [match.start() for match in re.finditer(re.escape(START_MARKER), text)]
+    ends = [match.start() for match in re.finditer(re.escape(END_MARKER), text)]
+    if len(starts) != 1 or len(ends) != 1:
+        return ["README.md: expected exactly one START_VERSIONS and END_VERSIONS marker"]
+    if starts[0] >= ends[0]:
+        return ["README.md: START_VERSIONS must precede END_VERSIONS"]
+    try:
+        expected = expected_version_block(root)
+    except ValueError as error:
+        return [f"README.md: {error}"]
+    actual = text[starts[0] + len(START_MARKER) : ends[0]].strip()
+    if actual != expected:
+        diff = "".join(
+            difflib.unified_diff(
+                (expected + "\n").splitlines(keepends=True),
+                (actual + "\n").splitlines(keepends=True),
+                fromfile="expected README version block",
+                tofile="actual README version block",
+            )
+        )
+        return ["README.md: generated version block is stale\n" + diff.rstrip()]
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
+    args = parser.parse_args(argv)
+    root = args.root.resolve()
+    paths = tracked_markdown_files(root)
+    errors = check_links(root, paths) + check_generated_indexes(root)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    print(f"Markdown checks passed ({len(paths)} tracked files; no network access).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_markdown_links.py
+++ b/scripts/test_check_markdown_links.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("check_markdown_links.py")
+SPEC = importlib.util.spec_from_file_location("check_markdown_links", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+class MarkdownCheckTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name)
+        (self.root / "README.md").write_text("# README\n", encoding="utf-8")
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_relative_file_and_fragment_links(self):
+        source = self.root / "docs" / "guide.md"
+        source.parent.mkdir()
+        target = source.parent / "target.md"
+        target.write_text("# Installation\n", encoding="utf-8")
+        source.write_text("[target](target.md#installation)\n", encoding="utf-8")
+        self.assertEqual([], MODULE.check_links(self.root, [source, target]))
+
+    def test_missing_target_and_fragment_are_reported(self):
+        source = self.root / "guide.md"
+        source.write_text("[missing](missing.md#nowhere)\n", encoding="utf-8")
+        errors = MODULE.check_links(self.root, [source])
+        self.assertEqual(1, len(errors))
+        self.assertIn("missing link target", errors[0])
+
+        target = self.root / "target.md"
+        target.write_text("# Present\n", encoding="utf-8")
+        source.write_text("[target](target.md#absent)\n", encoding="utf-8")
+        errors = MODULE.check_links(self.root, [source, target])
+        self.assertIn("missing link fragment", errors[0])
+
+    def test_external_links_are_ignored(self):
+        source = self.root / "guide.md"
+        source.write_text(
+            "[web](https://example.com/missing) ![image](https://example.com/image.png)\n",
+            encoding="utf-8",
+        )
+        self.assertEqual([], MODULE.check_links(self.root, [source]))
+
+    def test_generated_markers_must_be_unique(self):
+        self.assertEqual(1, len(MODULE.check_generated_indexes(self.root)))
+
+    def test_generated_block_matches_expected_values(self):
+        (self.root / "gradle").mkdir()
+        (self.root / "gradle/wrapper").mkdir()
+        (self.root / "gradle/libs.versions.toml").write_text(
+            'org-jetbrains-kotlin = "2.2.20"\n'
+            'composeBom = "2026.01.00"\n'
+            'dev-zacsweers-metro = "0.11.0"\n'
+            'androidx-room = "2.8.0"\n',
+            encoding="utf-8",
+        )
+        (self.root / "gradle/wrapper/gradle-wrapper.properties").write_text(
+            "distributionUrl=https\\://services.gradle.org/distributions/gradle-9.7.1-bin.zip\n",
+            encoding="utf-8",
+        )
+        block = MODULE.expected_version_block(self.root)
+        (self.root / "README.md").write_text(
+            f"# README\n{MODULE.START_MARKER}\n{block}\n{MODULE.END_MARKER}\n",
+            encoding="utf-8",
+        )
+        self.assertEqual([], MODULE.check_generated_indexes(self.root))
+        (self.root / "README.md").write_text(
+            f"# README\n{MODULE.START_MARKER}\n{block.replace('2.2.20', 'old')}\n{MODULE.END_MARKER}\n",
+            encoding="utf-8",
+        )
+        self.assertIn("generated version block is stale", MODULE.check_generated_indexes(self.root)[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reduce verified stale Detekt debt and stabilize Compose effect callbacks
- add an offline Markdown link/generated-version checker with tests and CI wiring
- remove the unused ACCESS_NETWORK_STATE declaration after merged-manifest verification

## Verification

- make test
- make screenshot-verify
- make lint
- make android-lint
- make konsist
- make architecture-policy
- make docs-check
- spotlessCheck
