### PR TITLE
Fix Android 15 edge-to-edge insets and prepare release 70

### DIFF
--- a/app/src/main/java/com/simtop/billionbeers/presentation/AppNavigation.kt
+++ b/app/src/main/java/com/simtop/billionbeers/presentation/AppNavigation.kt
@@ -2,6 +2,7 @@ package com.simtop.billionbeers.presentation
 
 import android.net.Uri
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -84,6 +85,10 @@ fun AppNavigation(
 
   Scaffold(
     modifier = modifier,
+    // The destination screens own their top-bar and content insets. Keeping the root inset-free
+    // lets those top bars draw behind the status bar instead of placing the entire NavDisplay
+    // below it. NavigationBar still contributes its measured height to innerPadding.
+    contentWindowInsets = WindowInsets(0),
     bottomBar = {
       if (showBottomBar) {
         NavigationBar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -120,5 +120,5 @@ android.defaults.buildfeatures.shaders=false
 # changed values in the build, and a constant in the convention jar makes every bump recompile
 # build-logic - invalidating every module's configuration and missing the configuration cache.
 # Read by billionbeers.android.application and by scripts/play-listing.sh.
-billionbeers.versionCode=69
-billionbeers.versionName=69
+billionbeers.versionCode=70
+billionbeers.versionName=70


### PR DESCRIPTION
Adjust the root Compose Scaffold so destination screens own system-bar insets, and bump the app to version 70 for the Play Store release. Validated with make test and make screenshot-verify.