### PR TITLE
test: close quality-tool survivors

### DIFF
--- a/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/mappers/BeersMapperTest.kt
@@ -9,9 +9,16 @@ import com.simtop.beer_network.models.Language
 import com.simtop.beer_network.models.NamedEntity
 import com.simtop.beer_network.models.NamedTranslation
 import com.simtop.beer_network.models.Translation
+import com.simtop.beer_network.models.TypologyApiResponseItem
 import com.simtop.beerdomain.domain.models.Beer
+import com.simtop.core.core.Diagnostic
+import com.simtop.core.core.DiagnosticArea
+import com.simtop.core.core.DiagnosticCode
+import com.simtop.core.core.DiagnosticLevel
 import com.simtop.core.core.LanguageProvider
-import com.simtop.core.core.NoOpLogger
+import com.simtop.core.core.LogPriority
+import com.simtop.core.core.LogTag
+import com.simtop.core.core.Logger
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
@@ -19,7 +26,8 @@ import strikt.assertions.isEqualTo
 class BeersMapperTest {
 
   private var languageCode = "en"
-  private val mapper = BeersMapper(LanguageProvider { languageCode }, NoOpLogger())
+  private val recordingLogger = RecordingLogger()
+  private val mapper = BeersMapper(LanguageProvider { languageCode }, recordingLogger)
 
   private fun fullResponse() =
     BeersApiResponseItem(
@@ -66,6 +74,34 @@ class BeersMapperTest {
           abv = 0.0,
           ibu = 0.0,
           foodPairing = emptyList(),
+        )
+      )
+  }
+
+  @Test
+  fun `fromBeersApiResponseItemToBeer reports missing identity and translation diagnostics`() {
+    recordingLogger.entries.clear()
+
+    mapper.fromBeersApiResponseItemToBeer(null)
+
+    expectThat(recordingLogger.entries)
+      .isEqualTo(
+        mutableListOf(
+          Diagnostic(
+            DiagnosticArea.DATA_MAPPING,
+            DiagnosticCode.MISSING_BEER_ID,
+            DiagnosticLevel.WARNING,
+          ),
+          Diagnostic(
+            DiagnosticArea.DATA_MAPPING,
+            DiagnosticCode.MISSING_BEER_NAME,
+            DiagnosticLevel.WARNING,
+          ),
+          Diagnostic(
+            DiagnosticArea.DATA_MAPPING,
+            DiagnosticCode.MISSING_BEER_TRANSLATION,
+            DiagnosticLevel.WARNING,
+          ),
         )
       )
   }
@@ -182,6 +218,66 @@ class BeersMapperTest {
     expectThat(beer.fermentationMethod).isEqualTo("Lager")
     expectThat(beer.ingredients).isEqualTo(listOf("Dark malt"))
     expectThat(beer.recommendedGlasses).isEqualTo(listOf("Chalice"))
+  }
+
+  @Test
+  fun `style and brewery mappers report incomplete identity diagnostics`() {
+    recordingLogger.entries.clear()
+
+    mapper.fromTypologyToBeerStyle(TypologyApiResponseItem(id = null, name = null))
+    mapper.fromBreweryApiResponseItemToBrewery(BreweryApiResponseItem(id = null, name = null))
+
+    expectThat(recordingLogger.entries)
+      .isEqualTo(
+        mutableListOf(
+          Diagnostic(
+            DiagnosticArea.DATA_MAPPING,
+            DiagnosticCode.MISSING_STYLE_ID_OR_NAME,
+            DiagnosticLevel.WARNING,
+          ),
+          Diagnostic(
+            DiagnosticArea.DATA_MAPPING,
+            DiagnosticCode.MISSING_BREWERY_ID_OR_NAME,
+            DiagnosticLevel.WARNING,
+          ),
+        )
+      )
+  }
+
+  @Test
+  fun `style and brewery diagnostics identify either missing identity field`() {
+    recordingLogger.entries.clear()
+
+    mapper.fromTypologyToBeerStyle(TypologyApiResponseItem(id = null, name = "Stout"))
+    mapper.fromTypologyToBeerStyle(TypologyApiResponseItem(id = "style", name = null))
+    mapper.fromBreweryApiResponseItemToBrewery(BreweryApiResponseItem(id = null, name = "Brewery"))
+    mapper.fromBreweryApiResponseItemToBrewery(BreweryApiResponseItem(id = "brewery", name = null))
+
+    expectThat(recordingLogger.entries)
+      .isEqualTo(
+        mutableListOf(
+          Diagnostic(
+            DiagnosticArea.DATA_MAPPING,
+            DiagnosticCode.MISSING_STYLE_ID_OR_NAME,
+            DiagnosticLevel.WARNING,
+          ),
+          Diagnostic(
+            DiagnosticArea.DATA_MAPPING,
+            DiagnosticCode.MISSING_STYLE_ID_OR_NAME,
+            DiagnosticLevel.WARNING,
+          ),
+          Diagnostic(
+            DiagnosticArea.DATA_MAPPING,
+            DiagnosticCode.MISSING_BREWERY_ID_OR_NAME,
+            DiagnosticLevel.WARNING,
+          ),
+          Diagnostic(
+            DiagnosticArea.DATA_MAPPING,
+            DiagnosticCode.MISSING_BREWERY_ID_OR_NAME,
+            DiagnosticLevel.WARNING,
+          ),
+        )
+      )
   }
 
   @Test
@@ -306,5 +402,13 @@ class BeersMapperTest {
           availability = false,
         )
       )
+  }
+
+  private class RecordingLogger : Logger {
+    val entries = mutableListOf<Diagnostic>()
+
+    override fun log(priority: LogPriority, tag: LogTag, diagnostic: Diagnostic) {
+      if (priority == LogPriority.WARN && tag == LogTag.BEERS_MAPPER) entries += diagnostic
+    }
   }
 }

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/BeersPagerFactoryImplTest.kt
@@ -236,6 +236,19 @@ class BeersPagerFactoryImplTest {
     }
 
   @Test
+  fun `a page covering the reported total ends pagination immediately`() =
+    runTest(testDispatcher) {
+      beersRemoteSource.setBeersResponse(listOf(apiItem(id = "1")), totalCount = 1)
+      val pager = factory.create()
+
+      pager.loadFirstPage()
+      pager.loadNextPage()
+
+      expectThat(pager.pagingState.value).isEqualTo(PagingState.EndOfPagination(totalCount = 1))
+      expectThat(beersRemoteSource.requestedPages.toList()).isEqualTo(listOf(1))
+    }
+
+  @Test
   fun `a style-filtered pager fetches with the typology id and keeps results in memory`() =
     runTest(testDispatcher) {
       beersRemoteSource.setBeersResponse(listOf(apiItem(id = "1")), totalCount = 1)

--- a/beer_data/src/test/java/com/simtop/beer_data/repositories/FetchBeersErrorsTest.kt
+++ b/beer_data/src/test/java/com/simtop/beer_data/repositories/FetchBeersErrorsTest.kt
@@ -1,0 +1,37 @@
+package com.simtop.beer_data.repositories
+
+import com.simtop.beerdomain.domain.errors.FetchBeersError
+import java.io.IOException
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import retrofit2.HttpException
+import retrofit2.Response
+
+class FetchBeersErrorsTest {
+
+  @Test
+  fun `maps known HTTP statuses`() {
+    assertEquals(FetchBeersError.NotFound, httpException(404).toFetchBeersError())
+    assertEquals(FetchBeersError.Forbidden, httpException(403).toFetchBeersError())
+    assertEquals(FetchBeersError.RateLimited, httpException(429).toFetchBeersError())
+  }
+
+  @Test
+  fun `maps IO failures to Network`() {
+    assertEquals(FetchBeersError.Network, IOException("offline").toFetchBeersError())
+  }
+
+  @Test
+  fun `preserves unknown causes`() {
+    val http = httpException(500)
+    val other = IllegalStateException("unexpected")
+
+    assertSame(http, (http.toFetchBeersError() as FetchBeersError.Unknown).cause)
+    assertSame(other, (other.toFetchBeersError() as FetchBeersError.Unknown).cause)
+  }
+
+  private fun httpException(code: Int) =
+    HttpException(Response.error<Unit>(code, "".toResponseBody(null)))
+}

--- a/core-common/src/test/kotlin/com/simtop/core/core/EnvironmentConfigTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/EnvironmentConfigTest.kt
@@ -1,5 +1,6 @@
 package com.simtop.core.core
 
+import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertSame
@@ -38,7 +39,10 @@ class EnvironmentConfigTest {
 
   @Test
   fun `release validation rejects an endpoint other than configured production`() {
-    assertReleaseRejected("https://staging.brewbuddy.dev/")
+    assertReleaseRejected(
+      baseUrl = "https://staging.brewbuddy.dev/",
+      expectedApiBaseUrl = "https://api.brewbuddy.dev/",
+    )
   }
 
   @Test
@@ -65,9 +69,41 @@ class EnvironmentConfigTest {
     assertIllegalArgument { EnvironmentConfig("ftp://api.brewbuddy.dev/") }
   }
 
-  private fun assertReleaseRejected(baseUrl: String) {
+  @Test
+  fun `accepts case-insensitive HTTP schemes`() {
+    val config = EnvironmentConfig("HTTPS://api.brewbuddy.dev/")
+    EnvironmentConfig("HTTP://api.brewbuddy.dev/")
+
+    assertSame(config, config.validateForRelease("HTTPS://api.brewbuddy.dev/"))
+  }
+
+  @Test
+  fun `rejects a URL with a query even when it has no fragment`() {
+    assertIllegalArgument { EnvironmentConfig("https://api.brewbuddy.dev/?token=secret") }
+  }
+
+  @Test
+  fun `rejects infinite timeouts`() {
     assertIllegalArgument {
-      EnvironmentConfig(apiBaseUrl = baseUrl).validateForRelease("https://api.brewbuddy.dev/")
+      EnvironmentConfig("https://api.brewbuddy.dev/", connectTimeout = Duration.INFINITE)
+    }
+  }
+
+  @Test
+  fun `rejects every supported localhost form`() {
+    assertReleaseRejected("https://localhost/")
+    assertReleaseRejected("https://service.localhost/")
+    assertReleaseRejected("https://[::1]/")
+    assertReleaseRejected("https://127.0.0.1/")
+    assertReleaseRejected("https://0.0.0.0/")
+  }
+
+  private fun assertReleaseRejected(
+    baseUrl: String,
+    expectedApiBaseUrl: String = baseUrl,
+  ) {
+    assertIllegalArgument {
+      EnvironmentConfig(apiBaseUrl = baseUrl).validateForRelease(expectedApiBaseUrl)
     }
   }
 

--- a/core-common/src/test/kotlin/com/simtop/core/core/ObservabilityTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/ObservabilityTest.kt
@@ -25,6 +25,11 @@ class ObservabilityTest {
   }
 
   @Test
+  fun `analytics accepts zero results`() {
+    assertEquals(0, AnalyticsEvent.SearchSubmitted(resultCount = 0).resultCount)
+  }
+
+  @Test
   fun `catalog ids reject URLs queries fragments and free-form text`() {
     assertEquals("42", CatalogId.from("42")?.value)
     assertNull(CatalogId.from("https://brewbuddy.dev/beers/42"))

--- a/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
+++ b/core-common/src/test/kotlin/com/simtop/core/core/PagingMediatorTest.kt
@@ -138,6 +138,33 @@ class PagingMediatorTest {
   }
 
   @Test
+  fun `only the newest load-more event is retained while nobody collects`() = runTest {
+    var failureCount = 0
+    val mediator =
+      PagingMediator<Int, String, String>(
+        initialKey = 1,
+        fetchRemote = { key ->
+          if (key == 1) {
+            PageResult(listOf("item 1"), nextKey = 2)
+          } else {
+            failureCount++
+            error("failure $failureCount")
+          }
+        },
+        classifyError = { it.message ?: "unknown" },
+      )
+
+    mediator.loadFirstPage()
+    mediator.loadNextPage()
+    mediator.loadNextPage()
+
+    mediator.events.test {
+      assertEquals(PagingEvent.LoadMoreFailed("failure 2"), awaitItem())
+      expectNoEvents()
+    }
+  }
+
+  @Test
   fun `first page failure emits no LoadMoreFailed event`() = runTest {
     val harness = Harness()
     harness.failOnKey(1)

--- a/core/src/test/java/com/simtop/core/network/NetworkFaultInterceptorTest.kt
+++ b/core/src/test/java/com/simtop/core/network/NetworkFaultInterceptorTest.kt
@@ -1,0 +1,69 @@
+package com.simtop.core.network
+
+import com.simtop.core.core.NetworkFaultController
+import com.simtop.core.core.NetworkFaultMode
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class NetworkFaultInterceptorTest {
+
+  private val request = Request.Builder().url("https://brewbuddy.dev/beers").build()
+  private val controller = TestNetworkFaultController()
+  private val chain = mockk<Interceptor.Chain>()
+  private val proceeded =
+    Response.Builder()
+      .request(request)
+      .protocol(Protocol.HTTP_1_1)
+      .code(200)
+      .message("OK")
+      .body("{}".toResponseBody(null))
+      .build()
+
+  init {
+    every { chain.request() } returns request
+    every { chain.proceed(request) } returns proceeded
+  }
+
+  @Test
+  fun `none mode delegates to the network`() {
+    val result = NetworkFaultInterceptor(controller).intercept(chain)
+
+    assertSame(proceeded, result)
+    verify(exactly = 1) { chain.proceed(request) }
+  }
+
+  @Test
+  fun `forced HTTP modes return synthetic errors without touching the network`() {
+    val interceptor = NetworkFaultInterceptor(controller)
+
+    controller.setMode(NetworkFaultMode.FORCE_404)
+    val notFound = interceptor.intercept(chain)
+    controller.setMode(NetworkFaultMode.FORCE_500)
+    val serverError = interceptor.intercept(chain)
+
+    assertEquals(404, notFound.code)
+    assertEquals("Not Found", notFound.message)
+    assertEquals(500, serverError.code)
+    assertEquals("Internal Server Error", serverError.message)
+    verify(exactly = 0) { chain.proceed(request) }
+  }
+
+  private class TestNetworkFaultController : NetworkFaultController {
+    private val state = MutableStateFlow(NetworkFaultMode.NONE)
+    override val mode = state
+
+    override fun setMode(mode: NetworkFaultMode) {
+      state.value = mode
+    }
+  }
+}

--- a/presentation_utils/src/test/java/com/simtop/presentation_utils/core/DynamicFeatureInstallerTest.kt
+++ b/presentation_utils/src/test/java/com/simtop/presentation_utils/core/DynamicFeatureInstallerTest.kt
@@ -63,6 +63,22 @@ class DynamicFeatureInstallerTest {
   }
 
   @Test
+  fun `an update for another module is ignored before session adoption`() {
+    installer.start()
+
+    manager.emit(
+      state(
+        SplitInstallSessionStatus.DOWNLOADING,
+        downloaded = 25,
+        total = 100,
+        modules = listOf("other"),
+      )
+    )
+
+    installer.status shouldBeEqualTo InstallStatus.Pending
+  }
+
+  @Test
   fun `updates from other sessions are ignored after adoption`() {
     installer.start()
     manager.startTasks.single().complete(SESSION_ID)
@@ -199,6 +215,29 @@ class DynamicFeatureInstallerTest {
     installer.status shouldBeEqualTo InstallStatus.Downloading(progress = 0.5f)
     manager.startTasks.size shouldBeEqualTo 1
     manager.listeners.size shouldBeEqualTo 1
+  }
+
+  @Test
+  fun `a failed install can register a listener again after retirement`() {
+    installer.start()
+    manager.startTasks.single().complete(SESSION_ID)
+    manager.emit(state(SplitInstallSessionStatus.FAILED))
+    installer.onRetired()
+
+    installer.start()
+
+    installer.status shouldBeEqualTo InstallStatus.Pending
+    manager.listeners.size shouldBeEqualTo 1
+  }
+
+  @Test
+  fun `one byte downloads report complete progress`() {
+    installer.start()
+    manager.startTasks.single().complete(SESSION_ID)
+
+    manager.emit(state(SplitInstallSessionStatus.DOWNLOADING, downloaded = 1, total = 1))
+
+    installer.status shouldBeEqualTo InstallStatus.Downloading(progress = 1f)
   }
 
   private fun state(

--- a/presentation_utils/src/test/java/com/simtop/presentation_utils/core/InfiniteListHandlerTest.kt
+++ b/presentation_utils/src/test/java/com/simtop/presentation_utils/core/InfiniteListHandlerTest.kt
@@ -82,6 +82,13 @@ class InfiniteListHandlerTest {
   }
 
   @Test
+  fun `a single visible item is enough to fire at the bottom`() = runTest {
+    val count = signalsFor(ListPosition(totalItems = 1, lastVisibleIndex = 0))
+
+    count shouldBeEqualTo 1
+  }
+
+  @Test
   fun `buffer widens the near-bottom trigger`() = runTest {
     // With buffer 5, item 20 of 25 already counts as "near bottom" (20 + 1 > 25 - 5).
     val count = signalsFor(ListPosition(totalItems = 25, lastVisibleIndex = 20), buffer = 5)


### PR DESCRIPTION
Closes the actionable test-oracle gaps identified by the refined Kotlin Mutation Forge and Kotlin Quality Compass runs. Adds focused coverage for mapper diagnostics, paging boundaries and events, environment validation, HTTP error classification, network fault injection, dynamic-feature state transitions, and infinite-list boundaries. The final in-scope Forge run completed with 100 covered mutants: 100 killed, 0 survived. Remaining Compass rows are UI/platform attribution or complexity review items, not automatic production fixes. No production behavior was changed. Verification: Java 25 make test passed, including build-logic tests; Konsist, Android Lint, formatting, focused tests, and both standalone tool test/build gates passed during the work.